### PR TITLE
127 Customize seeking with g:targets_seekRanges

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,12 @@ g:targets_nlNL
 g:targets_pairs
 g:targets_quotes
 g:targets_separators
+g:targets_tagTrigger
+g:targets_argTrigger
+g:targets_argOpening
+g:targets_argClosing
+g:targets_argSeparator
+g:targets_seekRanges
 ```
 
 ### g:targets_aiAI
@@ -613,6 +619,126 @@ also want to find arguments separatode by semicolon, use this:
 
 ```vim
 let g:targets_argSeparator = '[,;]'
+```
+
+### g:targets_seekRanges
+
+Default:
+
+```vim
+let g:targets_seekRanges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA'
+```
+
+Defines a priority ordered, space separated list of range types which can be
+used to customize seeking behavior. When using a command like `cib` to change
+inside a block, targets.vim considers the three targets:
+
+  - smallest target around cursor
+  - next target after cursor
+  - last target before cursor
+
+For each of those that were found, we detect what range type it has. A range
+type depends on the relative position of the start and end of the target,
+relative to the current cursor position and the currently visible lines.
+
+The possibly relative positions are:
+
+  - `l`: left of cursor in current line
+  - `r`: right of cursor in current line
+  - `a`: above cursor on screen
+  - `b`: below cursor on screen
+  - `A`: above cursor off screen
+  - `B`: below cursor off screen
+
+All possibly ranges are listed below, denoted by two characters: one for the
+relative start and one for the relative end position of the target. For
+example, `lr` means "from left of cursor to right of cursor in cursor line".
+
+Next to each range type is a pictogram of an example. They are made of these
+symbols:
+
+  - `.`: current cursor position
+  - `(`: start of target
+  - `)`: end of target
+  - `/`: line break before and after cursor line
+  - `|`: screen edge between hidden and visible lines
+
+#### Ranges around cursor:
+
+```
+lr   |  / (.) /  |   around cursor, current line
+lb   |  / (.  /) |   around cursor, multiline down, on screen
+ar   | (/  .) /  |   around cursor, multiline up, on screen
+ab   | (/  .  /) |   around cursor, multiline both, on screen
+lB   |  / (.  /  |)  around cursor, multiline down, partially off screen
+Ar  (|  /  .) /  |   around cursor, multiline up, partially off screen
+aB   | (/  .  /  |)  around cursor, multiline both, partially off screen bottom
+Ab  (|  /  .  /) |   around cursor, multiline both, partially off screen top
+AB  (|  /  .  /  |)  around cursor, multiline both, partially off screen both
+```
+
+#### Ranges after (right of/below) cursor
+
+```
+rr   |  /  .()/  |   after cursor, current line
+rb   |  /  .( /) |   after cursor, multiline, on screen
+rB   |  /  .( /  |)  after cursor, multiline, partially off screen
+bb   |  /  .  /()|   after cursor below, on screen
+bB   |  /  .  /( |)  after cursor below, partially off screen
+BB   |  /  .  /  |() after cursor below, off screen
+```
+
+#### Ranges before (left of/above) cursor
+
+```
+ll   |  /().  /  |   before cursor, current line
+al   | (/ ).  /  |   before cursor, multiline, on screen
+Al  (|  / ).  /  |   before cursor, multiline, partially off screen
+aa   |()/  .  /  |   before cursor above, on screen
+Aa  (| )/  .  /  |   before cursor above, partially off screen
+AA ()|  /  .  /  |   before cursor above, off screen
+```
+
+Pictogram legend:
+
+```
+    A  a  l r  b  B  relative positions
+     └───────────┘   visible screen
+        └─────┘      current line
+```
+
+Given the range types of our targets, we then pick the one that appears first
+in `g:targets_seekRanges`. If none is found, the selection fails.
+
+The default setting generally prefers targets around the cursor, with one
+exception: If the target around the cursor is not contained in the current
+cursor line, but the next or last target are, then prefer those.
+
+Some other useful example settings (or build your own!):
+
+Never seek backwards:
+```vim
+let g:targets_seekRanges = 'lr rr lb ar ab lB Ar aB Ab AB rb rB bb bB BB'
+```
+
+Only seek if next/last targets touch current line:
+```vim
+let g:targets_seekRanges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb rB al Al'
+```
+]
+Only consider targets fully visible on screen:
+```vim
+let g:targets_seekRanges = 'lr lb ar ab rr rb bb ll al aa'
+```
+
+Only consider targets around cursor:
+```vim
+let g:targets_seekRanges = 'lr lb ar ab lB Ar aB Ab AB'
+```
+
+Only consider targets fully contained in current line:
+```vim
+let g:targets_seekRanges = 'lr rr ll'
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -630,91 +630,13 @@ let g:targets_seekRanges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa b
 ```
 
 Defines a priority ordered, space separated list of range types which can be
-used to customize seeking behavior. When using a command like `cib` to change
-inside a block, targets.vim considers the three targets:
-
-  - smallest target around cursor
-  - next target after cursor
-  - last target before cursor
-
-For each of those that were found, we detect what range type it has. A range
-type depends on the relative position of the start and end of the target,
-relative to the current cursor position and the currently visible lines.
-
-The possibly relative positions are:
-
-  - `l`: left of cursor in current line
-  - `r`: right of cursor in current line
-  - `a`: above cursor on screen
-  - `b`: below cursor on screen
-  - `A`: above cursor off screen
-  - `B`: below cursor off screen
-
-All possibly ranges are listed below, denoted by two characters: one for the
-relative start and one for the relative end position of the target. For
-example, `lr` means "from left of cursor to right of cursor in cursor line".
-
-Next to each range type is a pictogram of an example. They are made of these
-symbols:
-
-  - `.`: current cursor position
-  - `(`: start of target
-  - `)`: end of target
-  - `/`: line break before and after cursor line
-  - `|`: screen edge between hidden and visible lines
-
-#### Ranges around cursor:
-
-```
-lr   |  / (.) /  |   around cursor, current line
-lb   |  / (.  /) |   around cursor, multiline down, on screen
-ar   | (/  .) /  |   around cursor, multiline up, on screen
-ab   | (/  .  /) |   around cursor, multiline both, on screen
-lB   |  / (.  /  |)  around cursor, multiline down, partially off screen
-Ar  (|  /  .) /  |   around cursor, multiline up, partially off screen
-aB   | (/  .  /  |)  around cursor, multiline both, partially off screen bottom
-Ab  (|  /  .  /) |   around cursor, multiline both, partially off screen top
-AB  (|  /  .  /  |)  around cursor, multiline both, partially off screen both
-```
-
-#### Ranges after (right of/below) cursor
-
-```
-rr   |  /  .()/  |   after cursor, current line
-rb   |  /  .( /) |   after cursor, multiline, on screen
-rB   |  /  .( /  |)  after cursor, multiline, partially off screen
-bb   |  /  .  /()|   after cursor below, on screen
-bB   |  /  .  /( |)  after cursor below, partially off screen
-BB   |  /  .  /  |() after cursor below, off screen
-```
-
-#### Ranges before (left of/above) cursor
-
-```
-ll   |  /().  /  |   before cursor, current line
-al   | (/ ).  /  |   before cursor, multiline, on screen
-Al  (|  / ).  /  |   before cursor, multiline, partially off screen
-aa   |()/  .  /  |   before cursor above, on screen
-Aa  (| )/  .  /  |   before cursor above, partially off screen
-AA ()|  /  .  /  |   before cursor above, off screen
-```
-
-Pictogram legend:
-
-```
-    A  a  l r  b  B  relative positions
-     └───────────┘   visible screen
-        └─────┘      current line
-```
-
-Given the range types of our targets, we then pick the one that appears first
-in `g:targets_seekRanges`. If none is found, the selection fails.
+used to customize seeking behavior.
 
 The default setting generally prefers targets around the cursor, with one
 exception: If the target around the cursor is not contained in the current
 cursor line, but the next or last target are, then prefer those.
 
-Some other useful example settings (or build your own!):
+Some other useful example settings:
 
 Never seek backwards:
 ```vim
@@ -740,6 +662,9 @@ Only consider targets fully contained in current line:
 ```vim
 let g:targets_seekRanges = 'lr rr ll'
 ```
+
+If you want to build your own, or are just curious what those cryptic letters
+mean, check out the full documentation in our [Cheat Sheet][cheatsheet].
 
 ## Notes
 

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -15,6 +15,15 @@ function! s:setup()
     let s:argOuter    = g:targets_argOpening . '\|' . g:targets_argClosing
     let s:argAll      = s:argOpeningS        . '\|' . g:targets_argClosing
     let s:none        = 'a^' " matches nothing
+
+    let s:rangeScores = {}
+    let ranges = split('lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA')
+    let rangesN = len(ranges)
+    let i = 0
+    while i < rangesN
+        let s:rangeScores[ranges[i]] = rangesN - i
+        let i = i + 1
+    endwhile
 endfunction
 
 call s:setup()
@@ -835,19 +844,19 @@ function! s:seekselectp(...)
 
     call setpos('.', oldpos)
 
-    let rangeAround = around.range(oldpos, min, max)
-    let rangeLast = last.range(oldpos, min, max)
-    let rangeNext = next.range(oldpos, min, max)
-
-    for range in split('lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA')
-        if range == rangeAround
-            return around
-        elseif range == rangeLast
-            return last
-        elseif range == rangeNext
-            return next
+    let bestScore = 0
+    for target in [last, around, next]
+        let range = target.range(oldpos, min, max)
+        let score = get(s:rangeScores, range)
+        if bestScore < score
+            let bestScore = score
+            let best = target
         endif
     endfor
+
+    if bestScore > 0
+        return best
+    endif
 
     return targets#target#withError('seekselectp')
 endfunction

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -17,7 +17,10 @@ function! s:setup()
     let s:none        = 'a^' " matches nothing
 
     let s:rangeScores = {}
-    let ranges = split('lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA')
+    if !exists('g:targets_seek_ranges')
+        let g:targets_seek_ranges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA'
+    endif
+    let ranges = split(g:targets_seek_ranges)
     let rangesN = len(ranges)
     let i = 0
     while i < rangesN

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -379,7 +379,7 @@ function! s:isNewSelection()
     return 0
 endfunction
 
-func! s:shouldGrow(trigger)
+function! s:shouldGrow(trigger)
     if s:newSelection
         return 0
     endif
@@ -667,26 +667,22 @@ function! s:seekselect()
     if rl > 0 " delim r found after cursor in line
         let [sl, sc] = searchpos(s:opening, 'b', line('.'))
         if sl > 0 " delim found before r in line
-            let [el, ec] = [rl, rc]
-            return targets#target#fromValues(sl, sc, el, ec)
+            return targets#target#fromValues(sl, sc, rl, rc)
         endif
         " no delim before cursor in line
         let [el, ec] = searchpos(s:opening, '', line('.'))
         if el > 0 " delim found after r in line
-            let [sl, sc] = [rl, rc]
-            return targets#target#fromValues(sl, sc, el, ec)
+            return targets#target#fromValues(rl, rc, el, ec)
         endif
         " no delim found after r in line
         let [sl, sc] = searchpos(s:opening, 'bW')
         if sl > 0 " delim found before r
-            let [el, ec] = [rl, rc]
-            return targets#target#fromValues(sl, sc, el, ec)
+            return targets#target#fromValues(sl, sc, rl, rc)
         endif
         " no delim found before r
         let [el, ec] = searchpos(s:opening, 'W')
         if el > 0 " delim found after r
-            let [sl, sc] = [rl, rc]
-            return targets#target#fromValues(sl, sc, el, ec)
+            return targets#target#fromValues(rl, rc, el, ec)
         endif
         " no delim found after r
         return targets#target#withError('seekselect 1')
@@ -697,20 +693,17 @@ function! s:seekselect()
     if ll > 0 " delim l found before cursor in line
         let [sl, sc] = searchpos(s:opening, 'b', line('.'))
         if sl > 0 " delim found before l in line
-            let [el, ec] = [ll, lc]
-            return targets#target#fromValues(sl, sc, el, ec)
+            return targets#target#fromValues(sl, sc, ll, lc)
         endif
         " no delim found before l in line
         let [el, ec] = searchpos(s:opening, 'W')
         if el > 0 " delim found after l
-            let [sl, sc] = [ll, lc]
-            return targets#target#fromValues(sl, sc, el, ec)
+            return targets#target#fromValues(ll, lc, el, ec)
         endif
         " no delim found after l
         let [sl, sc] = searchpos(s:opening, 'bW')
         if sl > 0 " delim found before l
-            let [el, ec] = [ll, lc]
-            return targets#target#fromValues(sl, sc, el, ec)
+            return targets#target#fromValues(sl, sc, ll, lc)
         endif
         " no delim found before l
         return targets#target#withError('seekselect 2')
@@ -721,14 +714,12 @@ function! s:seekselect()
     if rl > 0 " delim r found after cursor
         let [sl, sc] = searchpos(s:opening, 'bW')
         if sl > 0 " delim found before r
-            let [el, ec] = [rl, rc]
-            return targets#target#fromValues(sl, sc, el, ec)
+            return targets#target#fromValues(sl, sc, rl, rc)
         endif
         " no delim found before r
         let [el, ec] = searchpos(s:opening, 'W')
         if el > 0 " delim found after r
-            let [sl, sc] = [rl, rc]
-            return targets#target#fromValues(sl, sc, el, ec)
+            return targets#target#fromValues(rl, rc, el, ec)
         endif
         " no delim found after r
         return targets#target#withError('seekselect 3')

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -958,22 +958,21 @@ function! s:seekselecta(count)
 
     call setpos('.', oldpos)
 
-    let last = s:lastselecta(a:count)
+    let last = s:lastselecta()
 
     call setpos('.', oldpos)
 
-    let next = s:nextselecta(a:count)
+    let next = s:nextselecta()
 
     return s:bestSeekTarget([around, next, last], oldpos, min, max, 'seekselecta')
 endfunction
 
 " try to select a next argument, supports count and optional stopline
-" args (count, stopline=0)
+" args (count=1, stopline=0)
 function! s:nextselecta(...)
+    let [cnt, stopline] = [a:0 > 0 ? a:1 : 1, a:0 > 1 ? a:2 : 0]
     call s:prepareNext()
 
-    let cnt = a:1
-    let stopline = a:0 > 1 ? a:2 : 0
     if s:search(cnt, s:argOpeningS, 'W', stopline) > 0 " no start found
         return targets#target#withError('nextselecta 1')
     endif
@@ -1003,8 +1002,10 @@ function! s:nextselecta(...)
 endfunction
 
 " try to select a last argument, supports count and optional stopline
-" args (count, stopline=0)
+" args (count=1, stopline=0)
 function! s:lastselecta(...)
+    let [cnt, stopline] = [a:0 > 0 ? a:1 : 1, a:0 > 1 ? a:2 : 0]
+
     call s:prepareLast()
 
     " special case to handle vala when invoked on a separator
@@ -1016,8 +1017,6 @@ function! s:lastselecta(...)
         endif
     endif
 
-    let cnt = a:1
-    let stopline = a:0 > 1 ? a:2 : 0
     if s:search(cnt, s:argClosingS, 'bW', stopline) > 0 " no start found
         return targets#target#withError('lastselecta 1')
     endif

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -778,9 +778,16 @@ function! s:seekselect()
 endfunction
 
 " select a pair around the cursor
-function! s:selectp()
+" args(count=1, trigger=s:opening)
+function! s:selectp(...)
+    if a:0 == 2
+        let [cnt, trigger] = [a:1, a:2]
+    else
+        let [cnt, trigger] = [1, s:opening]
+    endif
+
     " try to select pair
-    silent! execute 'normal! va' . s:opening
+    silent! execute 'normal! v' . cnt . 'a' . trigger
     let [el, ec] = getpos('.')[1:2]
     silent! normal! o
     let [sl, sc] = getpos('.')[1:2]
@@ -806,17 +813,10 @@ function! s:seekselectp(...)
         let [cnt, opening, closing, trigger] = [a:1, s:opening, s:closing, s:closing]
     endif
 
-    " try to select around cursor
-    silent! execute 'normal! v' . cnt . 'a' . trigger
-    let [el, ec] = getpos('.')[1:2]
-    silent! normal! o
-    let [sl, sc] = getpos('.')[1:2]
-    silent! normal! v
-
-    if sc != ec || sl != el
+    let target = s:selectp(cnt, trigger)
+    if target.state().isValid()
         " found target around cursor
-        let cnt = 1
-        return targets#target#fromValues(sl, sc, el, ec)
+        return target
     endif
 
     if cnt > 1

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -842,11 +842,13 @@ function! s:seekselectp(...)
     call s:nextp(cnt)
     let next = s:selectp()
 
-    call setpos('.', oldpos)
+    return s:bestSeekTarget([last, around, next], oldpos, min, max, 'seekselectp')
+endfunction
 
+function! s:bestSeekTarget(targets, oldpos, min, max, message)
     let bestScore = 0
-    for target in [last, around, next]
-        let range = target.range(oldpos, min, max)
+    for target in a:targets
+        let range = target.range(a:oldpos, a:min, a:max)
         let score = get(s:rangeScores, range)
         if bestScore < score
             let bestScore = score
@@ -858,7 +860,7 @@ function! s:seekselectp(...)
         return best
     endif
 
-    return targets#target#withError('seekselectp')
+    return targets#target#withError(a:message)
 endfunction
 
 " tag pair matcher (works across multiple lines, supports seeking)

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -17,10 +17,10 @@ function! s:setup()
     let s:none        = 'a^' " matches nothing
 
     let s:rangeScores = {}
-    if !exists('g:targets_seek_ranges')
-        let g:targets_seek_ranges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA'
+    if !exists('g:targets_seekRanges')
+        let g:targets_seekRanges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA'
     endif
-    let ranges = split(g:targets_seek_ranges)
+    let ranges = split(g:targets_seekRanges)
     let rangesN = len(ranges)
     let i = 0
     while i < rangesN
@@ -998,9 +998,9 @@ endfunction
 "   A - above cursor off screen
 "   B - below cursor off screen
 
-" All possibly ranges are listed below, denoted by two characters, one for the
-" relative start and for the end position each. For example, `lr` means "from
-" left of cursor to right of cursor".
+" All possibly ranges are listed below, denoted by two characters: one for the
+" relative start and for the relative end position each of the target. For
+" example, `lr` means "from left of cursor to right of cursor in cursor line".
 
 " Next to each range type is a pictogram of an example. They are made of these
 " symbols:

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -946,35 +946,25 @@ function! s:seekselecta(count)
         return s:selecta('^')
     endif
 
-    let target = s:selecta('>')
-    if target.state().isValid()
-        return target
+    let min = line('w0')
+    let max = line('w$')
+    let oldpos = getpos('.')
+
+    let around = s:selecta('>')
+
+    if a:count > 1 " don't seek with count
+        return around
     endif
 
-    " TODO: get next and last and select best one instead of trying with
-    " restrictions
+    call setpos('.', oldpos)
 
-    let target = s:nextselecta(a:count, line('.'))
-    if target.state().isValid()
-        return target
-    endif
+    let last = s:lastselecta(a:count)
 
-    let target = s:lastselecta(a:count, line('.'))
-    if target.state().isValid()
-        return target
-    endif
+    call setpos('.', oldpos)
 
-    let target = s:nextselecta(a:count)
-    if target.state().isValid()
-        return target
-    endif
+    let next = s:nextselecta(a:count)
 
-    let target = s:lastselecta(a:count)
-    if target.state().isValid()
-        return target
-    endif
-
-    return targets#target#withError('seekselecta seek')
+    return s:bestSeekTarget([around, next, last], oldpos, min, max, 'seekselecta')
 endfunction
 
 " try to select a next argument, supports count and optional stopline

--- a/autoload/targets/target.vim
+++ b/autoload/targets/target.vim
@@ -21,6 +21,7 @@ function! targets#target#new(sl, sc, el, ec, error)
         \ 'cursorS': function('targets#target#cursorS'),
         \ 'cursorE': function('targets#target#cursorE'),
         \ 'state': function('targets#target#state'),
+        \ 'range': function('targets#target#range'),
         \ 'select': function('targets#target#select'),
         \ 'echom': function('targets#target#echom')
         \ }
@@ -118,6 +119,45 @@ function! targets#target#state() dict
         return targets#state#invalid()
     else
         return targets#state#nonempty()
+    endif
+endfunction
+
+function! targets#target#range(cursor, min, max) dict
+    if self.error != ''
+        return ''
+    endif
+
+    let positionS = s:position(self.sl, self.sc, a:cursor, a:min, a:max, 'l')
+    let positionE = s:position(self.el, self.ec, a:cursor, a:min, a:max, 'r')
+    return positionS . positionE
+endfunction
+
+function! s:position(line, column, cursor, min, max, tie)
+    let cursorLine = a:cursor[1]
+
+    if a:line == cursorLine " cursor line
+        let cursorColumn = a:cursor[2]
+        if a:column == cursorColumn " same column
+            return a:tie
+        elseif a:column < cursorColumn " left of cursor
+            return 'l'
+        else " a:column > cursorColumn " right of cursor
+            return 'r'
+        endif
+
+    elseif a:line < cursorLine
+        if a:line >= a:min " above on screen
+            return 'a'
+        else " above off screen
+            return 'A'
+        endif
+
+    else " a:line > cursorLine
+        if a:line <= a:max " below on screen
+            return 'b'
+        else " below off screen
+            return 'B'
+        endif
     endif
 endfunction
 

--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -136,3 +136,122 @@ a ( bbbbbb , ccccccc , d ( eeeeee , fffffff ) , gggggg ) h
                      ├───────2aa─────────────┘ │
                      └───────2Aa───────────────┘
 ```
+
+## Customize seeking
+
+Seeking is controlled by the setting `g:targets_seekRanges`. Default value:
+
+```vim
+let g:targets_seekRanges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA'
+```
+
+When using a command like `cib` to change inside a block, targets.vim considers
+the three targets:
+
+  - smallest target around cursor
+  - next target after cursor
+  - last target before cursor
+
+For each of those that were found, we detect what range type it has. A range
+type depends on the relative position of the start and end of the target,
+relative to the current cursor position and the currently visible lines.
+
+The possibly relative positions are:
+
+  - `l`: left of cursor in current line
+  - `r`: right of cursor in current line
+  - `a`: above cursor on screen
+  - `b`: below cursor on screen
+  - `A`: above cursor off screen
+  - `B`: below cursor off screen
+
+All possibly ranges are listed below, denoted by two characters: one for the
+relative start and one for the relative end position of the target. For
+example, `lr` means "from left of cursor to right of cursor in cursor line".
+
+Next to each range type is a pictogram of an example. They are made of these
+symbols:
+
+  - `.`: current cursor position
+  - `(`: start of target
+  - `)`: end of target
+  - `/`: line break before and after cursor line
+  - `|`: screen edge between hidden and visible lines
+
+#### Ranges around cursor:
+
+```
+lr   |  / (.) /  |   around cursor, current line
+lb   |  / (.  /) |   around cursor, multiline down, on screen
+ar   | (/  .) /  |   around cursor, multiline up, on screen
+ab   | (/  .  /) |   around cursor, multiline both, on screen
+lB   |  / (.  /  |)  around cursor, multiline down, partially off screen
+Ar  (|  /  .) /  |   around cursor, multiline up, partially off screen
+aB   | (/  .  /  |)  around cursor, multiline both, partially off screen bottom
+Ab  (|  /  .  /) |   around cursor, multiline both, partially off screen top
+AB  (|  /  .  /  |)  around cursor, multiline both, partially off screen both
+```
+
+#### Ranges after (right of/below) cursor
+
+```
+rr   |  /  .()/  |   after cursor, current line
+rb   |  /  .( /) |   after cursor, multiline, on screen
+rB   |  /  .( /  |)  after cursor, multiline, partially off screen
+bb   |  /  .  /()|   after cursor below, on screen
+bB   |  /  .  /( |)  after cursor below, partially off screen
+BB   |  /  .  /  |() after cursor below, off screen
+```
+
+#### Ranges before (left of/above) cursor
+
+```
+ll   |  /().  /  |   before cursor, current line
+al   | (/ ).  /  |   before cursor, multiline, on screen
+Al  (|  / ).  /  |   before cursor, multiline, partially off screen
+aa   |()/  .  /  |   before cursor above, on screen
+Aa  (| )/  .  /  |   before cursor above, partially off screen
+AA ()|  /  .  /  |   before cursor above, off screen
+```
+
+Pictogram legend:
+
+```
+    A  a  l r  b  B  relative positions
+     └───────────┘   visible screen
+        └─────┘      current line
+```
+
+Given the range types of our targets, we then pick the one that appears first
+in `g:targets_seekRanges`. If none is found, the selection fails.
+
+The default setting generally prefers targets around the cursor, with one
+exception: If the target around the cursor is not contained in the current
+cursor line, but the next or last target are, then prefer those.
+
+Some other useful example settings (or build your own!):
+
+Never seek backwards:
+```vim
+let g:targets_seekRanges = 'lr rr lb ar ab lB Ar aB Ab AB rb rB bb bB BB'
+```
+
+Only seek if next/last targets touch current line:
+```vim
+let g:targets_seekRanges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb rB al Al'
+```
+]
+Only consider targets fully visible on screen:
+```vim
+let g:targets_seekRanges = 'lr lb ar ab rr rb bb ll al aa'
+```
+
+Only consider targets around cursor:
+```vim
+let g:targets_seekRanges = 'lr lb ar ab lB Ar aB Ab AB'
+```
+
+Only consider targets fully contained in current line:
+```vim
+let g:targets_seekRanges = 'lr rr ll'
+```

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -504,6 +504,12 @@ Available options: ~
     |g:targets_pairs|
     |g:targets_quotes|
     |g:targets_separators|
+    |g:targets_tagTrigger|
+    |g:targets_argTrigger|
+    |g:targets_argOpening|
+    |g:targets_argClosing|
+    |g:targets_argSeparator|
+    |g:targets_seekRanges|
 
 ------------------------------------------------------------------------------
                                                               *g:targets_aiAI*
@@ -599,6 +605,97 @@ Defines a regular expression matching separators in an argument list. If you
 also want to find arguments separatode by semicolon, use this:
 
     let g:targets_argSeparator = '[,;]' ~
+
+                                                        *g:targets_seekRanges*
+
+Default:
+    let g:targets_seekRanges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA' ~
+
+Defines a priority ordered, space separated list of range types which can be
+used to customize seeking behavior. When using a command like `cib` to change
+inside a block, targets.vim considers the three targets:
+
+    smallest target around cursor
+    next target after cursor
+    last target before cursor
+
+For each of those that were found, we detect what range type it has. A range
+type depends on the relative position of the start and end of the target,
+relative to the current cursor position and the currently visible lines.
+
+The possibly relative positions are:
+    l    left of cursor in current line ~
+    r    right of cursor in current line ~
+    a    above cursor on screen ~
+    b    below cursor on screen ~
+    A    above cursor off screen ~
+    B    below cursor off screen ~
+
+All possibly ranges are listed below, denoted by two characters: one for the
+relative start and one for the relative end position of the target. For
+example, `lr` means "from left of cursor to right of cursor in cursor line".
+
+Next to each range type is a pictogram of an example. They are made of these
+symbols:
+    .    current cursor position ~
+   ( )   start and end of target ~
+    /    line break before and after cursor line ~
+    |    screen edge between hidden and visible lines ~
+
+Ranges around cursor:
+  lr   |  / (.) /  |   around cursor, current line ~
+  lb   |  / (.  /) |   around cursor, multiline down, on screen ~
+  ar   | (/  .) /  |   around cursor, multiline up, on screen ~
+  ab   | (/  .  /) |   around cursor, multiline both, on screen ~
+  lB   |  / (.  /  |)  around cursor, multiline down, partially off screen ~
+  Ar  (|  /  .) /  |   around cursor, multiline up, partially off screen ~
+  aB   | (/  .  /  |)  around cursor, multiline both, partially off screen bottom ~
+  Ab  (|  /  .  /) |   around cursor, multiline both, partially off screen top ~
+  AB  (|  /  .  /  |)  around cursor, multiline both, partially off screen both ~
+
+Ranges after (right of/below) cursor
+  rr   |  /  .()/  |   after cursor, current line ~
+  rb   |  /  .( /) |   after cursor, multiline, on screen ~
+  rB   |  /  .( /  |)  after cursor, multiline, partially off screen ~
+  bb   |  /  .  /()|   after cursor below, on screen ~
+  bB   |  /  .  /( |)  after cursor below, partially off screen ~
+  BB   |  /  .  /  |() after cursor below, off screen ~
+
+Ranges before (left of/above) cursor
+  ll   |  /().  /  |   before cursor, current line ~
+  al   | (/ ).  /  |   before cursor, multiline, on screen ~
+  Al  (|  / ).  /  |   before cursor, multiline, partially off screen ~
+  aa   |()/  .  /  |   before cursor above, on screen ~
+  Aa  (| )/  .  /  |   before cursor above, partially off screen ~
+  AA ()|  /  .  /  |   before cursor above, off screen ~
+
+      A  a  l r  b  B  relative positions
+       └───────────┘   visible screen
+          └─────┘      current line
+
+Given the range types of our targets, we then pick the one that appears first
+in `g:targets_seekRanges`. If none is found, the selection fails.
+
+The default setting generally prefers targets around the cursor, with one
+exception: If the target around the cursor is not contained in the current
+cursor line, but the next or last target are, then prefer those.
+
+Some other useful example settings (or build your own!):
+
+Never seek backwards:
+    let g:targets_seekRanges = 'lr rr lb ar ab lB Ar aB Ab AB rb rB bb bB BB' ~
+
+Only seek if next/last targets touch current line:
+    let g:targets_seekRanges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb rB al Al' ~
+
+Only consider targets fully visible on screen:
+    let g:targets_seekRanges = 'lr lb ar ab rr rb bb ll al aa' ~
+
+Only consider targets around cursor:
+    let g:targets_seekRanges = 'lr lb ar ab lB Ar aB Ab AB' ~
+
+Only consider targets fully contained in current line:
+    let g:targets_seekRanges = 'lr rr ll' ~
 
 ==============================================================================
 NOTES                                                          *targets-notes*

--- a/test/test3.ok
+++ b/test/test3.ok
@@ -8,9 +8,13 @@ D (D) c
 
 a (E) E
 
-a (F) e
+a ( b
+F (F) c
+d ) e
 
-a (G) e
+a ( b
+c (G) G
+d ) e
 
 a ( b ) H (H) d
 

--- a/test/test3.out
+++ b/test/test3.out
@@ -8,9 +8,13 @@ D (D) c
 
 a (E) E
 
-a (F) e
+a ( b
+F (F) c
+d ) e
 
-a (G) e
+a ( b
+c (G) G
+d ) e
 
 a ( b ) H (H) d
 


### PR DESCRIPTION
Close #127 

New setting: [`g:targets_seekRanges`](https://github.com/wellle/targets.vim/blob/127-seek-ranges/README.md#gtargets_seekranges)
Full documentation: [Customize seeking](https://github.com/wellle/targets.vim/blob/127-seek-ranges/cheatsheet.md#customize-seeking)

This also changes the default seeking behavior of pair text objects to be more consistent with seeking of the other text objects. Consider this example:
```
outer (
    x ( inner )
)
```
With the cursor on `x`, when typing `da(`, it would pick the outer pair surrounding the cursor:
```
outer 
```
After the change we prefer next or last text objects contained in the cursor line over multi line text objects around the cursor. Now it picks the inner pair:
```
outer (
    x 
)
```

--

@chochkov: I implemented the most flexible way to customize seeking that I could think of. Unfortunately it also became a bit cryptic. Would you take a look (at least at the documentation, see link above) and let me know if that looks manageable?

I added your specific request as an example setting. Let me know if there are other settings that might be useful additions.