### PR TITLE
Ignore the doc/tags file created by Pathogen's :Helptags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
This file is generated when running `:Helptags`. This is annoying when using Pathogen/submodules because it dirties the submodule, but if it's ignored everything is great :).
