### PR TITLE
Fix tag and argument triggers

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -325,9 +325,9 @@ function! s:getRawDelimiters(trigger)
         endfor
     endfor
 
-    if a:trigger ==# g:targets_tagTrigger
+    if a:trigger ==# 't'
         return ['t', 't', 0, 0] " TODO: set tag patterns here and remove special tag functions?
-    elseif a:trigger ==# g:targets_argTrigger
+    elseif a:trigger ==# 'a'
         return ['a', 0, 0, 0]
     else
         return [0, 0, 0, 1]


### PR DESCRIPTION
Changing `g:targets_tagTrigger` and `g:targets_argTrigger` only changes the map, not the arguments for `targets#o()`, so `getRawDelimiters` should always check for `a` or `t`, not `g:targets_tagTrigger` or `g:targets_argTrigger`.
