### PR TITLE
Update jumplist when jumping across multiple lines.

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -292,7 +292,7 @@ function! s:selectp()
     " `normal! %` doesn't work with `<>`
     silent! execute 'normal! v'
     for _ in range(s:count)
-        silent! execute 'normal! a' . s:opening
+        silent! execute 'keepjumps normal! a' . s:opening
         " TODO: fail if selection didn't change
     endfor
 


### PR DESCRIPTION
This finishes the `jumplist` behavior from #33 and closes #31.
