### PR TITLE
Vundle will deprecate "Bundle" in favor of Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Use your favorite plugin manager.
 - [Vundle][vundle]
 
     ```vim
-    Bundle 'wellle/targets.vim'
+    Plugin 'wellle/targets.vim'
     ```
 
 - [Pathogen][pathogen]


### PR DESCRIPTION
Vundle will deprecate "Bundle" in favor of "Plugin" as described in [vundle readme](https://github.com/VundleVim/Vundle.vim/blob/master/doc/vundle.txt#L399)