### PR TITLE
Respect qe option

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -349,7 +349,7 @@ function! s:getRawDelimiters(trigger)
 endfunction
 
 function! s:modifyDelimiter(kind, delimiter)
-    let delimiter = escape(copy(a:delimiter), '.~\$')
+    let delimiter = escape(a:delimiter, '.~\$')
     if a:kind ==# 'q' && &quoteescape !=# ''
         let qe = &quoteescape ==# '\' ? '\\' : &quoteescape
         let delimiter = '[^'.qe.']\zs'.delimiter.'\|^'.delimiter

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -351,7 +351,11 @@ endfunction
 function! s:modifyDelimiter(kind, delimiter)
     let delimiter = escape(a:delimiter, '.~\$')
     if a:kind ==# 'q' && &quoteescape !=# ''
-        let qe = &quoteescape ==# '\' ? '\\' : &quoteescape
+        let qe = escape(&quoteescape, '\')
+        let closeBracketPos = match(qe, ']')
+        if closeBracketPos != -1
+            let qe = ']'.strpart(qe, 0, closeBracketPos).strpart(qe, closeBracketPos+1)
+        endif
         let delimiter = '[^'.qe.']\zs'.delimiter.'\|^'.delimiter
     endif
     return delimiter

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -305,8 +305,8 @@ function! s:getDelimiters(trigger)
         return [0, 0, 0, err]
     endif
 
-    let opening = escape(rawOpening, '.~\$')
-    let closing = escape(rawClosing, '.~\$')
+    let opening = s:modifyDelimiter(kind, rawOpening)
+    let closing = s:modifyDelimiter(kind, rawClosing)
 
     " write to cache
     let s:delimiterCache[a:trigger] = [kind, opening, closing]
@@ -346,6 +346,15 @@ function! s:getRawDelimiters(trigger)
     else
         return [0, 0, 0, 1]
     endif
+endfunction
+
+function! s:modifyDelimiter(kind, delimiter)
+    let delimiter = escape(copy(a:delimiter), '.~\$')
+    if a:kind ==# 'q'
+        let qe = &quoteescape ==# '\' ? '\\' : &quoteescape
+        let delimiter = '[^'.qe.']\zs'.delimiter.'\|^'.delimiter
+    endif
+    return delimiter
 endfunction
 
 " return 0 if the selection changed since the last invocation. used for

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -350,7 +350,7 @@ endfunction
 
 function! s:modifyDelimiter(kind, delimiter)
     let delimiter = escape(copy(a:delimiter), '.~\$')
-    if a:kind ==# 'q'
+    if a:kind ==# 'q' && &quoteescape !=# ''
         let qe = &quoteescape ==# '\' ? '\\' : &quoteescape
         let delimiter = '[^'.qe.']\zs'.delimiter.'\|^'.delimiter
     endif

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -351,12 +351,7 @@ endfunction
 function! s:modifyDelimiter(kind, delimiter)
     let delimiter = escape(a:delimiter, '.~\$')
     if a:kind ==# 'q' && &quoteescape !=# ''
-        let qe = escape(&quoteescape, '\')
-        let closeBracketPos = match(qe, ']')
-        if closeBracketPos != -1
-            let qe = ']'.strpart(qe, 0, closeBracketPos).strpart(qe, closeBracketPos+1)
-        endif
-        let delimiter = '[^'.qe.']\zs'.delimiter.'\|^'.delimiter
+        let delimiter = '[^'.escape(&quoteescape, ']^-\').']\zs'.delimiter.'\|^'.delimiter
     endif
     return delimiter
 endfunction


### PR DESCRIPTION
Close #121.

This PR makes the quote text objects respect vim's ```'quoteescape'``` option. Now, if a quote is preceded by any character in ```'quoteescape'```, it will not be considered a quote which delimits the text object.

This implementation got a bit beefier than the last one you looked at because I re-read the documentation and it said:

> When one of the characters in this option is found inside a string, the following character will be skipped.

I originally thought that the ```'quoteescape'``` option was just one character, guess not. Let me know if you notice anything I missed!