### PR TITLE
Temporarily disable auto commands before inserting inside empty

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -1,8 +1,8 @@
 " targets.vim Provides additional text objects
 " Author:  Christian Wellenbrock <christian.wellenbrock@gmail.com>
 " License: MIT license
-" Updated: 2014-06-02
-" Version: 0.2.3
+" Updated: 2014-06-06
+" Version: 0.2.4
 
 let s:save_cpoptions = &cpoptions
 set cpo&vim

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -2,8 +2,8 @@
 
 Author:  Christian Wellenbrock <christian.wellenbrock@gmail.com>
 License: MIT license
-Updated: 2014-06-02
-Version: 0.2.3
+Updated: 2014-06-06
+Version: 0.2.4
 
                            ____
                            \___\_.::::::::::.____

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -1,13 +1,13 @@
 " targets.vim Provides additional text objects
 " Author:  Christian Wellenbrock <christian.wellenbrock@gmail.com>
 " License: MIT license
-" Updated: 2014-06-02
-" Version: 0.2.3
+" Updated: 2014-06-06
+" Version: 0.2.4
 
 if exists("g:loaded_targets") || &cp || v:version < 700
     finish
 endif
-let g:loaded_targets = '0.2.3' " version number
+let g:loaded_targets = '0.2.4' " version number
 let s:save_cpoptions = &cpoptions
 set cpo&vim
 

--- a/test/test.vim
+++ b/test/test.vim
@@ -1,8 +1,8 @@
 " targets.vim Provides additional text objects
 " Author:  Christian Wellenbrock <christian.wellenbrock@gmail.com>
 " License: MIT license
-" Updated: 2014-06-02
-" Version: 0.2.3
+" Updated: 2014-06-06
+" Version: 0.2.4
 
 set runtimepath+=../
 set softtabstop=16 expandtab


### PR DESCRIPTION
This fixes a strange interaction with neocomplete as discussed [in this reddit discussion](http://www.reddit.com/r/vim/comments/27byck/really_really_really_really_nice_enhancements_to/chzg2ej).
