### PR TITLE
Add option g:targets_jumpRanges to control jumplist behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ g:targets_argOpening
 g:targets_argClosing
 g:targets_argSeparator
 g:targets_seekRanges
+g:targets_addJumplist
 ```
 
 ### g:targets_aiAI
@@ -666,6 +667,21 @@ let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll'
 
 If you want to build your own, or are just curious what those cryptic letters
 mean, check out the full documentation in our [Cheat Sheet][cheatsheet].
+
+### g:targets_addJumplist
+
+Default:
+
+```vim
+let g:targets_addJumplist = 2
+```
+
+Controls whether or not to add the cursor position prior to selecting the text
+object to the jumplist. The settings are:
+
+- 2 - Always adds to the jumplist.
+- 1 - Only add to the jumplist if the cursor was not inside the text object.
+- 0 - Never add to the jump list.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ g:targets_argOpening
 g:targets_argClosing
 g:targets_argSeparator
 g:targets_seekRanges
-g:targets_addJumplist
+g:targets_jumpRanges
 ```
 
 ### g:targets_aiAI
@@ -668,20 +668,40 @@ let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll'
 If you want to build your own, or are just curious what those cryptic letters
 mean, check out the full documentation in our [Cheat Sheet][cheatsheet].
 
-### g:targets_addJumplist
+### g:targets_jumpRanges
 
 Default:
 
 ```vim
-let g:targets_addJumplist = 2
+let g:targets_jumpRanges = 'bb bB BB aa Aa AA' ~
 ```
 
-Controls whether or not to add the cursor position prior to selecting the text
-object to the jumplist. The settings are:
+Defines an unordered, space separated list of range types which can be used to
+customize the jumplist behavior (see documentation on seek ranges). It
+controls whether or not to add the cursor position prior to selecting the text
+object to the jumplist.
 
-- 2 - Always adds to the jumplist.
-- 1 - Only add to the jumplist if the cursor was not inside the text object.
-- 0 - Never add to the jump list.
+The default setting adds the previous cursor position to the jumplist if the
+target that was operated on doesn't intersect the cursor line. That means it
+adds a jumplist entry if the target ends above the cursor line or starts below
+the cursor line.
+
+Some other useful example settings (or build your own!):
+
+Never add cursor position to jumplist:
+```vim
+let g:targets_jumpRanges = '' ~
+```
+
+Always add cursor position to jumplist:
+```vim
+let g:targets_jumpRanges = 'cr cb cB lc ac Ac lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA' ~
+```
+
+Only add to jumplist if cursor was not inside the target:
+```vim
+let g:targets_jumpRanges = 'rr rb rB bb bB BB ll al Al aa Aa AA' ~
+```
 
 ## Notes
 

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -17,14 +17,20 @@ function! s:setup()
     let s:none        = 'a^' " matches nothing
 
     let s:rangeScores = {}
-    if !exists('g:targets_seekRanges')
-        let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA'
-    endif
     let ranges = split(g:targets_seekRanges)
     let rangesN = len(ranges)
     let i = 0
     while i < rangesN
         let s:rangeScores[ranges[i]] = rangesN - i
+        let i = i + 1
+    endwhile
+
+    let s:rangeJumps = {}
+    let ranges = split(g:targets_jumpRanges)
+    let rangesN = len(ranges)
+    let i = 0
+    while i < rangesN
+        let s:rangeJumps[ranges[i]] = 1
         let i = i + 1
     endwhile
 endfunction
@@ -435,11 +441,10 @@ function! s:selectTarget(target, rawTarget)
 endfunction
 
 function! s:addToJumplist(target)
-    if !g:targets_addJumplist
-        return 0
-    else
-        return g:targets_addJumplist - a:target.contains(s:oldpos)
-    endif
+    let min = line('w0')
+    let max = line('w$')
+    let range = a:target.range(s:oldpos, min, max)
+    return get(s:rangeJumps, range)
 endfunction
 
 " visually select a given match. used for match or old selection

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -1,8 +1,6 @@
 " targets.vim Provides additional text objects
 " Author:  Christian Wellenbrock <christian.wellenbrock@gmail.com>
 " License: MIT license
-" Updated: 2014-11-01
-" Version: 0.3.4
 
 " save cpoptions
 let s:save_cpoptions = &cpoptions

--- a/autoload/targets/target.vim
+++ b/autoload/targets/target.vim
@@ -23,7 +23,6 @@ function! targets#target#new(sl, sc, el, ec, error)
         \ 'state': function('targets#target#state'),
         \ 'range': function('targets#target#range'),
         \ 'select': function('targets#target#select'),
-        \ 'contains': function('targets#target#contains'),
         \ 'string': function('targets#target#string')
         \ }
 endfunction
@@ -173,17 +172,6 @@ function! targets#target#select() dict
     endif
 
     call cursor(self.e())
-endfunction
-
-function! targets#target#contains(cursor) dict
-    let cursorLine = a:cursor[1]
-    let cursorColumn = a:cursor[2]
-
-    if self.sl == self.el
-        return self.sc <= cursorColumn && cursorColumn <= self.ec && self.sl == cursorLine
-    else
-        return self.sl <= cursorLine && cursorLine <= self.el
-    endif
 endfunction
 
 function! targets#target#string() dict

--- a/autoload/targets/target.vim
+++ b/autoload/targets/target.vim
@@ -23,6 +23,7 @@ function! targets#target#new(sl, sc, el, ec, error)
         \ 'state': function('targets#target#state'),
         \ 'range': function('targets#target#range'),
         \ 'select': function('targets#target#select'),
+        \ 'contains': function('targets#target#contains'),
         \ 'string': function('targets#target#string')
         \ }
 endfunction
@@ -172,6 +173,17 @@ function! targets#target#select() dict
     endif
 
     call cursor(self.e())
+endfunction
+
+function! targets#target#contains(cursor) dict
+    let cursorLine = a:cursor[1]
+    let cursorColumn = a:cursor[2]
+
+    if self.sl == self.el
+        return self.sc <= cursorColumn && cursorColumn <= self.ec && self.sl == cursorLine
+    else
+        return self.sl <= cursorLine && cursorLine <= self.el
+    endif
 endfunction
 
 function! targets#target#string() dict

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -510,6 +510,7 @@ Available options: ~
     |g:targets_argClosing|
     |g:targets_argSeparator|
     |g:targets_seekRanges|
+    |g:targets_addJumplist|
 
 ------------------------------------------------------------------------------
                                                               *g:targets_aiAI*
@@ -697,6 +698,27 @@ Only consider targets around cursor:
 
 Only consider targets fully contained in current line:
     let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll' ~
+
+                                                      *g:targets_addJumplist*
+
+Default:
+    let g:targets_addJumplist = 2 ~
+
+Controls whether or not to add the cursor position prior to selecting the text
+object to the jumplist. The possible settings are:
+
+Always adds to the jumplist:
+    let g:targets_addJumplist = 2 ~
+
+Adds to the jumplist if the old cursor position was not inside the "around"
+version of the text object being used. For example, if the cursor is on an open
+parenthesis and the command `yi(` is issued then the old cursor position will
+not be added to the jump list because the opening parenthesis is contained in
+the `a(` text object:
+    let g:targets_addJumplist = 1 ~
+
+Never add to the jumplist:
+    let g:targets_addJumplist = 0 ~
 
 ==============================================================================
 NOTES                                                          *targets-notes*

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -2,8 +2,6 @@
 
 Author:  Christian Wellenbrock <christian.wellenbrock@gmail.com>
 License: MIT license
-Updated: 2014-11-01
-Version: 0.3.4
 
                            ____
                            \___\_.::::::::::.____

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -510,7 +510,7 @@ Available options: ~
     |g:targets_argClosing|
     |g:targets_argSeparator|
     |g:targets_seekRanges|
-    |g:targets_addJumplist|
+    |g:targets_jumpRanges|
 
 ------------------------------------------------------------------------------
                                                               *g:targets_aiAI*
@@ -699,26 +699,31 @@ Only consider targets around cursor:
 Only consider targets fully contained in current line:
     let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll' ~
 
-                                                      *g:targets_addJumplist*
+                                                        *g:targets_jumpRanges*
 
 Default:
-    let g:targets_addJumplist = 2 ~
+    let g:targets_jumpRanges = 'bb bB BB aa Aa AA' ~
 
-Controls whether or not to add the cursor position prior to selecting the text
-object to the jumplist. The possible settings are:
+Defines an unordered, space separated list of range types which can be used to
+customize the jumplist behavior (see documentation on seek ranges). It
+controls whether or not to add the cursor position prior to selecting the text
+object to the jumplist.
 
-Always adds to the jumplist:
-    let g:targets_addJumplist = 2 ~
+The default setting adds the previous cursor position to the jumplist if the
+target that was operated on doesn't intersect the cursor line. That means it
+adds a jumplist entry if the target ends above the cursor line or starts below
+the cursor line.
 
-Adds to the jumplist if the old cursor position was not inside the "around"
-version of the text object being used. For example, if the cursor is on an open
-parenthesis and the command `yi(` is issued then the old cursor position will
-not be added to the jump list because the opening parenthesis is contained in
-the `a(` text object:
-    let g:targets_addJumplist = 1 ~
+Some other useful example settings (or build your own!):
 
-Never add to the jumplist:
-    let g:targets_addJumplist = 0 ~
+Never add cursor position to jumplist:
+    let g:targets_jumpRanges = '' ~
+
+Always add cursor position to jumplist:
+    let g:targets_jumpRanges = 'cr cb cB lc ac Ac lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA' ~
+
+Only add to jumplist if cursor was not inside the target:
+    let g:targets_jumpRanges = 'rr rb rB bb bB BB ll al Al aa Aa AA' ~
 
 ==============================================================================
 NOTES                                                          *targets-notes*

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -1,13 +1,11 @@
 " targets.vim Provides additional text objects
 " Author:  Christian Wellenbrock <christian.wellenbrock@gmail.com>
 " License: MIT license
-" Updated: 2014-11-01
-" Version: 0.3.4
 
 if exists("g:loaded_targets") || &cp || v:version < 700
     finish
 endif
-let g:loaded_targets = '0.3.4' " version number
+let g:loaded_targets = '0.4.2' " version number
 let s:save_cpoptions = &cpoptions
 set cpo&vim
 

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -253,8 +253,11 @@ function! s:loadSettings()
     if !exists('g:targets_argSeparator')
         let g:targets_argSeparator = ','
     endif
-    if !exists('g:targets_addJumplist')
-        let g:targets_addJumplist = 2
+    if !exists('g:targets_seekRanges')
+        let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA'
+    endif
+    if !exists('g:targets_jumpRanges')
+        let g:targets_jumpRanges = 'bb bB BB aa Aa AA'
     endif
 
     let [s:a, s:i, s:A, s:I] = split(g:targets_aiAI, '\zs')

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -253,6 +253,9 @@ function! s:loadSettings()
     if !exists('g:targets_argSeparator')
         let g:targets_argSeparator = ','
     endif
+    if !exists('g:targets_addJumplist')
+        let g:targets_addJumplist = 2
+    endif
 
     let [s:a, s:i, s:A, s:I] = split(g:targets_aiAI, '\zs')
     let [s:n, s:l, s:N, s:L] = split(g:targets_nlNL, '\zs')

--- a/test/test.vim
+++ b/test/test.vim
@@ -1,8 +1,6 @@
 " targets.vim Provides additional text objects
 " Author:  Christian Wellenbrock <christian.wellenbrock@gmail.com>
 " License: MIT license
-" Updated: 2014-11-01
-" Version: 0.3.4
 
 set runtimepath+=../
 set softtabstop=16 expandtab


### PR DESCRIPTION
This PR continues #132 by replacing the initial setting `g:targets_addJumplist` with a more flexible `g:targets_jumpRanges` (similar to `g:targets_seekRanges`).

This also implicitly changes the default jumplist behavior:

- Before: Always add to jumplist, sometimes multiple times (thanks @lag13 for fixing it :+1:)
- After: Only add to jumplist when operating on distant targets, and only once

@lag13: Thanks again for fixing the jumplist behavior in the first place! Sorry for not getting back to this earlier. Do you want to have a look at the commits I added? I would appreciate any feedback on the updated setting.

@Konfekt: I tried your example from #138 with this new behavior and it works now as you expected (as it already did on #132). Do you want to try this branch and confirm?