### PR TITLE
ijkl support

### DIFF
--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -94,24 +94,33 @@ long list.
 Default: >
     let g:targets_pairs = '()b {}B []r <>a'
 <
-Defines the list of pair objects you wish to use, along with optional one
-letter aliases for them.
+Defines the space separated list of pair objects you wish to use, along with
+optional one letter aliases for them.
 ------------------------------------------------------------------------------
                                                             *targets_quotes*
->
-    let g:targets_quotes = "\"'`"
+Default: >
+    let g:targets_quotes = "\" ' ` "
 <
-Defines the list of quoting objects you wish to use. Note that you may have to
-escape some characters in the list.
-
+Defines the space separated list of quoting objects you wish to use. Note that
+you may have to escape some characters in the list. Quote objects can
+optionally be followed by a single one letter alias. For example, to set 'd'
+as an alias for double quotes, allowing such commands as 'cid' to be
+equivalent to 'ci"', you could define:
+>
+    let g:targets_quotes = "\"d ' ` "
+<
 ------------------------------------------------------------------------------
                                                             *targets_separators*
->
-    let g:targets_separators = ',.;:+-~_*/\|'
+Default: >
+    let g:targets_separators = ', . ; : + - ~ _ * / \ |'
 <
-Defines the list of separator objects you wish to use.
-
-
+Defines the space separated list of separator objects you wish to use. Like
+quote objects, separator objects can optionally be followed by a single one
+letter alias. To set 'c' as an alias for comma, allowing such commands as
+'dic' to be equivalent to 'di,', you could define:
+>
+    let g:targets_separators = ',c . ; : + - ~ _ * / \ |'
+<
 ==============================================================================
 OVERVIEW                                                    *targets-overview*
 

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -36,10 +36,10 @@ let s:pair_list = exists('g:targets_pairs')
             \? split(g:targets_pairs)
             \: ['()b', '{}B', '[]r', '<>a']
 let s:quote_list = exists('g:targets_quotes')
-            \? split(g:targets_quotes, '\zs')
+            \? split(g:targets_quotes)
             \: [ "'", '"', '`' ]
 let s:separator_list = exists('g:targets_separators')
-            \? split(g:targets_separators, '\zs')
+            \? split(g:targets_separators)
             \: [ ',', '.', ';', ':', '+', '-', '~', '_', '*', '/', '\', '|' ]
 
 " create a text object by combining prefix and trigger to call Match with
@@ -79,7 +79,10 @@ endfunction
 
 " creat a text object for a single delimiter
 function! s:createSimpleTextObject(prefix, delimiter, matchers)
-    call s:createTextObject(a:prefix, a:delimiter, a:delimiter, a:matchers)
+    call s:createTextObject(a:prefix, a:delimiter[0], a:delimiter[0], a:matchers)
+    if strlen(a:delimiter) > 1  " check for alias
+        call s:createTextObject(a:prefix, a:delimiter[1], a:delimiter[0], a:matchers)
+    endif
 endfunction
 
 " create multiple text objects for a pair of delimiters and optional


### PR DESCRIPTION
I'm a heretic and remap everything from `hjkl` to the arrow-key-shape `ijkl`. This patch lets anyone else who does the same use targets.vim comfortably in visual mode by setting `let g:alternate_visual_inner_key = 'h'`, and does nothing if that option isn't set.

Since there's not a lot of people who do that I'd understand if you don't want to merge this, just figured I'd throw a request since it'd be easier than maintaining my own fork.
