### PR TITLE
106 Only call getcmdwintype if it exists

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -434,7 +434,7 @@ endfunction
 " abort when no match was found
 function! s:abortMatch(message)
     " get into normal mode and beep
-    if getcmdwintype() ==# ""
+    if !exists("*getcmdwintype") || getcmdwintype() ==# ""
         call feedkeys("\<C-\>\<C-N>\<Esc>", 'n')
     endif
 


### PR DESCRIPTION
Turns out `getcmdwintype` is only available since version 7.4.392.

Close #106.
