### PR TITLE
Use <C-L> to clear command line (for vim-surround)

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -81,10 +81,9 @@ function! s:cleanUp()
     unlet s:failed
 endfunction
 
+" clear the commandline to hide targets function calls
 function! s:clearCommandLine()
-    if v:operator != 'c'
-        call feedkeys(":\<C-C>", 'n')
-    endif
+    execute "normal! \<C-L>"
 endfunction
 
 " try to find match and return 1 in case of success


### PR DESCRIPTION
Enable `ysi)"` ([vim-surround](https://github.com/tpope/vim-surround)) while still supporting `cxi"` ([vim-exchange](https://github.com/tommcdo/vim-exchange)).

Close #29.
