### PR TITLE
Added backwards compatibility for regex introduced in #124

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -352,7 +352,11 @@ function! s:modifyDelimiter(kind, delimiter)
     let delimiter = escape(a:delimiter, '.~\$')
     if a:kind ==# 'q' && &quoteescape !=# ''
         let escapedqe = escape(&quoteescape, ']^-\')
-        let delimiter = '[' . escapedqe . ']\@1<!' . delimiter
+        let optimizeIfPossible = '1'
+        if v:version < 704
+            let optimizeIfPossible = ''
+        endif
+        let delimiter = '[' . escapedqe . ']\@'.optimizeIfPossible.'<!' . delimiter
     endif
     return delimiter
 endfunction


### PR DESCRIPTION
Nice catch with the empty quotes in #124 by the way. I just tested it though and it looks like selecting quote text objects is now broken prior to version 7.4 because the ```\@123<!``` pattern didn't come around until then. So this PR would fix that by using the ```\@<!``` pattern if the version is wrong and your optimized pattern otherwise.

What do you think?

On a sort of unrelated note, would you mind checking out https://github.com/tommcdo/vim-exchange/issues/38 when you get a chance? No rush of course. I only mention it because wilywampa thinks that a change will be needed in targets.vim to get it to work. I kind of think the change would be better if added to exchange.vim but your opinion would be nice to hear!