### PR TITLE
145 Make it possible to use comma as argument trigger

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -335,6 +335,13 @@ function! s:getDelimiters(trigger)
 endfunction
 
 function! s:getRawDelimiters(trigger)
+    " check more specific ones first for #145
+    if a:trigger ==# g:targets_tagTrigger
+        return ['t', 't', 0, 0] " TODO: set tag patterns here and remove special tag functions?
+    elseif a:trigger ==# g:targets_argTrigger
+        return ['a', 0, 0, 0]
+    endif
+
     for pair in split(g:targets_pairs)
         for trigger in split(pair, '\zs')
             if trigger ==# a:trigger
@@ -359,13 +366,7 @@ function! s:getRawDelimiters(trigger)
         endfor
     endfor
 
-    if a:trigger ==# g:targets_tagTrigger
-        return ['t', 't', 0, 0] " TODO: set tag patterns here and remove special tag functions?
-    elseif a:trigger ==# g:targets_argTrigger
-        return ['a', 0, 0, 0]
-    else
-        return [0, 0, 0, 1]
-    endif
+    return [0, 0, 0, 1]
 endfunction
 
 function! s:modifyDelimiter(kind, delimiter)

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -264,12 +264,13 @@ endfunction
 
 call s:loadSettings()
 
-" create the text objects (current total count: 528)
-call s:createPairTextObjects('o')
+" create the text objects (current total count: 544)
+" more specific ones first for #145
 call s:createTagTextObjects('o')
+call s:createArgTextObjects('o')
+call s:createPairTextObjects('o')
 call s:createQuoteTextObjects('o')
 call s:createSeparatorTextObjects('o')
-call s:createArgTextObjects('o')
 call s:addVisualMappings()
 
 let &cpoptions = s:save_cpoptions

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -5,7 +5,7 @@
 if exists("g:loaded_targets") || &cp || v:version < 700
     finish
 endif
-let g:loaded_targets = '0.4.3' " version number
+let g:loaded_targets = '0.4.4' " version number
 let s:save_cpoptions = &cpoptions
 set cpo&vim
 


### PR DESCRIPTION
Close #145

>Create more specific mappings before more general mappings because the later fails because of uniqueness.

>Check more specific triggers before more general ones.

>That way in case of mapping conflicts we prefer the more specific one.
This also improves similar issues with triggers for tag objects.