### PR TITLE
Add support for older versions of vim

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -29,6 +29,15 @@ function! targets#o(trigger)
     call s:handleTarget(target)
     call s:clearCommandLine()
     call s:cleanUp()
+    if v:version < 704
+        let cmd = v:operator.modifier.(which ==# 'c' ? '' : which).delimiter
+        if v:operator ==# 'c'
+            let cmd = cmd."\<C-r>.\<ESC>"
+        endif
+        if v:operator !=# 'y' || match(&cpoptions, 'y') !=# -1
+            silent! call repeat#set(cmd, v:count)
+        endif
+    endif
 endfunction
 
 function! targets#e(modifier)

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -11,15 +11,15 @@ let g:loaded_targets = '0.3.4' " version number
 let s:save_cpoptions = &cpoptions
 set cpo&vim
 
-function! s:addMapping1(mapping, aiAI)
+function! s:addMapping1(mapping_type, mapping, aiAI)
     if a:aiAI !=# ' '
-        silent! execute 'onoremap <silent> <unique>' . a:aiAI . a:mapping
+        silent! execute a:mapping_type . 'noremap <silent> <unique>' . a:aiAI . a:mapping
     endif
 endfunction
 
-function! s:addMapping2(mapping, aiAI, nlNL)
+function! s:addMapping2(mapping_type, mapping, aiAI, nlNL)
     if a:aiAI !=# ' ' && a:nlNL !=# ' '
-        silent! execute 'onoremap <silent> <unique>' . a:aiAI . a:nlNL . a:mapping
+        silent! execute a:mapping_type . 'noremap <silent> <unique>' . a:aiAI . a:nlNL . a:mapping
     endif
 endfunction
 
@@ -40,43 +40,53 @@ endfunction
 "         │   │└──────il)─────┘│││└─────2i)─────┘│││└──────in)─────┘││
 "         │   ├───────al)──────┘│├──────2a)──────┘│├───────an)──────┘│
 "         │   └───────Al)───────┘└──────2A)───────┘└───────An)───────┘
-function! s:createPairTextObjects()
+function! s:createPairTextObjects(mapping_type)
     for trigger in split(g:targets_pairs, '\zs')
         if trigger ==# ' '
             continue
         endif
-        let triggerMap = trigger . " :<C-U>call targets#o('" . trigger
-        call s:addMapping1(triggerMap . "ci')<CR>", s:i)
-        call s:addMapping1(triggerMap . "ca')<CR>", s:a)
-        call s:addMapping1(triggerMap . "cI')<CR>", s:I)
-        call s:addMapping1(triggerMap . "cA')<CR>", s:A)
-        call s:addMapping2(triggerMap . "ni')<CR>", s:i, s:n)
-        call s:addMapping2(triggerMap . "na')<CR>", s:a, s:n)
-        call s:addMapping2(triggerMap . "nI')<CR>", s:I, s:n)
-        call s:addMapping2(triggerMap . "nA')<CR>", s:A, s:n)
-        call s:addMapping2(triggerMap . "li')<CR>", s:i, s:l)
-        call s:addMapping2(triggerMap . "la')<CR>", s:a, s:l)
-        call s:addMapping2(triggerMap . "lI')<CR>", s:I, s:l)
-        call s:addMapping2(triggerMap . "lA')<CR>", s:A, s:l)
+        if a:mapping_type ==# 'x'
+            let rest_of_mapping = "', v:count1)<CR>"
+        else
+            let rest_of_mapping = "')<CR>"
+        endif
+        let triggerMap = trigger . " :<C-U>call targets#" . a:mapping_type . "('" . trigger
+        call s:addMapping1(a:mapping_type, triggerMap . "ci" . rest_of_mapping, s:i)
+        call s:addMapping1(a:mapping_type, triggerMap . "ca" . rest_of_mapping, s:a)
+        call s:addMapping1(a:mapping_type, triggerMap . "cI" . rest_of_mapping, s:I)
+        call s:addMapping1(a:mapping_type, triggerMap . "cA" . rest_of_mapping, s:A)
+        call s:addMapping2(a:mapping_type, triggerMap . "ni" . rest_of_mapping, s:i, s:n)
+        call s:addMapping2(a:mapping_type, triggerMap . "na" . rest_of_mapping, s:a, s:n)
+        call s:addMapping2(a:mapping_type, triggerMap . "nI" . rest_of_mapping, s:I, s:n)
+        call s:addMapping2(a:mapping_type, triggerMap . "nA" . rest_of_mapping, s:A, s:n)
+        call s:addMapping2(a:mapping_type, triggerMap . "li" . rest_of_mapping, s:i, s:l)
+        call s:addMapping2(a:mapping_type, triggerMap . "la" . rest_of_mapping, s:a, s:l)
+        call s:addMapping2(a:mapping_type, triggerMap . "lI" . rest_of_mapping, s:I, s:l)
+        call s:addMapping2(a:mapping_type, triggerMap . "lA" . rest_of_mapping, s:A, s:l)
     endfor
 endfunction
 
 " tag text objects work on tags (similar to pair text objects)
-function! s:createTagTextObjects()
+function! s:createTagTextObjects(mapping_type)
     let trigger = g:targets_tagTrigger
-    let triggerMap = trigger . " :<C-U>call targets#o('" . trigger
-    call s:addMapping1(triggerMap . "ci')<CR>", s:i)
-    call s:addMapping1(triggerMap . "ca')<CR>", s:a)
-    call s:addMapping1(triggerMap . "cI')<CR>", s:I)
-    call s:addMapping1(triggerMap . "cA')<CR>", s:A)
-    call s:addMapping2(triggerMap . "ni')<CR>", s:i, s:n)
-    call s:addMapping2(triggerMap . "na')<CR>", s:a, s:n)
-    call s:addMapping2(triggerMap . "nI')<CR>", s:I, s:n)
-    call s:addMapping2(triggerMap . "nA')<CR>", s:A, s:n)
-    call s:addMapping2(triggerMap . "li')<CR>", s:i, s:l)
-    call s:addMapping2(triggerMap . "la')<CR>", s:a, s:l)
-    call s:addMapping2(triggerMap . "lI')<CR>", s:I, s:l)
-    call s:addMapping2(triggerMap . "lA')<CR>", s:A, s:l)
+    if a:mapping_type ==# 'x'
+        let rest_of_mapping = "', v:count1)<CR>"
+    else
+        let rest_of_mapping = "')<CR>"
+    endif
+    let triggerMap = trigger . " :<C-U>call targets#" . a:mapping_type . "('" . trigger
+    call s:addMapping1(a:mapping_type, triggerMap . "ci" . rest_of_mapping, s:i)
+    call s:addMapping1(a:mapping_type, triggerMap . "ca" . rest_of_mapping, s:a)
+    call s:addMapping1(a:mapping_type, triggerMap . "cI" . rest_of_mapping, s:I)
+    call s:addMapping1(a:mapping_type, triggerMap . "cA" . rest_of_mapping, s:A)
+    call s:addMapping2(a:mapping_type, triggerMap . "ni" . rest_of_mapping, s:i, s:n)
+    call s:addMapping2(a:mapping_type, triggerMap . "na" . rest_of_mapping, s:a, s:n)
+    call s:addMapping2(a:mapping_type, triggerMap . "nI" . rest_of_mapping, s:I, s:n)
+    call s:addMapping2(a:mapping_type, triggerMap . "nA" . rest_of_mapping, s:A, s:n)
+    call s:addMapping2(a:mapping_type, triggerMap . "li" . rest_of_mapping, s:i, s:l)
+    call s:addMapping2(a:mapping_type, triggerMap . "la" . rest_of_mapping, s:a, s:l)
+    call s:addMapping2(a:mapping_type, triggerMap . "lI" . rest_of_mapping, s:I, s:l)
+    call s:addMapping2(a:mapping_type, triggerMap . "lA" . rest_of_mapping, s:A, s:l)
 endfunction
 
 " quote text objects expand into quote (by counting quote signs)
@@ -96,36 +106,41 @@ endfunction
 "         │   │└─i'─┘││     │     │└─i'─┘││    │      │└─i'─┘││
 "         │   ├──a'──┘│     │     ├──a'──┘│    │      ├──a'──┘│
 "         │   └──A'───┘     │     └──A'───┘    │      └──A'───┘
-function! s:createQuoteTextObjects()
+function! s:createQuoteTextObjects(mapping_type)
     " quote text objects
     for trigger in split(g:targets_quotes, '\zs')
         if trigger ==# " "
             continue
         elseif trigger ==# "'"
-            let triggerMap = "' :<C-U>call targets#o('''"
+            let triggerMap = "' :<C-U>call targets#" . a:mapping_type . "('''"
         else
-            let triggerMap = trigger . " :<C-U>call targets#o('" . trigger
+            let triggerMap = trigger . " :<C-U>call targets#" . a:mapping_type . "('" . trigger
         endif
-        call s:addMapping1(triggerMap . "ci')<CR>", s:i)
-        call s:addMapping1(triggerMap . "ca')<CR>", s:a)
-        call s:addMapping1(triggerMap . "cI')<CR>", s:I)
-        call s:addMapping1(triggerMap . "cA')<CR>", s:A)
-        call s:addMapping2(triggerMap . "ni')<CR>", s:i, s:n)
-        call s:addMapping2(triggerMap . "na')<CR>", s:a, s:n)
-        call s:addMapping2(triggerMap . "nI')<CR>", s:I, s:n)
-        call s:addMapping2(triggerMap . "nA')<CR>", s:A, s:n)
-        call s:addMapping2(triggerMap . "li')<CR>", s:i, s:l)
-        call s:addMapping2(triggerMap . "la')<CR>", s:a, s:l)
-        call s:addMapping2(triggerMap . "lI')<CR>", s:I, s:l)
-        call s:addMapping2(triggerMap . "lA')<CR>", s:A, s:l)
-        call s:addMapping2(triggerMap . "Ni')<CR>", s:i, s:N)
-        call s:addMapping2(triggerMap . "Na')<CR>", s:a, s:N)
-        call s:addMapping2(triggerMap . "NI')<CR>", s:I, s:N)
-        call s:addMapping2(triggerMap . "NA')<CR>", s:A, s:N)
-        call s:addMapping2(triggerMap . "Li')<CR>", s:i, s:L)
-        call s:addMapping2(triggerMap . "La')<CR>", s:a, s:L)
-        call s:addMapping2(triggerMap . "LI')<CR>", s:I, s:L)
-        call s:addMapping2(triggerMap . "LA')<CR>", s:A, s:L)
+        if a:mapping_type ==# 'x'
+            let rest_of_mapping = "', v:count1)<CR>"
+        else
+            let rest_of_mapping = "')<CR>"
+        endif
+        call s:addMapping1(a:mapping_type, triggerMap . "ci" . rest_of_mapping, s:i)
+        call s:addMapping1(a:mapping_type, triggerMap . "ca" . rest_of_mapping, s:a)
+        call s:addMapping1(a:mapping_type, triggerMap . "cI" . rest_of_mapping, s:I)
+        call s:addMapping1(a:mapping_type, triggerMap . "cA" . rest_of_mapping, s:A)
+        call s:addMapping2(a:mapping_type, triggerMap . "ni" . rest_of_mapping, s:i, s:n)
+        call s:addMapping2(a:mapping_type, triggerMap . "na" . rest_of_mapping, s:a, s:n)
+        call s:addMapping2(a:mapping_type, triggerMap . "nI" . rest_of_mapping, s:I, s:n)
+        call s:addMapping2(a:mapping_type, triggerMap . "nA" . rest_of_mapping, s:A, s:n)
+        call s:addMapping2(a:mapping_type, triggerMap . "li" . rest_of_mapping, s:i, s:l)
+        call s:addMapping2(a:mapping_type, triggerMap . "la" . rest_of_mapping, s:a, s:l)
+        call s:addMapping2(a:mapping_type, triggerMap . "lI" . rest_of_mapping, s:I, s:l)
+        call s:addMapping2(a:mapping_type, triggerMap . "lA" . rest_of_mapping, s:A, s:l)
+        call s:addMapping2(a:mapping_type, triggerMap . "Ni" . rest_of_mapping, s:i, s:N)
+        call s:addMapping2(a:mapping_type, triggerMap . "Na" . rest_of_mapping, s:a, s:N)
+        call s:addMapping2(a:mapping_type, triggerMap . "NI" . rest_of_mapping, s:I, s:N)
+        call s:addMapping2(a:mapping_type, triggerMap . "NA" . rest_of_mapping, s:A, s:N)
+        call s:addMapping2(a:mapping_type, triggerMap . "Li" . rest_of_mapping, s:i, s:L)
+        call s:addMapping2(a:mapping_type, triggerMap . "La" . rest_of_mapping, s:a, s:L)
+        call s:addMapping2(a:mapping_type, triggerMap . "LI" . rest_of_mapping, s:I, s:L)
+        call s:addMapping2(a:mapping_type, triggerMap . "LA" . rest_of_mapping, s:A, s:L)
     endfor
 endfunction
 
@@ -143,7 +158,7 @@ endfunction
 "         │   │└─i,─┤ │      │       │└─i,─┤ │
 "         │   ├──a,─┘ │      │       ├──a,─┘ │
 "         │   └──A,───┘      │       └──A,───┘
-function! s:createSeparatorTextObjects()
+function! s:createSeparatorTextObjects(mapping_type)
     " separator text objects
     for trigger in split(g:targets_separators, '\zs')
         if trigger ==# ' '
@@ -151,27 +166,32 @@ function! s:createSeparatorTextObjects()
         elseif trigger ==# '|'
             let trigger = '\|'
         endif
-        let triggerMap = trigger . " :<C-U>call targets#o('" . trigger
-        call s:addMapping1(triggerMap . "ci')<CR>", s:i)
-        call s:addMapping1(triggerMap . "ca')<CR>", s:a)
-        call s:addMapping1(triggerMap . "cI')<CR>", s:I)
-        call s:addMapping1(triggerMap . "cA')<CR>", s:A)
-        call s:addMapping2(triggerMap . "ni')<CR>", s:i, s:n)
-        call s:addMapping2(triggerMap . "na')<CR>", s:a, s:n)
-        call s:addMapping2(triggerMap . "nI')<CR>", s:I, s:n)
-        call s:addMapping2(triggerMap . "nA')<CR>", s:A, s:n)
-        call s:addMapping2(triggerMap . "li')<CR>", s:i, s:l)
-        call s:addMapping2(triggerMap . "la')<CR>", s:a, s:l)
-        call s:addMapping2(triggerMap . "lI')<CR>", s:I, s:l)
-        call s:addMapping2(triggerMap . "lA')<CR>", s:A, s:l)
-        call s:addMapping2(triggerMap . "Ni')<CR>", s:i, s:N)
-        call s:addMapping2(triggerMap . "Na')<CR>", s:a, s:N)
-        call s:addMapping2(triggerMap . "NI')<CR>", s:I, s:N)
-        call s:addMapping2(triggerMap . "NA')<CR>", s:A, s:N)
-        call s:addMapping2(triggerMap . "Li')<CR>", s:i, s:L)
-        call s:addMapping2(triggerMap . "La')<CR>", s:a, s:L)
-        call s:addMapping2(triggerMap . "LI')<CR>", s:I, s:L)
-        call s:addMapping2(triggerMap . "LA')<CR>", s:A, s:L)
+        if a:mapping_type ==# 'x'
+            let rest_of_mapping = "', v:count1)<CR>"
+        else
+            let rest_of_mapping = "')<CR>"
+        endif
+        let triggerMap = trigger . " :<C-U>call targets#" . a:mapping_type . "('" . trigger
+        call s:addMapping1(a:mapping_type, triggerMap . "ci" . rest_of_mapping, s:i)
+        call s:addMapping1(a:mapping_type, triggerMap . "ca" . rest_of_mapping, s:a)
+        call s:addMapping1(a:mapping_type, triggerMap . "cI" . rest_of_mapping, s:I)
+        call s:addMapping1(a:mapping_type, triggerMap . "cA" . rest_of_mapping, s:A)
+        call s:addMapping2(a:mapping_type, triggerMap . "ni" . rest_of_mapping, s:i, s:n)
+        call s:addMapping2(a:mapping_type, triggerMap . "na" . rest_of_mapping, s:a, s:n)
+        call s:addMapping2(a:mapping_type, triggerMap . "nI" . rest_of_mapping, s:I, s:n)
+        call s:addMapping2(a:mapping_type, triggerMap . "nA" . rest_of_mapping, s:A, s:n)
+        call s:addMapping2(a:mapping_type, triggerMap . "li" . rest_of_mapping, s:i, s:l)
+        call s:addMapping2(a:mapping_type, triggerMap . "la" . rest_of_mapping, s:a, s:l)
+        call s:addMapping2(a:mapping_type, triggerMap . "lI" . rest_of_mapping, s:I, s:l)
+        call s:addMapping2(a:mapping_type, triggerMap . "lA" . rest_of_mapping, s:A, s:l)
+        call s:addMapping2(a:mapping_type, triggerMap . "Ni" . rest_of_mapping, s:i, s:N)
+        call s:addMapping2(a:mapping_type, triggerMap . "Na" . rest_of_mapping, s:a, s:N)
+        call s:addMapping2(a:mapping_type, triggerMap . "NI" . rest_of_mapping, s:I, s:N)
+        call s:addMapping2(a:mapping_type, triggerMap . "NA" . rest_of_mapping, s:A, s:N)
+        call s:addMapping2(a:mapping_type, triggerMap . "Li" . rest_of_mapping, s:i, s:L)
+        call s:addMapping2(a:mapping_type, triggerMap . "La" . rest_of_mapping, s:a, s:L)
+        call s:addMapping2(a:mapping_type, triggerMap . "LI" . rest_of_mapping, s:I, s:L)
+        call s:addMapping2(a:mapping_type, triggerMap . "LA" . rest_of_mapping, s:A, s:L)
     endfor
 endfunction
 
@@ -188,30 +208,43 @@ endfunction
 "         │                      │└──────2ia─────────────┤ │
 "         │                      ├───────2aa─────────────┘ │
 "         │                      └───────2Aa───────────────┘
-function! s:createArgTextObjects()
+function! s:createArgTextObjects(mapping_type)
     let trigger = g:targets_argTrigger
-    let triggerMap = trigger . " :<C-U>call targets#o('" . trigger
-    call s:addMapping1(triggerMap . "ci')<CR>", s:i)
-    call s:addMapping1(triggerMap . "ca')<CR>", s:a)
-    call s:addMapping1(triggerMap . "cI')<CR>", s:I)
-    call s:addMapping1(triggerMap . "cA')<CR>", s:A)
-    call s:addMapping2(triggerMap . "ni')<CR>", s:i, s:n)
-    call s:addMapping2(triggerMap . "na')<CR>", s:a, s:n)
-    call s:addMapping2(triggerMap . "nI')<CR>", s:I, s:n)
-    call s:addMapping2(triggerMap . "nA')<CR>", s:A, s:n)
-    call s:addMapping2(triggerMap . "li')<CR>", s:i, s:l)
-    call s:addMapping2(triggerMap . "la')<CR>", s:a, s:l)
-    call s:addMapping2(triggerMap . "lI')<CR>", s:I, s:l)
-    call s:addMapping2(triggerMap . "lA')<CR>", s:A, s:l)
+    if a:mapping_type ==# 'x'
+        let rest_of_mapping = "', v:count1)<CR>"
+    else
+        let rest_of_mapping = "')<CR>"
+    endif
+    let triggerMap = trigger . " :<C-U>call targets#" . a:mapping_type . "('" . trigger
+    call s:addMapping1(a:mapping_type, triggerMap . "ci" . rest_of_mapping, s:i)
+    call s:addMapping1(a:mapping_type, triggerMap . "ca" . rest_of_mapping, s:a)
+    call s:addMapping1(a:mapping_type, triggerMap . "cI" . rest_of_mapping, s:I)
+    call s:addMapping1(a:mapping_type, triggerMap . "cA" . rest_of_mapping, s:A)
+    call s:addMapping2(a:mapping_type, triggerMap . "ni" . rest_of_mapping, s:i, s:n)
+    call s:addMapping2(a:mapping_type, triggerMap . "na" . rest_of_mapping, s:a, s:n)
+    call s:addMapping2(a:mapping_type, triggerMap . "nI" . rest_of_mapping, s:I, s:n)
+    call s:addMapping2(a:mapping_type, triggerMap . "nA" . rest_of_mapping, s:A, s:n)
+    call s:addMapping2(a:mapping_type, triggerMap . "li" . rest_of_mapping, s:i, s:l)
+    call s:addMapping2(a:mapping_type, triggerMap . "la" . rest_of_mapping, s:a, s:l)
+    call s:addMapping2(a:mapping_type, triggerMap . "lI" . rest_of_mapping, s:I, s:l)
+    call s:addMapping2(a:mapping_type, triggerMap . "lA" . rest_of_mapping, s:A, s:l)
 endfunction
 
 " add expression mappings for `A` and `I` in visual mode #23 unless
-" deactivated #49
-function! s:addExpressionMappings()
-    silent! execute 'xnoremap <expr> <silent> <unique> ' . s:i . " targets#e('i')"
-    silent! execute 'xnoremap <expr> <silent> <unique> ' . s:a . " targets#e('a')"
-    silent! execute 'xnoremap <expr> <silent> <unique> ' . s:I . " targets#e('I')"
-    silent! execute 'xnoremap <expr> <silent> <unique> ' . s:A . " targets#e('A')"
+" deactivated #49. Manually make mappings for older verions of vim #117.
+function! s:addVisualMappings()
+    if v:version >= 704 || (v:version == 703 && has('patch338'))
+        silent! execute 'xnoremap <expr> <silent> <unique> ' . s:i . " targets#e('i')"
+        silent! execute 'xnoremap <expr> <silent> <unique> ' . s:a . " targets#e('a')"
+        silent! execute 'xnoremap <expr> <silent> <unique> ' . s:I . " targets#e('I')"
+        silent! execute 'xnoremap <expr> <silent> <unique> ' . s:A . " targets#e('A')"
+    else
+        call s:createPairTextObjects('x')
+        call s:createTagTextObjects('x')
+        call s:createQuoteTextObjects('x')
+        call s:createSeparatorTextObjects('x')
+        call s:createArgTextObjects('x')
+    endif
 endfunction
 
 function! s:loadSettings()
@@ -253,12 +286,12 @@ endfunction
 call s:loadSettings()
 
 " create the text objects (current total count: 528)
-call s:createPairTextObjects()
-call s:createTagTextObjects()
-call s:createQuoteTextObjects()
-call s:createSeparatorTextObjects()
-call s:createArgTextObjects()
-call s:addExpressionMappings()
+call s:createPairTextObjects('o')
+call s:createTagTextObjects('o')
+call s:createQuoteTextObjects('o')
+call s:createSeparatorTextObjects('o')
+call s:createArgTextObjects('o')
+call s:addVisualMappings()
 
 let &cpoptions = s:save_cpoptions
 unlet s:save_cpoptions


### PR DESCRIPTION
Close #117

Summary
------------
These changes were made so this plugin will work on versions of vim older than 7.4. If a version less than 7.4 is being used then visual mappings for each text object will be created instead of creating expression mappings. Repeating these text objects on earlier versions with the '.' command will also be possible if Tim Pope's repeat.vim is installed. There will be no issue if his plugin is not installed, repeating with '.' just won't work.

### Test Code
I got my altered code to pass your tests just fine if I was running those tests with vim version 7.4. Oddly though, when I was running those tests with vim 7.3 they would **all** fail. I looked into it for a while but couldn't figure it out. I think it has to be some issue with the startup process between those two versions. I think this because I temporarily changed test/test.vim so I could call the functions after sourcing that file. When I manually called those functions and compared the test.out and test.ok files, tests 2-5 passed and test1 passed more times.

### Startup Time
Looks like I might have made things a tad slower, but I don't think it's too serious:

Vim Version 7.4:
- 066.158  022.530  022.530
- 068.550  024.328  024.328
- 065.817  022.482  022.482

Vim Version 7.3:
- 082.872  051.987  051.987
- 084.687  053.590  053.590
- 086.914  056.802  056.802