### PR TITLE
Update documentation regarding repeating with counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,9 +356,13 @@ Use your favorite plugin manager.
     git clone git://github.com/wellle/targets.vim.git ~/.vim/bundle/targets.vim
     ```
 
-## Issues
+## Notes
 
 - [Repeating an operator-pending mapping forgets its last count.][repeatcount]
+    Works since Vim 7.4.160
+
+## Issues
+
 - [Empty matches can't be selected because it is not possible to visually select
   zero-character ranges.][emptyrange]
 - Forcing to motion to work linewise by inserting `V` in `dVan(` doesn't work

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -376,10 +376,14 @@ pair of separators, it seeks for the separator before or after the cursor.
 This is similar to using the explicit version containing `n` or `l`.
 
 ==============================================================================
-ISSUES                                                        *targets-issues*
+NOTES                                                          *targets-notes*
 
 Repeating an operator-pending mapping forgets its last count.
     https://groups.google.com/forum/?fromgroups#!topic/vim_dev/G4SSgcRVN7g
+Works since Vim 7.4.160
+
+==============================================================================
+ISSUES                                                        *targets-issues*
 
 Empty matches can't be selected because it is no possible to visually select
 zero-character ranges.


### PR DESCRIPTION
Repeating commands with counts works since Vim 7.4.160. Example:

``` vim
a, b, c, d, e, f
a, b, c, d, e, f
```

Executing `d3an,` and repeating on the next line with `+.` leads to:

``` vim
a, b, c, e, f
a, b, c, e, f
```
