### PR TITLE
New option to control adding to the jumplist

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ g:targets_argOpening
 g:targets_argClosing
 g:targets_argSeparator
 g:targets_seekRanges
+g:targets_addJumplist
 ```
 
 ### g:targets_aiAI
@@ -665,6 +666,21 @@ let g:targets_seekRanges = 'lr rr ll'
 
 If you want to build your own, or are just curious what those cryptic letters
 mean, check out the full documentation in our [Cheat Sheet][cheatsheet].
+
+### g:targets_addJumplist
+
+Default:
+
+```vim
+let g:targets_addJumplist = 2
+```
+
+Controls whether or not to add the cursor position prior to selecting the text
+object to the jumplist. The settings are:
+
+- 2 - Always adds to the jumplist.
+- 1 - Only add to the jumplist if the cursor was not inside the text object.
+- 0 - Never add to the jump list.
 
 ## Notes
 

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -39,7 +39,7 @@ function! targets#o(trigger, count)
     if target.state().isInvalid()
         return s:cleanUp()
     endif
-    call s:handleTarget(target)
+    call s:handleTarget(target, rawTarget)
     call s:clearCommandLine()
     call s:prepareRepeat(delimiter, which, modifier)
     call s:cleanUp()
@@ -84,7 +84,7 @@ function! targets#x(trigger, count)
         call s:abortMatch('#x')
         return s:cleanUp()
     endif
-    if s:handleTarget(target) == 0
+    if s:handleTarget(target, rawTarget) == 0
         let s:lastTrigger = a:trigger
         let s:lastRawTarget = rawTarget
         let s:lastTarget = target
@@ -413,23 +413,33 @@ function! s:clearCommandLine()
 endfunction
 
 " handle the match by either selecting or aborting it
-function! s:handleTarget(target)
+function! s:handleTarget(target, rawTarget)
     if a:target.state().isInvalid()
         return s:abortMatch('handleTarget')
     elseif a:target.state().isEmpty()
         return s:handleEmptyMatch(a:target)
     else
-        return s:selectTarget(a:target)
+        return s:selectTarget(a:target, a:rawTarget)
     endif
 endfunction
 
 " select a proper match
-function! s:selectTarget(target)
+function! s:selectTarget(target, rawTarget)
     " add old position to jump list
-    call setpos('.', s:oldpos)
-    normal! m'
+    if s:addToJumplist(a:rawTarget)
+        call setpos('.', s:oldpos)
+        normal! m'
+    endif
 
     call s:selectRegion(a:target)
+endfunction
+
+function! s:addToJumplist(target)
+    if !g:targets_addJumplist
+        return 0
+    else
+        return g:targets_addJumplist - a:target.contains(s:oldpos)
+    endif
 endfunction
 
 " visually select a given match. used for match or old selection
@@ -708,7 +718,7 @@ function! s:selectp(...)
     endif
 
     " try to select pair
-    silent! execute 'normal! v' . cnt . 'a' . trigger
+    silent! execute 'keepjumps normal! v' . cnt . 'a' . trigger
     let [el, ec] = getpos('.')[1:2]
     silent! normal! o
     let [sl, sc] = getpos('.')[1:2]
@@ -859,7 +869,7 @@ function! s:findArgBoundary(...)
                 endif
                 break
             elseif char =~# skip
-                silent! normal! %
+                silent! keepjumps normal! %
             else
                 return [0, 0, s:fail('findArgBoundary 2')]
             endif

--- a/autoload/targets/target.vim
+++ b/autoload/targets/target.vim
@@ -23,6 +23,7 @@ function! targets#target#new(sl, sc, el, ec, error)
         \ 'state': function('targets#target#state'),
         \ 'range': function('targets#target#range'),
         \ 'select': function('targets#target#select'),
+        \ 'contains': function('targets#target#contains'),
         \ 'echom': function('targets#target#echom')
         \ }
 endfunction
@@ -172,6 +173,17 @@ function! targets#target#select() dict
     endif
 
     call cursor(self.e())
+endfunction
+
+function! targets#target#contains(cursor) dict
+    let cursorLine = a:cursor[1]
+    let cursorColumn = a:cursor[2]
+
+    if self.sl == self.el
+        return self.sc <= cursorColumn && cursorColumn <= self.ec && self.sl == cursorLine
+    else
+        return self.sl <= cursorLine && cursorLine <= self.el
+    endif
 endfunction
 
 function! targets#target#echom() dict

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -510,6 +510,7 @@ Available options: ~
     |g:targets_argClosing|
     |g:targets_argSeparator|
     |g:targets_seekRanges|
+    |g:targets_addJumplist|
 
 ------------------------------------------------------------------------------
                                                               *g:targets_aiAI*
@@ -696,6 +697,27 @@ Only consider targets around cursor:
 
 Only consider targets fully contained in current line:
     let g:targets_seekRanges = 'lr rr ll' ~
+
+                                                      *g:targets_addJumplist*
+
+Default:
+    let g:targets_addJumplist = 2 ~
+
+Controls whether or not to add the cursor position prior to selecting the text
+object to the jumplist. The possible settings are:
+
+Always adds to the jumplist:
+    let g:targets_addJumplist = 2 ~
+
+Adds to the jumplist if the old cursor position was not inside the "around"
+version of the text object being used. For example, if the cursor is on an open
+parenthesis and the command `yi(` is issued then the old cursor position will
+not be added to the jump list because the opening parenthesis is contained in
+the `a(` text object:
+    let g:targets_addJumplist = 1 ~
+
+Never add to the jumplist:
+    let g:targets_addJumplist = 0 ~
 
 ==============================================================================
 NOTES                                                          *targets-notes*

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -253,6 +253,9 @@ function! s:loadSettings()
     if !exists('g:targets_argSeparator')
         let g:targets_argSeparator = ','
     endif
+    if !exists('g:targets_addJumplist')
+        let g:targets_addJumplist = 2
+    endif
 
     let [s:a, s:i, s:A, s:I] = split(g:targets_aiAI, '\zs')
     let [s:n, s:l, s:N, s:L] = split(g:targets_nlNL, '\zs')


### PR DESCRIPTION
Hello again! Merry Christmas!! Here's a present? This PR adds a new option which solves a slight annoyance I've encountered while editing. I'll illustrate with an example. Say I'm happily editing a file and I want to change a string somewhere in that file. So I'll do a sequence of commands like this:

```vim
" Go to the string I want to edit, this leaves my cursor on the opening quote of the string
/'str<CR>
" Changes the contents of the string
ci'hello world<ESC>
``` 

After doing that I might want to go back to where I was before the search and so I instinctively do ``` `` ```, but it doesn't quite work. Since this plugin adds the cursor position before the selection of the text object to the jump list, doing ``` `` ``` will actually just move me to the opening quote of the string which now says `'hello world'`. To get back to where I was originally, I'll need to issue a couple `<C-o>`'s. Not terrible by any means (I can't honestly say how often it comes up. I've been meaning to tally up when it happens and get a basic sense of frequency) but I thought it would be nice if it could be fixed! Had some free time this vacation so I did.

### Your Opinion

Do you think this a useful option to add? Is the sort of problem I described ever something you encounter? The short summary of possible settings for this new option are:

1. Always add to the jump list (same as current behavior)
2. Only add to the jump list if the cursor position prior to selection was not inside the 'around'/'raw' version of the text object. In doing this I wondered if I should add another setting similar to this where we add to the jump list if the cursor was not inside the *actual* text object being selected rather than the 'raw' text object. If this option existed and was set then doing `ci'` in my above example *would* have added the cursor position to the jump list because my cursor was on the opening `'` which is not contained by the `i'` text object. But this wasn't the behavior I was interested in so I decided not to implement it. But it would be simple to add that behavior in if you think someone might want or just for the heck of it.
3. Never add to the jump list. Honestly I don't know if anyone would want this. I kind of just threw it in for the sake of completeness (because then you get on, off, and half on).

### Found a couple bugs!

In the process of making this PR I found a couple things which I think are bugs. This plugin adds to the jump list multiple times when the 'argument' or 'pair' text objects get used.

#### https://github.com/wellle/targets.vim/blob/master/autoload/targets.vim#L711

I wasn't aware of this but it seems to be the case that in vanilla vim when you use a text object described in the help pages as a "block" (like `i(` or `a{`) then it adds the cursor position prior to the selection to the jump list. So whenever this line of code runs it will add to the jump list.

#### https://github.com/wellle/targets.vim/blob/master/autoload/targets.vim#L862

Whenever you have to skip over a function call, this line of code will add to the jump list.

### Yep

So yeah, I think that's about it. Merry christmas!
