### PR TITLE
133 Seeking prefer targets with boundary under cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ let g:targets_argSeparator = '[,;]'
 Default:
 
 ```vim
-let g:targets_seekRanges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA'
+let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA'
 ```
 
 Defines a priority ordered, space separated list of range types which can be
@@ -634,33 +634,34 @@ used to customize seeking behavior.
 
 The default setting generally prefers targets around the cursor, with one
 exception: If the target around the cursor is not contained in the current
-cursor line, but the next or last target are, then prefer those.
+cursor line, but the next or last target are, then prefer those. Targets
+beginning or ending on the cursor are preferred over everything else.
 
 Some other useful example settings:
 
 Never seek backwards:
 ```vim
-let g:targets_seekRanges = 'lr rr lb ar ab lB Ar aB Ab AB rb rB bb bB BB'
+let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr lb ar ab lB Ar aB Ab AB rb rB bb bB BB'
 ```
 
 Only seek if next/last targets touch current line:
 ```vim
-let g:targets_seekRanges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb rB al Al'
+let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll lb ar ab lB Ar aB Ab AB rb rB al Al'
 ```
-]
+
 Only consider targets fully visible on screen:
 ```vim
-let g:targets_seekRanges = 'lr lb ar ab rr rb bb ll al aa'
+let g:targets_seekRanges = 'cr cb cB lc ac Ac lr lb ar ab rr rb bb ll al aa'
 ```
 
 Only consider targets around cursor:
 ```vim
-let g:targets_seekRanges = 'lr lb ar ab lB Ar aB Ab AB'
+let g:targets_seekRanges = 'cr cb cB lc ac Ac lr lb ar ab lB Ar aB Ab AB'
 ```
 
 Only consider targets fully contained in current line:
 ```vim
-let g:targets_seekRanges = 'lr rr ll'
+let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll'
 ```
 
 If you want to build your own, or are just curious what those cryptic letters

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -18,7 +18,7 @@ function! s:setup()
 
     let s:rangeScores = {}
     if !exists('g:targets_seekRanges')
-        let g:targets_seekRanges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA'
+        let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA'
     endif
     let ranges = split(g:targets_seekRanges)
     let rangesN = len(ranges)
@@ -659,7 +659,8 @@ function! s:select(direction)
         return targets#target#withError(message)
     endif
 
-    return targets#target#fromValues(sl, sc, el, ec)
+    let target = targets#target#fromValues(sl, sc, el, ec)
+    return target
 endfunction
 
 " TODO: inject direction and return proper target
@@ -991,6 +992,7 @@ endfunction
 " position and the currently visible lines
 
 " The possibly relative positions are:
+"   c - on cursor position
 "   l - left of cursor in current line
 "   r - right of cursor in current line
 "   a - above cursor on screen
@@ -1008,6 +1010,14 @@ endfunction
 "   ( ) - start and end of target
 "    /  - line break before and after cursor line
 "    |  - screen edge between hidden and visible lines
+
+" ranges on cursor:
+"   cr   |  /  () /  |   starting on cursor, current line
+"   cb   |  /  (  /) |   starting on cursor, multiline down, on screen
+"   cB   |  /  (  /  |)  starting on cursor, multiline down, partially off screen
+"   lc   |  / ()  /  |   ending on cursor, current line
+"   ac   | (/  )  /  |   ending on cursor, multiline up, on screen
+"   Ac  (|  /  )  /  |   ending on cursor, multiline up, partially off screen
 
 " ranges around cursor:
 "   lr   |  / (.) /  |   around cursor, current line

--- a/autoload/targets/target.vim
+++ b/autoload/targets/target.vim
@@ -127,8 +127,8 @@ function! targets#target#range(cursor, min, max) dict
         return ''
     endif
 
-    let positionS = s:position(self.sl, self.sc, a:cursor, a:min, a:max, 'l')
-    let positionE = s:position(self.el, self.ec, a:cursor, a:min, a:max, 'r')
+    let positionS = s:position(self.sl, self.sc, a:cursor, a:min, a:max, 'c')
+    let positionE = s:position(self.el, self.ec, a:cursor, a:min, a:max, 'c')
     return positionS . positionE
 endfunction
 

--- a/autoload/targets/target.vim
+++ b/autoload/targets/target.vim
@@ -23,7 +23,7 @@ function! targets#target#new(sl, sc, el, ec, error)
         \ 'state': function('targets#target#state'),
         \ 'range': function('targets#target#range'),
         \ 'select': function('targets#target#select'),
-        \ 'echom': function('targets#target#echom')
+        \ 'string': function('targets#target#string')
         \ }
 endfunction
 
@@ -174,6 +174,10 @@ function! targets#target#select() dict
     call cursor(self.e())
 endfunction
 
-function! targets#target#echom() dict
-    echom '[' . self.sl self.sc . '; ' . self.el self.ec . ']'
+function! targets#target#string() dict
+    if self.error != ''
+        return '[err:' . self.error . ']'
+    endif
+
+    return '[' . self.sl . ' ' . self.sc . '; ' . self.el . ' ' . self.ec . ']'
 endfunction

--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -158,6 +158,7 @@ relative to the current cursor position and the currently visible lines.
 
 The possibly relative positions are:
 
+  - `c`: on cursor position
   - `l`: left of cursor in current line
   - `r`: right of cursor in current line
   - `a`: above cursor on screen
@@ -177,6 +178,17 @@ symbols:
   - `)`: end of target
   - `/`: line break before and after cursor line
   - `|`: screen edge between hidden and visible lines
+
+#### Ranges on cursor:
+
+```
+cr   |  /  () /  |   starting on cursor, current line
+cb   |  /  (  /) |   starting on cursor, multiline down, on screen
+cB   |  /  (  /  |)  starting on cursor, multiline down, partially off screen
+lc   |  / ()  /  |   ending on cursor, current line
+ac   | (/  )  /  |   ending on cursor, multiline up, on screen
+Ac  (|  /  )  /  |   ending on cursor, multiline up, partially off screen
+```
 
 #### Ranges around cursor:
 
@@ -227,31 +239,32 @@ in `g:targets_seekRanges`. If none is found, the selection fails.
 
 The default setting generally prefers targets around the cursor, with one
 exception: If the target around the cursor is not contained in the current
-cursor line, but the next or last target are, then prefer those.
+cursor line, but the next or last target are, then prefer those. Targets
+beginning or ending on the cursor are preferred over everything else.
 
-Some other useful example settings (or build your own!):
+Some other useful example settings:
 
 Never seek backwards:
 ```vim
-let g:targets_seekRanges = 'lr rr lb ar ab lB Ar aB Ab AB rb rB bb bB BB'
+let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr lb ar ab lB Ar aB Ab AB rb rB bb bB BB'
 ```
 
 Only seek if next/last targets touch current line:
 ```vim
-let g:targets_seekRanges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb rB al Al'
+let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll lb ar ab lB Ar aB Ab AB rb rB al Al'
 ```
-]
+
 Only consider targets fully visible on screen:
 ```vim
-let g:targets_seekRanges = 'lr lb ar ab rr rb bb ll al aa'
+let g:targets_seekRanges = 'cr cb cB lc ac Ac lr lb ar ab rr rb bb ll al aa'
 ```
 
 Only consider targets around cursor:
 ```vim
-let g:targets_seekRanges = 'lr lb ar ab lB Ar aB Ab AB'
+let g:targets_seekRanges = 'cr cb cB lc ac Ac lr lb ar ab lB Ar aB Ab AB'
 ```
 
 Only consider targets fully contained in current line:
 ```vim
-let g:targets_seekRanges = 'lr rr ll'
+let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll'
 ```

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -609,7 +609,7 @@ also want to find arguments separatode by semicolon, use this:
                                                         *g:targets_seekRanges*
 
 Default:
-    let g:targets_seekRanges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA' ~
+    let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA' ~
 
 Defines a priority ordered, space separated list of range types which can be
 used to customize seeking behavior. When using a command like `cib` to change
@@ -678,24 +678,25 @@ in `g:targets_seekRanges`. If none is found, the selection fails.
 
 The default setting generally prefers targets around the cursor, with one
 exception: If the target around the cursor is not contained in the current
-cursor line, but the next or last target are, then prefer those.
+cursor line, but the next or last target are, then prefer those. Targets
+beginning or ending on the cursor are preferred over everything else.
 
 Some other useful example settings (or build your own!):
 
 Never seek backwards:
-    let g:targets_seekRanges = 'lr rr lb ar ab lB Ar aB Ab AB rb rB bb bB BB' ~
+    let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr lb ar ab lB Ar aB Ab AB rb rB bb bB BB' ~
 
 Only seek if next/last targets touch current line:
-    let g:targets_seekRanges = 'lr rr ll lb ar ab lB Ar aB Ab AB rb rB al Al' ~
+    let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll lb ar ab lB Ar aB Ab AB rb rB al Al' ~
 
 Only consider targets fully visible on screen:
-    let g:targets_seekRanges = 'lr lb ar ab rr rb bb ll al aa' ~
+    let g:targets_seekRanges = 'cr cb cB lc ac Ac lr lb ar ab rr rb bb ll al aa' ~
 
 Only consider targets around cursor:
-    let g:targets_seekRanges = 'lr lb ar ab lB Ar aB Ab AB' ~
+    let g:targets_seekRanges = 'cr cb cB lc ac Ac lr lb ar ab lB Ar aB Ab AB' ~
 
 Only consider targets fully contained in current line:
-    let g:targets_seekRanges = 'lr rr ll' ~
+    let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll' ~
 
 ==============================================================================
 NOTES                                                          *targets-notes*


### PR DESCRIPTION
Close #133 

This PR adds new rules for seeking behavior that always prefers targets which a boundary under the cursor to make it possible to select targets like in the example described in #133.

/cc @qstrahl