### PR TITLE
Mark correct column when jumping across multiple lines

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -1,8 +1,8 @@
 " targets.vim Provides additional text objects
 " Author:  Christian Wellenbrock <christian.wellenbrock@gmail.com>
 " License: MIT license
-" Updated: 2014-02-28
-" Version: 0.1.0
+" Updated: 2014-03-01
+" Version: 0.1.1
 
 let s:save_cpoptions = &cpoptions
 set cpo&vim

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -2,8 +2,8 @@
 
 Author:  Christian Wellenbrock <christian.wellenbrock@gmail.com>
 License: MIT license
-Updated: 2014-02-28
-Version: 0.1.0
+Updated: 2014-03-01
+Version: 0.1.1
 
                            ____
                            \___\_.::::::::::.____

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -1,13 +1,13 @@
 " targets.vim Provides additional text objects
 " Author:  Christian Wellenbrock <christian.wellenbrock@gmail.com>
 " License: MIT license
-" Updated: 2014-02-28
-" Version: 0.1.0
+" Updated: 2014-03-01
+" Version: 0.1.1
 
 if exists("g:loaded_targets") || &cp || v:version < 700
     finish
 endif
-let g:loaded_targets = '0.1.0' " version number
+let g:loaded_targets = '0.1.1' " version number
 let s:save_cpoptions = &cpoptions
 set cpo&vim
 

--- a/test/test.vim
+++ b/test/test.vim
@@ -1,8 +1,8 @@
 " targets.vim Provides additional text objects
 " Author:  Christian Wellenbrock <christian.wellenbrock@gmail.com>
 " License: MIT license
-" Updated: 2014-02-28
-" Version: 0.1.0
+" Updated: 2014-03-01
+" Version: 0.1.1
 
 set runtimepath+=../
 set softtabstop=16 expandtab


### PR DESCRIPTION
Fixes issue described in https://github.com/wellle/targets.vim/pull/35#issuecomment-36405755.
