### PR TITLE
Improve quote text objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ Supported trigger characters:
 - `<` `>` (work on angle brackets)
 - `t` (work on tags)
 
+Pair text objects work over multiple lines and support seeking. See below for
+details about seeking.
+
 The following examples will use parentheses, but they all work for each listed
 trigger character accordingly.
-
-Pair text objects work over multiple lines.
 
 #### In Pair
 
@@ -67,8 +68,7 @@ Pair text objects work over multiple lines.
 - This overrides Vim's default text object to allow seeking for the next pair
   in the current line to the right or left when the cursor is not inside a
   pair. This behavior is similar to Vim's seeking behavior of `di'` when not
-  inside of quotes, but it works both ways. See below for details about
-  seeking.
+  inside of quotes, but it works both ways.
 - Accepts a count to select multiple blocks.
 
 ```
@@ -100,7 +100,6 @@ a ( b ( cccccccc ) d ) e
 - Select contents of pair characters.
 - Like inside of parentheses, but exclude whitespace at both ends. Useful for
   changing contents while preserving spacing.
-- Supports seeking.
 - Accepts a count.
 
 ```
@@ -117,7 +116,6 @@ a ( b ( cccccccc ) d ) e
 - Select around pair characters.
 - Like a pair, but include whitespace at one side of the pair. Prefers to
   select trailing whitespace, falls back to select leading whitespace.
-- Supports seeking.
 - Accepts a count.
 
 ```
@@ -157,15 +155,25 @@ Supported trigger characters:
 - `"`     (work on double quotes)
 - `` ` `` (work on back ticks)
 
+These quote text objects try to be smarter than the default ones. They count
+the quotation marks from the beginning of the line to decide which of these are
+the beginning of a quote and which ones are the end.
+
+If you type `ci,` on the `,` in the example below, it will automatically skip
+and change `world` instead of changing the false quote `,` between the two
+proper quotes `hello` and `world`.
+
+```
+buffer │ join("hello", "world")
+proper │      └─────┘  └─────┘
+false  │            └──┘
+```
+
+Quote text objects work over multiple lines and support seeking. See below for
+details about seeking.
+
 The following examples will use single quotes, but they all work for each
 mentioned separator character accordingly.
-
-
-Quote text objects work over multiple lines.
-
-When the cursor is positioned on a quotation mark, the quote text objects count
-the numbers of quotation marks from the beginning of the line to choose the
-properly quoted text to the left or right of the cursor.
 
 #### In Quote
 
@@ -173,11 +181,10 @@ properly quoted text to the left or right of the cursor.
 
 - Select inside quote.
 - This overrides Vim's default text object to allow seeking in both directions.
-  See below for details about seeking.
 
 ```
   ............
-a ' bbbbbbbb ' c ' d
+a ' bbbbbbbb ' c ' d ' e
    └── i' ──┘
 ```
 
@@ -191,7 +198,7 @@ a ' bbbbbbbb ' c ' d
 
 ```
   ............
-a ' bbbbbbbb ' c ' d
+a ' bbbbbbbb ' c ' d ' e
   └─── a' ───┘
 ```
 
@@ -202,11 +209,10 @@ a ' bbbbbbbb ' c ' d
 - Select contents of a quote.
 - Like inside quote, but exclude whitespace at both ends. Useful for changing
   contents while preserving spacing.
-- Supports seeking.
 
 ```
   ............
-a ' bbbbbbbb ' c ' d
+a ' bbbbbbbb ' c ' d ' e
     └─ I' ─┘
 ```
 
@@ -217,11 +223,10 @@ a ' bbbbbbbb ' c ' d
 - Select around a quote.
 - Like a quote, but include whitespace in one direction. Prefers to select
   trailing whitespace, falls back to select leading whitespace.
-- Supports seeking.
 
 ```
   ............
-a ' bbbbbbbb ' c ' d
+a ' bbbbbbbb ' c ' d ' e
   └─── A' ────┘
 ```
 
@@ -262,17 +267,16 @@ Supported separators:
 , . ; : + - = ~ _ * # / | \ & $
 ```
 
+Separator text objects work over multiple lines and support seeking.
+
 The following examples will use commas, but they all work for each listed
 separator character accordingly.
-
-Separator text objects work over multiple lines.
 
 #### In Separator
 
 `i, i. i; i: i+ i- i= i~ i_ i* i# i/ i| i\ i& i$`
 
 - Select inside separators. Similar to in quote.
-- Supports seeking.
 
 ```
       ...........
@@ -288,7 +292,6 @@ a , b , cccccccc , d , e
 - Includes the leading separator, but excludes the trailing one. This leaves
   a proper list separated by the separator character after deletion. See the
   examples above.
-- Supports seeking.
 
 ```
       ...........
@@ -303,7 +306,6 @@ a , b , cccccccc , d , e
 - Select contents between separators.
 - Like inside separators, but exclude whitespace at both ends. Useful for
   changing contents while preserving spacing.
-- Supports seeking.
 
 ```
       ...........
@@ -318,7 +320,6 @@ a , b , cccccccc , d , e
 - Select around a pair of separators.
 - Includes both separators and a surrounding whitespace, similar to `a'` and
   `A(`.
-- Supports seeking.
 
 ```
       ...........
@@ -356,14 +357,13 @@ These text objects are similar to separator text objects, but are specialized
 for arguments surrounded by braces and commas. They also take matching braces
 into account to capture only valid arguments.
 
-Argument text objects work over multiple lines.
+Argument text objects work over multiple lines and support seeking.
 
 #### In Argument
 
 `ia`
 
 - Select inside arguments. Similar to in quote.
-- Supports seeking.
 - Accepts a count.
 
 ```
@@ -379,7 +379,6 @@ a , b ( cccccccc , d ) e
 - Select an argument in a list of arguments.
 - Includes a separator if preset, but excludes surrounding braces. This leaves
   a proper argument list after deletion.
-- Supports seeking.
 - Accepts a count.
 
 ```
@@ -395,7 +394,6 @@ a , b ( cccccccc , d ) e
 - Select content of an argument.
 - Like inside separators, but exclude whitespace at both ends. Useful for
   changing contents while preserving spacing.
-- Supports seeking.
 - Accepts a count.
 
 ```
@@ -411,7 +409,6 @@ a , b ( cccccccc , d ) e
 - Select around an argument.
 - Includes both delimiters and a surrounding whitespace, similar to `a'` and
   `A(`.
-- Supports seeking.
 - Accepts a count.
 
 ```

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -721,11 +721,8 @@ endfunction
 " select a pair around the cursor
 " args (count=1, trigger=s:opening)
 function! s:selectp(...)
-    if a:0 == 2
-        let [cnt, trigger] = [a:1, a:2]
-    else
-        let [cnt, trigger] = [1, s:opening]
-    endif
+    let cnt     = a:0 >= 1 ? a:1 : 1
+    let trigger = a:0 >= 2 ? a:2 : s:opening
 
     " try to select pair
     silent! execute 'keepjumps normal! v' . cnt . 'a' . trigger
@@ -748,11 +745,10 @@ endfunction
 "          │ └── 2 ──┘
 " args (count, opening=s:opening, closing=s:closing, trigger=s:closing)
 function! s:seekselectp(...)
-    if a:0 == 4
-        let [cnt, opening, closing, trigger] = [a:1, a:2, a:3, a:4]
-    else
-        let [cnt, opening, closing, trigger] = [a:1, s:opening, s:closing, s:closing]
-    endif
+    let cnt     =            a:1 " required
+    let opening = a:0 >= 2 ? a:2 : s:opening
+    let closing = a:0 >= 3 ? a:3 : s:closing
+    let trigger = a:0 >= 4 ? a:4 : s:closing
 
     let min = line('w0')
     let max = line('w$')
@@ -848,12 +844,13 @@ endfunction
 " separator=g:targets_argSeparator, cnt=2)
 " return (line, column, err)
 function! s:findArgBoundary(...)
-    let [flags1, flags2, skip, finish] = [a:1, a:2, a:3, a:4]
-    if a:0 == 7
-        let [all, separator, cnt] = [a:5, a:6, a:7]
-    else
-        let [all, separator, cnt] = [s:argAll, g:targets_argSeparator, 1]
-    endif
+    let flags1    =            a:1 " required
+    let flags2    =            a:2
+    let skip      =            a:3
+    let finish    =            a:4
+    let all       = a:0 >= 5 ? a:5 : s:argAll
+    let separator = a:0 >= 6 ? a:6 : g:targets_argSeparator
+    let cnt       = a:0 >= 7 ? a:7 : 1
 
     let tl = 0
     for _ in range(cnt)
@@ -925,7 +922,8 @@ endfunction
 " try to select a next argument, supports count and optional stopline
 " args (count=1, stopline=0)
 function! s:nextselecta(...)
-    let [cnt, stopline] = [a:0 > 0 ? a:1 : 1, a:0 > 1 ? a:2 : 0]
+    let cnt      = a:0 >= 1 ? a:1 : 1
+    let stopline = a:0 >= 2 ? a:2 : 0
 
     if s:search(cnt, s:argOpeningS, 'W', stopline) > 0 " no start found
         return targets#target#withError('nextselecta 1')
@@ -958,7 +956,8 @@ endfunction
 " try to select a last argument, supports count and optional stopline
 " args (count=1, stopline=0)
 function! s:lastselecta(...)
-    let [cnt, stopline] = [a:0 > 0 ? a:1 : 1, a:0 > 1 ? a:2 : 0]
+    let cnt      = a:0 >= 1 ? a:1 : 1
+    let stopline = a:0 >= 2 ? a:2 : 0
 
     " special case to handle vala when invoked on a separator
     let separator = g:targets_argSeparator
@@ -1246,12 +1245,10 @@ endfunction
 " search for pattern using flags and a count, optional stopline
 " args (cnt, pattern, flags, stopline=0)
 function! s:search(...)
-    let [cnt, pattern, flags] = [a:1, a:2, a:3]
-    if a:0 == 4
-        let stopline = a:4
-    elseif a:0 == 3
-        let stopline = 0
-    endif
+    let cnt      =            a:1 " required
+    let pattern  =            a:2
+    let flags    =            a:3
+    let stopline = a:0 >= 4 ? a:4 : 0
 
     for _ in range(cnt)
         let line = searchpos(pattern, flags, stopline)[0]
@@ -1264,11 +1261,9 @@ endfunction
 " return 1 and send a message to s:debug
 " args (message, parameters=nil)
 function! s:fail(...)
-    if a:0 == 2
-        call s:debug('fail ' . a:1 . ' ' . string(a:2))
-    else
-        call s:debug('fail ' . a:1)
-    endif
+    let message = 'fail ' . a:1
+    let message .= a:0 >= 2 ? ' ' . string(a:2) : ''
+    call s:debug(message)
     return 1
 endfunction
 

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -85,7 +85,7 @@ function! targets#x(trigger, count)
     let [delimiter, which, modifier] = split(a:trigger, '\zs')
     let [target, rawTarget] = s:findTarget(delimiter, which, modifier, a:count)
     if target.state().isInvalid()
-        call s:abortMatch('#x')
+        call s:abortMatch('#x: ' . target.error)
         return s:cleanUp()
     endif
     if s:handleTarget(target, rawTarget) == 0
@@ -179,7 +179,7 @@ function! s:findRawTarget(kind, which, count)
         elseif a:which ==# 'l'
             return s:lastselect(a:count * rateL - skipL)
         else
-            return targets#target#withError('findRawTarget q')
+            return targets#target#withError('findRawTarget q: ' . a:which)
         endif
 
     elseif a:kind ==# 's'
@@ -227,7 +227,7 @@ endfunction
 
 function! s:modifyTarget(target, kind, modifier)
     if a:target.state().isInvalid()
-        return targets#target#withError('modifyTarget invalid')
+        return targets#target#withError('modifyTarget invalid: ' . a:target.error)
     endif
     let target = a:target.copy()
 

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -578,31 +578,34 @@ function! s:quote()
     endif
 endfunction
 
-" returns [direction, error]
+" returns [direction, skip, error]
 function! s:quoteDir()
     let oldpos = getpos('.')
-    let [direction, error] = s:quoteDirInternal(oldpos[2])
+    let [direction, skipL, skipR, error, rep] = s:quoteDirInternal(oldpos[2])
+
     call setpos('.', oldpos)
-    return [direction, error]
+    return [direction, skipL, skipR, error]
 endfunction
 
 " doesn't restore old position
-"    .    () rep
-"         --1 good multiline around if final
-"   (     b-0 good multiline below single if final
-"    (    o-0 good multiline below single on if final
-"     (   a-0 good multiline above if final
-" ( )     bb1 bad after last if final
-"  ( )    bo1 good end on cursor select to left
-"   ( )   ba1 good around cursor select around
-"    ( )  oa1 good start on cursor select to right
-"     ( ) aa1 bad before first
-" ) (     bb0 good multiline below multi if final
-"  ) (    ob0 good multiline below multi on if final
-"   ) (   ab0 bad between pairs
+" cursor  rep dir skips description
+"    .    ()
+"         xx1  >   0 0  good multiline around if final
+"   (     bx0  >   0 0  good multiline below single if final
+"    (    ox0  >   0 0  good multiline below single on if final
+"     (   ax0  <   0 0  good multiline above if final
+" ( )     bb1           bad after last if final
+"  ( )    bo1  <   1 0  good end on cursor select to left
+"   ( )   ba1  >   1 1  good around cursor select around
+"    ( )  oa1  >   0 1  good start on cursor select to right
+"     ( ) aa1           bad before first
+" ) (     bb0  >   1 0  good multiline below multi if final
+"  ) (    ob0  >   0 0  good multiline below multi on if final
+"   ) (   ab0           bad between pairs
+" returns [dir, skipL, skipR, error, rep]
 function! s:quoteDirInternal(oldcolumn)
     let column = 0
-    let positions = ['-', '-']
+    let positions = ['x', 'x']
     let index = 1 " write into opening first (will be toggled first)
 
     silent! normal! 0
@@ -620,19 +623,19 @@ function! s:quoteDirInternal(oldcolumn)
         let rep = positions[0] . positions[1] . index
         if rep == 'bo1'
             call s:debug('good end on cursor select to left')
-            return ['<', '']
+            return ['<', 1, 0, '', rep]
         elseif rep == 'ba1'
             call s:debug('good around cursor select around')
-            return ['>', '']
+            return ['>', 1, 1, '', rep]
         elseif rep == 'oa1'
             call s:debug('good start on cursor select to right')
-            return ['>', '']
+            return ['>', 0, 1, '', rep]
         elseif rep == 'aa1'
             call s:debug('bad before first')
-            return ['', '']
+            return ['', 0, 0, '', rep]
         elseif rep == 'ab0'
             call s:debug('bad between pairs')
-            return ['', '']
+            return ['', 0, 0, '', rep]
         else
             " call s:debug('not final ' . rep)
         endif
@@ -641,29 +644,29 @@ function! s:quoteDirInternal(oldcolumn)
     endwhile
 
     let rep = positions[0] . positions[1] . index
-    if rep == '--1'
+    if rep == 'xx1'
         call s:debug('good multiline around')
-        return ['>', '']
-    elseif rep == 'b-0'
+        return ['>', 0, 0, '', rep]
+    elseif rep == 'bx0'
         call s:debug('good multiline below single')
-        return ['>', '']
-    elseif rep == 'o-0'
+        return ['>', 0, 0, '', rep]
+    elseif rep == 'ox0'
         call s:debug('good multiline below single on')
-        return ['>', '']
-    elseif rep == 'a-0'
+        return ['>', 0, 0, '', rep]
+    elseif rep == 'ax0'
         call s:debug('good multiline above')
-        return ['<', '']
+        return ['<', 0, 0, '', rep]
     elseif rep == 'bb1'
         call s:debug('bad after last')
-        return ['', '']
+        return ['', 0, 0, '', rep]
     elseif rep == 'bb0'
         call s:debug('good multiline below multi')
-        return ['>', '']
+        return ['>', 1, 0, '', rep]
     elseif rep == 'ob0'
         call s:debug('good multiline below multi on')
-        return ['>', '']
+        return ['>', 0, 0, '', rep]
     else
-        return ['', 'quoteDir not found ' . rep]
+        return ['', 0, 0, 'quoteDir not found ' . rep]
     endif
 endfunction
 

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -90,7 +90,6 @@ function! targets#x(trigger, count)
     endif
     if s:handleTarget(target, rawTarget) == 0
         let s:lastTrigger = a:trigger
-        let s:lastRawTarget = rawTarget
         let s:lastTarget = target
     endif
     call s:cleanUp()
@@ -168,8 +167,6 @@ function! s:findRawTarget(kind, which, count)
             return targets#target#withError('findRawTarget p')
         endif
 
-    " TODO: there is something wrong when skipping to the right from the first
-    " quote on a line
     elseif a:kind ==# 'q'
         let [dir, skipL, skipR, error] = s:quoteDir()
         if error !=# ''
@@ -639,40 +636,17 @@ function! s:quoteDirInternal(oldcolumn)
     endif
 endfunction
 
-" find `count` next delimiter (multi line)
-" in   │     ...
-" line │  '  '  '  '
-" out  │        1  2
-" args (count=1)
-function! s:nextselect(...)
-    let cnt = a:0 == 1 ? a:1 : 1
-
-    call s:prepareNext()
-
-    if s:search(cnt, s:opening, 'W') > 0
+function! s:nextselect(count)
+    if s:search(a:count, s:opening, 'W') > 0
         return targets#target#withError('nextselect')
     endif
 
     return s:select('>')
 endfunction
 
-" find `count` last delimiter, move in front of it (multi line)
-" in   │     ...
-" line │  '  '  '  '
-" out  │ 2  1
-" args (count=1)
-function! s:lastselect(...)
-    let cnt = a:0 == 1 ? a:1 : 1
-
-    " if started on closing, but not when skipping
-    if !s:prepareLast() && s:getchar() ==# s:closing
-        let [cnt, message] = [cnt - 1, 'lastselect 1']
-    else
-        let [cnt, message] = [cnt, 'lastselect 2']
-    endif
-
-    if s:search(cnt, s:closing, 'bW') > 0
-        return targets#target#withError(message)
+function! s:lastselect(count)
+    if s:search(a:count, s:closing, 'bW') > 0
+        return targets#target#withError('lastselect')
     endif
 
     return s:select('<')
@@ -683,7 +657,6 @@ endfunction
 " line │ ( ) ( ) ( ( ) ) ( )
 " out  │     1   2 3     4
 function! s:nextp(count)
-    call s:prepareNext()
     return s:search(a:count, s:opening, 'W')
 endfunction
 
@@ -692,7 +665,6 @@ endfunction
 " line │ ( ) ( ) ( ( ) ) ( )
 " out  │   4   3     2 1
 function! s:lastp(count)
-    call s:prepareLast()
     return s:search(a:count, s:closing, 'bW')
 endfunction
 
@@ -701,7 +673,6 @@ endfunction
 " line │ <a> </a> <b> </b> <c> <d> </d> </c> <e> </e>
 " out  │          1        2   3             4
 function! s:nextt(count)
-    call s:prepareNext()
     return s:search(a:count, '<\a', 'W')
 endfunction
 
@@ -710,7 +681,6 @@ endfunction
 " line │ <a> </a> <b> </b> <c> <d> </d> </c> <e> </e>
 " out  │     4        3            2    1
 function! s:lastt(count)
-    call s:prepareLast()
     return s:search(a:count, '</\a\zs', 'bW')
 endfunction
 
@@ -993,7 +963,6 @@ endfunction
 " args (count=1, stopline=0)
 function! s:nextselecta(...)
     let [cnt, stopline] = [a:0 > 0 ? a:1 : 1, a:0 > 1 ? a:2 : 0]
-    call s:prepareNext()
 
     if s:search(cnt, s:argOpeningS, 'W', stopline) > 0 " no start found
         return targets#target#withError('nextselecta 1')
@@ -1027,8 +996,6 @@ endfunction
 " args (count=1, stopline=0)
 function! s:lastselecta(...)
     let [cnt, stopline] = [a:0 > 0 ? a:1 : 1, a:0 > 1 ? a:2 : 0]
-
-    call s:prepareLast()
 
     " special case to handle vala when invoked on a separator
     let separator = g:targets_argSeparator
@@ -1305,36 +1272,7 @@ function! s:grow()
         return 0
     endif
 
-    " move cursor back to last raw end of selection to avoid growing being
-    " confused by last modifiers
-    call s:prepareNext()
-
     return 1
-endfunction
-
-" if in visual mode, move cursor to start of last raw selection
-" also used in s:grow to move to last raw end
-function! s:prepareNext()
-    if s:newSelection
-        return
-    endif
-
-    if s:mapmode ==# 'x' && exists('s:lastRawTarget') && s:lastRawTarget.state().isNonempty()
-        call s:lastRawTarget.cursorS()
-    endif
-endfunction
-
-" if in visual mode, move cursor to end of last raw selection
-" returns whether or not the cursor was moved
-function! s:prepareLast()
-    if s:newSelection
-        return
-    endif
-
-    if s:mapmode ==# 'x' && exists('s:lastRawTarget') && s:lastRawTarget.state().isNonempty()
-        call s:lastRawTarget.cursorE()
-        return 1
-    endif
 endfunction
 
 " returns the character under the cursor

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -548,7 +548,7 @@ endfunction
 function! s:quoteDir()
     let oldpos = getpos('.')
     let [direction, rateL, skipL, rateR, skipR, error, rep] = s:quoteDirInternal(oldpos[2])
-    echom 'rep' rep 'rateL' rateL 'skipL' skipL 'rateR' rateR 'skipR' skipR
+    " echom 'rep' rep 'rateL' rateL 'skipL' skipL 'rateR' rateR 'skipR' skipR
 
     call setpos('.', oldpos)
     return [direction, rateL, skipL, rateR, skipR, error]

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -171,7 +171,7 @@ function! s:findRawTarget(kind, which, count)
     elseif a:kind ==# 'q'
         if a:which ==# 'c'
             call s:quote()
-            return s:seekselect()
+            return s:seekselect('>', 0, 0)
         elseif a:which ==# 'n'
             call s:quote()
             return s:nextselect(a:count)
@@ -190,7 +190,7 @@ function! s:findRawTarget(kind, which, count)
 
     elseif a:kind ==# 's'
         if a:which ==# 'c'
-            return s:seekselect()
+            return s:seekselect('>', 0, 0)
         elseif a:which ==# 'n'
             return s:nextselect(a:count)
         elseif a:which ==# 'l'
@@ -793,20 +793,20 @@ function! s:findSeparators(flags1, flags2, opening, closing)
 endfunction
 
 " select pair of delimiters around cursor (multi line, supports seeking)
-function! s:seekselect()
+function! s:seekselect(dir, skipL, skipR)
     let min = line('w0')
     let max = line('w$')
     let oldpos = getpos('.')
 
-    let around = s:select('>')
+    let around = s:select(a:dir)
 
     call setpos('.', oldpos)
 
-    let last = s:lastselect()
+    let last = s:lastselect(1 + a:skipL)
 
     call setpos('.', oldpos)
 
-    let next = s:nextselect()
+    let next = s:nextselect(1 + a:skipR)
 
     return s:bestSeekTarget([around, next, last], oldpos, min, max, 'seekselect')
 endfunction

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -661,42 +661,17 @@ endfunction
 " line    │ ' ' b ' '
 " matcher │   └───┘
 function! s:select(direction)
-    let oldpos = getpos('.')
-
     if a:direction ==# ''
         return targets#target#withError('select without direction')
     elseif a:direction ==# '>'
-        let [sl, sc, el, ec, err] = s:findSeparators('bcW', 'W', s:opening, s:closing)
-        let message = 'select 1'
+        let [sl, sc] = searchpos(s:opening, 'bcW') " search left for opening
+        let [el, ec] = searchpos(s:closing, 'W')   " then right for closing
+        return targets#target#fromValues(sl, sc, el, ec)
     else
-        let [el, ec, sl, sc, err] = s:findSeparators('cW', 'bW', s:closing, s:opening)
-        let message = 'select 2'
+        let [el, ec] = searchpos(s:closing, 'cW') " search right for closing
+        let [sl, sc] = searchpos(s:opening, 'bW') " then left for opening
+        return targets#target#fromValues(sl, sc, el, ec)
     endif
-
-    if err > 0
-        call setpos('.', oldpos)
-        return targets#target#withError(message)
-    endif
-
-    let target = targets#target#fromValues(sl, sc, el, ec)
-    return target
-endfunction
-
-" TODO: inject direction and return proper target
-" find separators around cursor by searching for opening with flags1 and for
-" closing with flags2
-function! s:findSeparators(flags1, flags2, opening, closing)
-    let [sl, sc] = searchpos(a:opening, a:flags1)
-    if sc == 0 " no match to the left
-        return [0, 0, 0, 0, s:fail('findSeparators 1')]
-    endif
-
-    let [el, ec] = searchpos(a:closing, a:flags2)
-    if ec == 0 " no match to the right
-        return [0, 0, 0, 0, s:fail('findSeparators 2')]
-    endif
-
-    return [sl, sc, el, ec, 0]
 endfunction
 
 " select pair of delimiters around cursor (multi line, supports seeking)

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -168,22 +168,19 @@ function! s:findRawTarget(kind, which, count)
             return targets#target#withError('findRawTarget p')
         endif
 
+    " TODO: there is something wrong when skipping to the right from the first
+    " quote on a line
     elseif a:kind ==# 'q'
+        let [dir, skipL, skipR, error] = s:quoteDir()
+        if error !=# ''
+            return targets#target#withError('findRawTarget quoteDir')
+        endif
         if a:which ==# 'c'
-            call s:quote()
-            return s:seekselect('>', 0, 0)
+            return s:seekselect(dir, skipL, skipR)
         elseif a:which ==# 'n'
-            call s:quote()
-            return s:nextselect(a:count)
+            return s:nextselect(a:count * 2 + skipR - 1)
         elseif a:which ==# 'l'
-            call s:quote()
-            return s:lastselect(a:count)
-        elseif a:which ==# 'N'
-            call s:quote()
-            return s:nextselect(a:count * 2)
-        elseif a:which ==# 'L'
-            call s:quote()
-            return s:lastselect(a:count * 2)
+            return s:lastselect(a:count * 2 + skipL - 1)
         else
             return targets#target#withError('findRawTarget q')
         endif

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -664,7 +664,9 @@ endfunction
 function! s:select(direction)
     let oldpos = getpos('.')
 
-    if a:direction ==# '>'
+    if a:direction ==# ''
+        return targets#target#withError('select without direction')
+    elseif a:direction ==# '>'
         let [sl, sc, el, ec, err] = s:findSeparators('bcW', 'W', s:opening, s:closing)
         let message = 'select 1'
     else

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -547,34 +547,6 @@ function! targets#undo(lastseq)
     endif
 endfunction
 
-" position modifiers
-" ¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯
-
-" move the cursor inside of a proper quote when positioned on a delimiter
-" (move one character to the left when over an odd number of quotation mark)
-" the number of delimiters to the left of the cursor is counted to decide
-" if this is an opening or closing quote delimiter
-" in   │ . │  . │ . │  .
-" line │ ' │  ' │ ' │  '
-" out  │ . │ .  │ . │ .
-function! s:quote()
-    if s:getchar() !=# s:opening
-        return
-    endif
-
-    let oldpos = getpos('.')
-    let closing = 1
-    let line = 1
-    while line != 0
-        let line = searchpos(s:opening, 'b', line('.'))[0]
-        let closing = !closing
-    endwhile
-    call setpos('.', oldpos)
-    if closing " cursor is on closing delimiter
-        silent! normal! h
-    endif
-endfunction
-
 " returns [direction, skip, error]
 function! s:quoteDir()
     let oldpos = getpos('.')

--- a/autoload/targets/target.vim
+++ b/autoload/targets/target.vim
@@ -28,6 +28,9 @@ function! targets#target#new(sl, sc, el, ec, error)
 endfunction
 
 function! targets#target#fromValues(sl, sc, el, ec)
+    if a:sl == 0 || a:sc == 0 || a:el == 0 || a:ec == 0
+        return targets#target#withError("zero found")
+    endif
     return targets#target#new(a:sl, a:sc, a:el, a:ec, '')
 endfunction
 

--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -57,14 +57,12 @@ Available mappings
 Chart for a list of quotes
 
 ```
-                      ..........
-a ' bbbbbbb ' ccccccc ' dddddd ' eeeeeee ' fffffff ' g
-  ││└ IL' ┘│││└ Il' ┘│││└ I' ┘│││└ In' ┘│││└ IN' ┘│││
-  │└─ iL' ─┘│├─ il' ─┘│├─ i' ─┘│├─ in' ─┘│├─ iN' ─┘││
-  ├── aL' ──┤│        ├┼─ a' ──┤│        ├┼─ aN' ──┘│
-  └── AL' ──┼┘        ├┼─ A' ──┼┘        ├┼─ AN' ───┘
-            ├── al' ──┘│       ├── an' ──┘│
-            └── Al' ───┘       └── An' ───┘
+             .............
+a ' bbbbbbb ' c ' dddddd ' e ' fffffff ' g
+  ││└ Il' ┘│││  ││└ I' ┘│││  ││└ In' ┘│││
+  │└─ il' ─┘││  │└─ i' ─┘││  │└─ in' ─┘││
+  ├── al' ──┘│  ├── a' ──┘│  ├── an' ──┘│
+  └── Al' ───┘  └── A' ───┘  └── An' ───┘
 ```
 
 ## Separator mappings

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -64,11 +64,11 @@ Supported trigger characters:
     < >       (work on angle brackets)
         t     (work on tags)
 
+Pair text objects work over multiple lines and support |targets-pair-seek|.
+
 We borrowed the aliases `r` and `a` from the |surround| plugin by Tim Pope.
 The following examples will use parentheses, but they all work for each listed
 trigger character accordingly.
-
-Pair text objects work over multiple lines.
 
 i( i) ib i[ i] it                    *it_t* *i(_t* *i)_t* *ib_t* *i[_t* *i]_t*
 i{ i} iB i< i>                              *i{_t* *i}_t* *iB_t* *i<_t* *i>_t*
@@ -76,7 +76,7 @@ i{ i} iB i< i>                              *i{_t* *i}_t* *iB_t* *i<_t* *i>_t*
     to allow seeking for the next pair in the current line to the right or
     left when the cursor is not inside a pair. This behavior is similar to
     Vim's seeking behavior of `di'` when not inside of quotes, but it works
-    both ways. See |targets-pair-seek|. Accepts a [count] to select multiple
+    both ways. Accepts a [count] to select multiple
     blocks.
 
               ............
@@ -87,7 +87,7 @@ i{ i} iB i< i>                              *i{_t* *i}_t* *iB_t* *i<_t* *i>_t*
 a( a) ab a[ a] at                    *at_t* *a(_t* *a)_t* *ab_t* *a[_t* *a]_t*
 a{ a} aB a< a>                              *a{_t* *a}_t* *aB_t* *a<_t* *a>_t*
     Select a pair. Overrides Vim's default text object to allow seeking.
-    Supports |targets-pair-seek|. Accepts [count].
+    Accepts [count].
 
               ............
         a ( b ( cccccccc ) d ) e ~
@@ -98,7 +98,7 @@ I( I) Ib I[ I] It                                *It* *I(* *I)* *Ib* *I[* *I]*
 I{ I} IB I< I>                                        *I{* *I}* *IB* *I<* *I>*
     Select contents of pair characters. Like inside of parentheses, but
     exclude whitespace at both ends. Useful for changing contents while
-    preserving spacing. Supports |targets-pair-seek|. Accepts [count].
+    preserving spacing. Accepts [count].
 
               ............
         a ( b ( cccccccc ) d ) e ~
@@ -109,7 +109,7 @@ A( A) Ab A[ A] At                                *At* *A(* *A)* *Ab* *A[* *A]*
 A{ A} AB A< A>                                        *A{* *A}* *AB* *A<* *A>*
     Select around pair characters. Like a pair, but include whitespace at one
     side of the pair. Prefers to select trailing whitespace, falls back to
-    select leading whitespace. Supports |targets-pair-seek|. Accepts [count].
+    select leading whitespace. Accepts [count].
 
               ............
         a ( b ( cccccccc ) d ) e ~
@@ -183,21 +183,30 @@ Supported trigger characters:
     "         (work on double quotes)
     `         (work on back ticks)
 
+These quote text objects try to be smarter than the default ones. They count
+the quotation marks from the beginning of the line to decide which of these
+are the beginning of a quote and which ones are the end.
+
+If you type `ci,` on the `,` in the example below, it will automatically skip
+and change `world` instead of changing the false quote `,` between the two
+proper quotes `hello` and `world`.
+
+    join("hello", "world") ~
+         └─────┘  └─────┘     proper quotes
+               └──┘           false quotes
+
+
+Quote text objects work over multiple lines and support |targets-quote-seek|.
+
 The following examples will use single quotes, but they all work for each
 listed quoting character accordingly.
 
-Quote text objects work over multiple lines.
-
-When the cursor is positioned on a quotation mark, the quote text objects
-count the numbers of quotation marks from the beginning of the line to choose
-the properly quoted text to the left or right of the cursor.
-
 i' i" i`                                              *i`_t* *i'_t* *iquote_t*
     Select inside quote. This overrides Vim's default text object to allow
-    seeking in both directions. See |targets-quote-seek|.
+    seeking in both directions.
 
           ............
-        a ' bbbbbbbb ' c ' d ~
+        a ' bbbbbbbb ' c ' d ' e~
            └── i' ──┘
 
 a' a" a`                                              *a`_t* *a'_t* *aquote_t*
@@ -206,25 +215,24 @@ a' a" a`                                              *a`_t* *a'_t* *aquote_t*
     surrounding whitespace.
 
           ............
-        a ' bbbbbbbb ' c ' d ~
+        a ' bbbbbbbb ' c ' d ' e~
           └─── a' ───┘
 
 I' I" I`                                                    *I`* *I'* *Iquote*
     Select contents of a quote. Like inside quote, but exclude whitespace at
-    both ends. Useful for changing contents while preserving spacing. Supports
-    |targets-quote-seek|.
+    both ends. Useful for changing contents while preserving spacing.
 
           ............
-        a ' bbbbbbbb ' c ' d ~
+        a ' bbbbbbbb ' c ' d ' e~
             └─ I' ─┘
 
 A' A" A`                                                    *A`* *A'* *Aquote*
     Select around a quote. Like a quote, but include whitespace in one
     direction. Prefers to select trailing whitespace, falls back to select
-    leading whitespace.  Supports |targets-quote-seek|.
+    leading whitespace.
 
           ............
-        a ' bbbbbbbb ' c ' d ~
+        a ' bbbbbbbb ' c ' d ' e~
           └─── A' ────┘
 
 ------------------------------------------------------------------------------
@@ -276,14 +284,15 @@ Supported separators:
 
     , . ; : + - = ~ _ * # / | \ & $ ~
 
+Separator text objects work over multiple lines and support
+|targets-separator-seek|.
+
 The following examples will use commas, but they all work for each listed
 separator character accordingly.
 
-Separator text objects work over multiple lines.
-
 i, i. i; i: i+ i- i= i~             *i,* *i.* *i;* *i:* *i+* *i-* *i=* *i~*
 i_ i/ i| i\ i& i$ i# i*             *i_* *i/* *i|* *i\* *i&* *i$* *i#* *istar*
-    Select inside separators. Supports |targets-separator-seek|.
+    Select inside separators.
 
               ...........
         a , b , cccccccc , d , e ~
@@ -294,7 +303,7 @@ a_ a/ a| a\ a& a$ a# a*             *a_* *a/* *a|* *a\* *ar* *a$* *a#* *astar*
     Select an item in a list separated by the separator character. This
     includes the leading separator, but excludes the trailing one. This leaves
     a proper list separated by the separator character after deletion. See
-    |targets-examples|. Supports |targets-separator-seek|.
+    |targets-examples|.
 
               ...........
         a , b , cccccccc , d , e ~
@@ -304,7 +313,7 @@ I, I. I; I: I+ I- I= I~             *I,* *I.* *I;* *I:* *I+* *I-* *I=* *I~*
 I_ I/ I| I\ I& I$ I# I*             *I_* *I/* *I|* *I\* *I&* *I$* *I#* *Istar*
     Select contents between separators. Like inside separators, but exclude
     whitespace at both ends. Useful for changing contents while preserving
-    spacing. Supports |targets-separator-seek|.
+    spacing.
 
               ...........
         a , b , cccccccc , d , e ~
@@ -313,8 +322,7 @@ I_ I/ I| I\ I& I$ I# I*             *I_* *I/* *I|* *I\* *I&* *I$* *I#* *Istar*
 A, A. A; A: A+ A- A= A~             *A,* *A.* *A;* *A:* *A+* *A-* *A=* *A~*
 A_ A/ A| A\ A& A$ A# A*             *A_* *A/* *A|* *A\* *A&* *A$* *A#* *Astar*
     Select around a pair of separators. This includes both separators and a
-    surrounding whitespace, similar to `a'` and `A(`. Supports
-    |targets-separator-seek|.
+    surrounding whitespace, similar to `a'` and `A(`.
 
               ...........
         a , b , cccccccc , d , e ~
@@ -411,10 +419,11 @@ These text objects are similar to separator text objects, but are specialized
 for arguments surrounded by braces and commas. They also take matching braces
 into account to capture only valid arguments.
 
-Argument text objects work over multiple lines.
+Argument text objects work over multiple lines and support
+|targets-argument-seek|.
 
 ia                                                                        *ia*
-    Select inside argument. Supports |targets-argument-seek|. Accepts a
+    Select inside argument. Accepts a
     [count] to select bigger nested arguments.
 
               ...........
@@ -424,7 +433,7 @@ ia                                                                        *ia*
 aa                                                                        *aa*
     Select an argument in a list of arguments. This includes a separator if
     present, but excludes surrounding braces. This leaves a proper of
-    arguments after deletion. Supports |targets-argument-seek|. Accepts a
+    arguments after deletion. Accepts a
     [count] to select bigger nested arguments.
 
               ...........
@@ -434,7 +443,7 @@ aa                                                                        *aa*
 Ia                                                                        *Ia*
     Select contents of an argument. Like inside argument, but exclude
     whitespace at both ends. Useful for changing contents while preserving
-    spacing. Supports |targets-argument-seek|. Accepts a [count] to select
+    spacing. Accepts a [count] to select
     bigger nested arguments.
 
               ...........
@@ -443,8 +452,8 @@ Ia                                                                        *Ia*
 
 Aa                                                                        *Aa*
     Select around an argument. This includes both delimiters and a surrounding
-    whitespace, similar to `a'` and `A(`. Supports |targets-argument-seek|.
-    Accepts a [count] to select bigger nested arguments.
+    whitespace, similar to `a'` and `A(`. Accepts a [count] to select bigger
+    nested arguments.
 
               ...........
         a , b ( cccccccc , d ) e ~

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -258,12 +258,12 @@ IN' IN" IN` IL' IL" IL`            *IN`* *IN'* *INquote* *IL`* *IL'* *ILquote*
                                                          *targets-quote-chart*
 The following chart summarizes all quote mappings:
 
-                          ..........
-    a ' bbbbbbb ' ccccccc ' dddddd ' eeeeeee ' fffffff ' g ~
-      ││└ IL' ┘│││└ Il' ┘│││└ I' ┘│││└ In' ┘│││└ IN' ┘│ │
-      │└─ iL' ─┘│├─ il' ─┘│├─ i' ─┘│├─ in' ─┘│├─ iN' ─┘ │
-      └── aL' ──┼┘        └┼─ a' ──┼┘        └┼─ aN' ───┘
-                └── al' ───┘       └── an' ───┘
+                 .............
+    a ' bbbbbbb ' c ' dddddd ' e ' fffffff ' g ~
+      ││└ Il' ┘│││  ││└ I' ┘│││  ││└ In' ┘│││
+      │└─ il' ─┘││  │└─ i' ─┘││  │└─ in' ─┘││
+      ├── al' ──┘│  ├── a' ──┘│  ├── an' ──┘│
+      └── Al' ───┘  └── A' ───┘  └── An' ───┘
 
 ------------------------------------------------------------------------------
 QUOTE SEEK                                                *targets-quote-seek*

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -5,7 +5,7 @@
 if exists("g:loaded_targets") || &cp || v:version < 700
     finish
 endif
-let g:loaded_targets = '0.4.4' " version number
+let g:loaded_targets = '0.4.5' " version number
 let s:save_cpoptions = &cpoptions
 set cpo&vim
 

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -120,13 +120,12 @@ function! s:createQuoteTextObjects(mapType)
 endfunction
 
 " separator text objects expand to the right
-" cursor  │                   ........
-" line    │ a , bbbbb , ccccc , ddddd , eeeee , fffff , g
-" command │   ││└IL,┘│││└Il,┘│││└ I,┘│││└In,┘│││└IN,┘│ │
-"         │   │└─iL,─┤│├─il,─┤│├─ i,─┤│├─in,─┤│├─iN,─┤ │
-"         │   ├──aL,─┘├┼─al,─┘├┼─ a,─┘├┼─an,─┘├┼─aN,─┘ │
-"         │   └──AL,──┼┘      └┼─ A,──┼┘      └┼─AN,───┘
-"         │           └─ Al, ──┘      └─ An, ──┘
+" cursor  │              .............
+" line    │ a ' bbbbbbb ' c ' dddddd ' e ' fffffff ' g ~
+" command │   ││└ Il' ┘│││  ││└ I' ┘│││  ││└ In' ┘│││
+"         │   │└─ il' ─┘││  │└─ i' ─┘││  │└─ in' ─┘││
+"         │   ├── al' ──┘│  ├── a' ──┘│  ├── an' ──┘│
+"         │   └── Al' ───┘  └── A' ───┘  └── An' ───┘
 " cursor  │ .........        │       ..........
 " line    │ a , bbbb , c , d │ a , b , cccc , d
 " command │   ││└I,┘│ │      │       ││└I,┘│ │

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -116,19 +116,11 @@ function! s:createQuoteTextObjects(mapType)
         call s:addMapping2(a:mapType, triggerMap . "la', v:count1)<CR>", s:a, s:l)
         call s:addMapping2(a:mapType, triggerMap . "lI', v:count1)<CR>", s:I, s:l)
         call s:addMapping2(a:mapType, triggerMap . "lA', v:count1)<CR>", s:A, s:l)
-        call s:addMapping2(a:mapType, triggerMap . "Ni', v:count1)<CR>", s:i, s:N)
-        call s:addMapping2(a:mapType, triggerMap . "Na', v:count1)<CR>", s:a, s:N)
-        call s:addMapping2(a:mapType, triggerMap . "NI', v:count1)<CR>", s:I, s:N)
-        call s:addMapping2(a:mapType, triggerMap . "NA', v:count1)<CR>", s:A, s:N)
-        call s:addMapping2(a:mapType, triggerMap . "Li', v:count1)<CR>", s:i, s:L)
-        call s:addMapping2(a:mapType, triggerMap . "La', v:count1)<CR>", s:a, s:L)
-        call s:addMapping2(a:mapType, triggerMap . "LI', v:count1)<CR>", s:I, s:L)
-        call s:addMapping2(a:mapType, triggerMap . "LA', v:count1)<CR>", s:A, s:L)
     endfor
 endfunction
 
 " separator text objects expand to the right
-" cursor  |                   ........
+" cursor  │                   ........
 " line    │ a , bbbbb , ccccc , ddddd , eeeee , fffff , g
 " command │   ││└IL,┘│││└Il,┘│││└ I,┘│││└In,┘│││└IN,┘│ │
 "         │   │└─iL,─┤│├─il,─┤│├─ i,─┤│├─in,─┤│├─iN,─┤ │
@@ -174,7 +166,7 @@ function! s:createSeparatorTextObjects(mapType)
 endfunction
 
 " argument text objects expand to the right
-" cursor  |                          .........
+" cursor  │                          .........
 " line    │ a ( bbbbbb , ccccccc , d ( eeeeee , fffffff ) , gggggg ) h
 " command │   ││├2Ila┘│││└─Ila─┘││││ ││├─Ia─┘│││└─Ina─┘│││││└2Ina┘│ │
 "         │   │└┼2ila─┘│├──ila──┤│││ │└┼─ia──┘│├──ina──┤│││├─2ina─┤ │

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,3 +7,4 @@ all:
 	@git diff --no-index test4.ok test4.out && echo "test4 OK" || echo "test4 failed"
 	@git diff --no-index test5.ok test5.out && echo "test5 OK" || echo "test5 failed"
 	@git diff --no-index test6.ok test6.out && echo "test6 OK" || echo "test6 failed"
+	@git diff --no-index test7.ok test7.out && echo "test7 OK" || echo "test7 failed"

--- a/test/test.vim
+++ b/test/test.vim
@@ -200,11 +200,54 @@ function s:testEmpty()
     write! test6.out
 endfunction
 
+function s:testQuotes()
+    edit! test7.in
+    normal gg0
+
+    normal ci"A
+    normal +
+    normal cin"A
+    normal +
+    normal c2in"B
+
+    normal +fx
+    normal ci"D
+    normal +fx
+    normal cin"D
+    normal +fx
+    normal c2in"E
+    normal +fx
+    normal cil"C
+    normal +fx
+    normal c2il"B
+
+    normal +fx
+    normal ci"X
+    normal +fx
+    normal cin"D
+    normal +fx
+    normal c2in"E
+    normal +fx
+    normal cil"C
+    normal +fx
+    normal c2il"B
+
+    normal +fx
+    normal ci"C
+    normal +fx
+    normal cil"C
+    normal +fx
+    normal c2il"B
+
+    write! test7.out
+endfunction
+
 call s:testBasic()
 call s:testMultiline()
 call s:testSeeking()
 call s:testVisual()
 call s:testModifiers()
 call s:testEmpty()
+call s:testQuotes()
 
 quit!

--- a/test/test.vim
+++ b/test/test.vim
@@ -57,7 +57,7 @@ function! s:testBasic()
 
         for op in [ 'c', 'd', 'y', 'v' ]
             for cnt in [ '', '1', '2' ]
-                for LlnN in [ 'L', 'l', '', 'n', 'N' ]
+                for LlnN in [ 'l', '', 'n' ]
                     for iaIA in [ 'I', 'i', 'a', 'A' ]
                         execute "normal \"lpfx"
                         call s:execute(op, cnt . iaIA . LlnN . del)

--- a/test/test1.ok
+++ b/test/test1.ok
@@ -1589,728 +1589,440 @@ v2ant           a <a> b </a> <b> c </b> <c> <d> x </d> </c> <e> e </e> _________
 v2Ant           a <a> b </a> <b> c </b> <c> <d> x </d> </c> <e> e </e> ___________g
 
 a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l
-cIL'            a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
-ciL'            a ' b ' c '_' e ' x ' g ' h ' i ' k ' l
-caL'            a ' b ' c _ e ' x ' g ' h ' i ' k ' l
-cAL'            a ' b ' c _e ' x ' g ' h ' i ' k ' l
-cIl'            a ' b ' c ' d ' _ ' x ' g ' h ' i ' k ' l
-cil'            a ' b ' c ' d '_' x ' g ' h ' i ' k ' l
-cal'            a ' b ' c ' d _ x ' g ' h ' i ' k ' l
-cAl'            a ' b ' c ' d _x ' g ' h ' i ' k ' l
+cIl'            a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
+cil'            a ' b ' c '_' e ' x ' g ' h ' i ' k ' l
+cal'            a ' b ' c _ e ' x ' g ' h ' i ' k ' l
+cAl'            a ' b ' c _e ' x ' g ' h ' i ' k ' l
 cI'             a ' b ' c ' d ' e ' _ ' g ' h ' i ' k ' l
 ci'             a ' b ' c ' d ' e '_' g ' h ' i ' k ' l
 ca'             a ' b ' c ' d ' e _ g ' h ' i ' k ' l
 cA'             a ' b ' c ' d ' e _g ' h ' i ' k ' l
-cIn'            a ' b ' c ' d ' e ' x ' _ ' h ' i ' k ' l
-cin'            a ' b ' c ' d ' e ' x '_' h ' i ' k ' l
-can'            a ' b ' c ' d ' e ' x _ h ' i ' k ' l
-cAn'            a ' b ' c ' d ' e ' x _h ' i ' k ' l
-cIN'            a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
-ciN'            a ' b ' c ' d ' e ' x ' g '_' i ' k ' l
-caN'            a ' b ' c ' d ' e ' x ' g _ i ' k ' l
-cAN'            a ' b ' c ' d ' e ' x ' g _i ' k ' l
-c1IL'           a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
-c1iL'           a ' b ' c '_' e ' x ' g ' h ' i ' k ' l
-c1aL'           a ' b ' c _ e ' x ' g ' h ' i ' k ' l
-c1AL'           a ' b ' c _e ' x ' g ' h ' i ' k ' l
-c1Il'           a ' b ' c ' d ' _ ' x ' g ' h ' i ' k ' l
-c1il'           a ' b ' c ' d '_' x ' g ' h ' i ' k ' l
-c1al'           a ' b ' c ' d _ x ' g ' h ' i ' k ' l
-c1Al'           a ' b ' c ' d _x ' g ' h ' i ' k ' l
+cIn'            a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
+cin'            a ' b ' c ' d ' e ' x ' g '_' i ' k ' l
+can'            a ' b ' c ' d ' e ' x ' g _ i ' k ' l
+cAn'            a ' b ' c ' d ' e ' x ' g _i ' k ' l
+c1Il'           a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
+c1il'           a ' b ' c '_' e ' x ' g ' h ' i ' k ' l
+c1al'           a ' b ' c _ e ' x ' g ' h ' i ' k ' l
+c1Al'           a ' b ' c _e ' x ' g ' h ' i ' k ' l
 c1I'            a ' b ' c ' d ' e ' _ ' g ' h ' i ' k ' l
 c1i'            a ' b ' c ' d ' e '_' g ' h ' i ' k ' l
 c1a'            a ' b ' c ' d ' e _ g ' h ' i ' k ' l
 c1A'            a ' b ' c ' d ' e _g ' h ' i ' k ' l
-c1In'           a ' b ' c ' d ' e ' x ' _ ' h ' i ' k ' l
-c1in'           a ' b ' c ' d ' e ' x '_' h ' i ' k ' l
-c1an'           a ' b ' c ' d ' e ' x _ h ' i ' k ' l
-c1An'           a ' b ' c ' d ' e ' x _h ' i ' k ' l
-c1IN'           a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
-c1iN'           a ' b ' c ' d ' e ' x ' g '_' i ' k ' l
-c1aN'           a ' b ' c ' d ' e ' x ' g _ i ' k ' l
-c1AN'           a ' b ' c ' d ' e ' x ' g _i ' k ' l
-c2IL'           a ' _ ' c ' d ' e ' x ' g ' h ' i ' k ' l
-c2iL'           a '_' c ' d ' e ' x ' g ' h ' i ' k ' l
-c2aL'           a _ c ' d ' e ' x ' g ' h ' i ' k ' l
-c2AL'           a _c ' d ' e ' x ' g ' h ' i ' k ' l
-c2Il'           a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
-c2il'           a ' b ' c '_' e ' x ' g ' h ' i ' k ' l
-c2al'           a ' b ' c _ e ' x ' g ' h ' i ' k ' l
-c2Al'           a ' b ' c _e ' x ' g ' h ' i ' k ' l
+c1In'           a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
+c1in'           a ' b ' c ' d ' e ' x ' g '_' i ' k ' l
+c1an'           a ' b ' c ' d ' e ' x ' g _ i ' k ' l
+c1An'           a ' b ' c ' d ' e ' x ' g _i ' k ' l
+c2Il'           a ' _ ' c ' d ' e ' x ' g ' h ' i ' k ' l
+c2il'           a '_' c ' d ' e ' x ' g ' h ' i ' k ' l
+c2al'           a _ c ' d ' e ' x ' g ' h ' i ' k ' l
+c2Al'           a _c ' d ' e ' x ' g ' h ' i ' k ' l
 c2I'            a ' b ' c ' d ' e ' _ ' g ' h ' i ' k ' l
 c2i'            a ' b ' c ' d ' e '_' g ' h ' i ' k ' l
 c2a'            a ' b ' c ' d ' e _ g ' h ' i ' k ' l
 c2A'            a ' b ' c ' d ' e _g ' h ' i ' k ' l
-c2In'           a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
-c2in'           a ' b ' c ' d ' e ' x ' g '_' i ' k ' l
-c2an'           a ' b ' c ' d ' e ' x ' g _ i ' k ' l
-c2An'           a ' b ' c ' d ' e ' x ' g _i ' k ' l
-c2IN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' _ ' l
-c2iN'           a ' b ' c ' d ' e ' x ' g ' h ' i '_' l
-c2aN'           a ' b ' c ' d ' e ' x ' g ' h ' i _ l
-c2AN'           a ' b ' c ' d ' e ' x ' g ' h ' i _l
-dIL'            a ' b ' c '  ' e ' x ' g ' h ' i ' k ' l
-diL'            a ' b ' c '' e ' x ' g ' h ' i ' k ' l
-daL'            a ' b ' c  e ' x ' g ' h ' i ' k ' l
-dAL'            a ' b ' c e ' x ' g ' h ' i ' k ' l
-dIl'            a ' b ' c ' d '  ' x ' g ' h ' i ' k ' l
-dil'            a ' b ' c ' d '' x ' g ' h ' i ' k ' l
-dal'            a ' b ' c ' d  x ' g ' h ' i ' k ' l
-dAl'            a ' b ' c ' d x ' g ' h ' i ' k ' l
+c2In'           a ' b ' c ' d ' e ' x ' g ' h ' i ' _ ' l
+c2in'           a ' b ' c ' d ' e ' x ' g ' h ' i '_' l
+c2an'           a ' b ' c ' d ' e ' x ' g ' h ' i _ l
+c2An'           a ' b ' c ' d ' e ' x ' g ' h ' i _l
+dIl'            a ' b ' c '  ' e ' x ' g ' h ' i ' k ' l
+dil'            a ' b ' c '' e ' x ' g ' h ' i ' k ' l
+dal'            a ' b ' c  e ' x ' g ' h ' i ' k ' l
+dAl'            a ' b ' c e ' x ' g ' h ' i ' k ' l
 dI'             a ' b ' c ' d ' e '  ' g ' h ' i ' k ' l
 di'             a ' b ' c ' d ' e '' g ' h ' i ' k ' l
 da'             a ' b ' c ' d ' e  g ' h ' i ' k ' l
 dA'             a ' b ' c ' d ' e g ' h ' i ' k ' l
-dIn'            a ' b ' c ' d ' e ' x '  ' h ' i ' k ' l
-din'            a ' b ' c ' d ' e ' x '' h ' i ' k ' l
-dan'            a ' b ' c ' d ' e ' x  h ' i ' k ' l
-dAn'            a ' b ' c ' d ' e ' x h ' i ' k ' l
-dIN'            a ' b ' c ' d ' e ' x ' g '  ' i ' k ' l
-diN'            a ' b ' c ' d ' e ' x ' g '' i ' k ' l
-daN'            a ' b ' c ' d ' e ' x ' g  i ' k ' l
-dAN'            a ' b ' c ' d ' e ' x ' g i ' k ' l
-d1IL'           a ' b ' c '  ' e ' x ' g ' h ' i ' k ' l
-d1iL'           a ' b ' c '' e ' x ' g ' h ' i ' k ' l
-d1aL'           a ' b ' c  e ' x ' g ' h ' i ' k ' l
-d1AL'           a ' b ' c e ' x ' g ' h ' i ' k ' l
-d1Il'           a ' b ' c ' d '  ' x ' g ' h ' i ' k ' l
-d1il'           a ' b ' c ' d '' x ' g ' h ' i ' k ' l
-d1al'           a ' b ' c ' d  x ' g ' h ' i ' k ' l
-d1Al'           a ' b ' c ' d x ' g ' h ' i ' k ' l
+dIn'            a ' b ' c ' d ' e ' x ' g '  ' i ' k ' l
+din'            a ' b ' c ' d ' e ' x ' g '' i ' k ' l
+dan'            a ' b ' c ' d ' e ' x ' g  i ' k ' l
+dAn'            a ' b ' c ' d ' e ' x ' g i ' k ' l
+d1Il'           a ' b ' c '  ' e ' x ' g ' h ' i ' k ' l
+d1il'           a ' b ' c '' e ' x ' g ' h ' i ' k ' l
+d1al'           a ' b ' c  e ' x ' g ' h ' i ' k ' l
+d1Al'           a ' b ' c e ' x ' g ' h ' i ' k ' l
 d1I'            a ' b ' c ' d ' e '  ' g ' h ' i ' k ' l
 d1i'            a ' b ' c ' d ' e '' g ' h ' i ' k ' l
 d1a'            a ' b ' c ' d ' e  g ' h ' i ' k ' l
 d1A'            a ' b ' c ' d ' e g ' h ' i ' k ' l
-d1In'           a ' b ' c ' d ' e ' x '  ' h ' i ' k ' l
-d1in'           a ' b ' c ' d ' e ' x '' h ' i ' k ' l
-d1an'           a ' b ' c ' d ' e ' x  h ' i ' k ' l
-d1An'           a ' b ' c ' d ' e ' x h ' i ' k ' l
-d1IN'           a ' b ' c ' d ' e ' x ' g '  ' i ' k ' l
-d1iN'           a ' b ' c ' d ' e ' x ' g '' i ' k ' l
-d1aN'           a ' b ' c ' d ' e ' x ' g  i ' k ' l
-d1AN'           a ' b ' c ' d ' e ' x ' g i ' k ' l
-d2IL'           a '  ' c ' d ' e ' x ' g ' h ' i ' k ' l
-d2iL'           a '' c ' d ' e ' x ' g ' h ' i ' k ' l
-d2aL'           a  c ' d ' e ' x ' g ' h ' i ' k ' l
-d2AL'           a c ' d ' e ' x ' g ' h ' i ' k ' l
-d2Il'           a ' b ' c '  ' e ' x ' g ' h ' i ' k ' l
-d2il'           a ' b ' c '' e ' x ' g ' h ' i ' k ' l
-d2al'           a ' b ' c  e ' x ' g ' h ' i ' k ' l
-d2Al'           a ' b ' c e ' x ' g ' h ' i ' k ' l
+d1In'           a ' b ' c ' d ' e ' x ' g '  ' i ' k ' l
+d1in'           a ' b ' c ' d ' e ' x ' g '' i ' k ' l
+d1an'           a ' b ' c ' d ' e ' x ' g  i ' k ' l
+d1An'           a ' b ' c ' d ' e ' x ' g i ' k ' l
+d2Il'           a '  ' c ' d ' e ' x ' g ' h ' i ' k ' l
+d2il'           a '' c ' d ' e ' x ' g ' h ' i ' k ' l
+d2al'           a  c ' d ' e ' x ' g ' h ' i ' k ' l
+d2Al'           a c ' d ' e ' x ' g ' h ' i ' k ' l
 d2I'            a ' b ' c ' d ' e '  ' g ' h ' i ' k ' l
 d2i'            a ' b ' c ' d ' e '' g ' h ' i ' k ' l
 d2a'            a ' b ' c ' d ' e  g ' h ' i ' k ' l
 d2A'            a ' b ' c ' d ' e g ' h ' i ' k ' l
-d2In'           a ' b ' c ' d ' e ' x ' g '  ' i ' k ' l
-d2in'           a ' b ' c ' d ' e ' x ' g '' i ' k ' l
-d2an'           a ' b ' c ' d ' e ' x ' g  i ' k ' l
-d2An'           a ' b ' c ' d ' e ' x ' g i ' k ' l
-d2IN'           a ' b ' c ' d ' e ' x ' g ' h ' i '  ' l
-d2iN'           a ' b ' c ' d ' e ' x ' g ' h ' i '' l
-d2aN'           a ' b ' c ' d ' e ' x ' g ' h ' i  l
-d2AN'           a ' b ' c ' d ' e ' x ' g ' h ' i l
-yIL'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'd'
-yiL'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' d '
-yaL'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ''
-yAL'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ' '
-yIl'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'e'
-yil'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' e '
-yal'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' e ''
-yAl'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' e ' '
+d2In'           a ' b ' c ' d ' e ' x ' g ' h ' i '  ' l
+d2in'           a ' b ' c ' d ' e ' x ' g ' h ' i '' l
+d2an'           a ' b ' c ' d ' e ' x ' g ' h ' i  l
+d2An'           a ' b ' c ' d ' e ' x ' g ' h ' i l
+yIl'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'd'
+yil'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' d '
+yal'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ''
+yAl'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ' '
 yI'             a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'x'
 yi'             a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' x '
 ya'             a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' x ''
 yA'             a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' x ' '
-yIn'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'g'
-yin'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' g '
-yan'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' g ''
-yAn'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' g ' '
-yIN'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'h'
-yiN'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' h '
-yaN'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ''
-yAN'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ' '
-y1IL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'd'
-y1iL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' d '
-y1aL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ''
-y1AL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ' '
-y1Il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'e'
-y1il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' e '
-y1al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' e ''
-y1Al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' e ' '
+yIn'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'h'
+yin'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' h '
+yan'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ''
+yAn'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ' '
+y1Il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'd'
+y1il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' d '
+y1al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ''
+y1Al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ' '
 y1I'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'x'
 y1i'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' x '
 y1a'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' x ''
 y1A'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' x ' '
-y1In'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'g'
-y1in'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' g '
-y1an'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' g ''
-y1An'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' g ' '
-y1IN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'h'
-y1iN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' h '
-y1aN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ''
-y1AN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ' '
-y2IL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'b'
-y2iL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' b '
-y2aL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' b ''
-y2AL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' b ' '
-y2Il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'd'
-y2il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' d '
-y2al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ''
-y2Al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ' '
+y1In'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'h'
+y1in'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' h '
+y1an'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ''
+y1An'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ' '
+y2Il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'b'
+y2il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' b '
+y2al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' b ''
+y2Al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' b ' '
 y2I'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'x'
 y2i'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' x '
 y2a'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' x ''
 y2A'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' x ' '
-y2In'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'h'
-y2in'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' h '
-y2an'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ''
-y2An'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ' '
-y2IN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'k'
-y2iN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' k '
-y2aN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' k ''
-y2AN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' k ' '
-vIL'            a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
-viL'            a ' b ' c '___' e ' x ' g ' h ' i ' k ' l
-vaL'            a ' b ' c _____ e ' x ' g ' h ' i ' k ' l
-vAL'            a ' b ' c ______e ' x ' g ' h ' i ' k ' l
-vIl'            a ' b ' c ' d ' _ ' x ' g ' h ' i ' k ' l
-vil'            a ' b ' c ' d '___' x ' g ' h ' i ' k ' l
-val'            a ' b ' c ' d _____ x ' g ' h ' i ' k ' l
-vAl'            a ' b ' c ' d ______x ' g ' h ' i ' k ' l
+y2In'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'k'
+y2in'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' k '
+y2an'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' k ''
+y2An'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' k ' '
+vIl'            a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
+vil'            a ' b ' c '___' e ' x ' g ' h ' i ' k ' l
+val'            a ' b ' c _____ e ' x ' g ' h ' i ' k ' l
+vAl'            a ' b ' c ______e ' x ' g ' h ' i ' k ' l
 vI'             a ' b ' c ' d ' e ' _ ' g ' h ' i ' k ' l
 vi'             a ' b ' c ' d ' e '___' g ' h ' i ' k ' l
 va'             a ' b ' c ' d ' e _____ g ' h ' i ' k ' l
 vA'             a ' b ' c ' d ' e ______g ' h ' i ' k ' l
-vIn'            a ' b ' c ' d ' e ' x ' _ ' h ' i ' k ' l
-vin'            a ' b ' c ' d ' e ' x '___' h ' i ' k ' l
-van'            a ' b ' c ' d ' e ' x _____ h ' i ' k ' l
-vAn'            a ' b ' c ' d ' e ' x ______h ' i ' k ' l
-vIN'            a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
-viN'            a ' b ' c ' d ' e ' x ' g '___' i ' k ' l
-vaN'            a ' b ' c ' d ' e ' x ' g _____ i ' k ' l
-vAN'            a ' b ' c ' d ' e ' x ' g ______i ' k ' l
-v1IL'           a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
-v1iL'           a ' b ' c '___' e ' x ' g ' h ' i ' k ' l
-v1aL'           a ' b ' c _____ e ' x ' g ' h ' i ' k ' l
-v1AL'           a ' b ' c ______e ' x ' g ' h ' i ' k ' l
-v1Il'           a ' b ' c ' d ' _ ' x ' g ' h ' i ' k ' l
-v1il'           a ' b ' c ' d '___' x ' g ' h ' i ' k ' l
-v1al'           a ' b ' c ' d _____ x ' g ' h ' i ' k ' l
-v1Al'           a ' b ' c ' d ______x ' g ' h ' i ' k ' l
+vIn'            a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
+vin'            a ' b ' c ' d ' e ' x ' g '___' i ' k ' l
+van'            a ' b ' c ' d ' e ' x ' g _____ i ' k ' l
+vAn'            a ' b ' c ' d ' e ' x ' g ______i ' k ' l
+v1Il'           a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
+v1il'           a ' b ' c '___' e ' x ' g ' h ' i ' k ' l
+v1al'           a ' b ' c _____ e ' x ' g ' h ' i ' k ' l
+v1Al'           a ' b ' c ______e ' x ' g ' h ' i ' k ' l
 v1I'            a ' b ' c ' d ' e ' _ ' g ' h ' i ' k ' l
 v1i'            a ' b ' c ' d ' e '___' g ' h ' i ' k ' l
 v1a'            a ' b ' c ' d ' e _____ g ' h ' i ' k ' l
 v1A'            a ' b ' c ' d ' e ______g ' h ' i ' k ' l
-v1In'           a ' b ' c ' d ' e ' x ' _ ' h ' i ' k ' l
-v1in'           a ' b ' c ' d ' e ' x '___' h ' i ' k ' l
-v1an'           a ' b ' c ' d ' e ' x _____ h ' i ' k ' l
-v1An'           a ' b ' c ' d ' e ' x ______h ' i ' k ' l
-v1IN'           a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
-v1iN'           a ' b ' c ' d ' e ' x ' g '___' i ' k ' l
-v1aN'           a ' b ' c ' d ' e ' x ' g _____ i ' k ' l
-v1AN'           a ' b ' c ' d ' e ' x ' g ______i ' k ' l
-v2IL'           a ' _ ' c ' d ' e ' x ' g ' h ' i ' k ' l
-v2iL'           a '___' c ' d ' e ' x ' g ' h ' i ' k ' l
-v2aL'           a _____ c ' d ' e ' x ' g ' h ' i ' k ' l
-v2AL'           a ______c ' d ' e ' x ' g ' h ' i ' k ' l
-v2Il'           a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
-v2il'           a ' b ' c '___' e ' x ' g ' h ' i ' k ' l
-v2al'           a ' b ' c _____ e ' x ' g ' h ' i ' k ' l
-v2Al'           a ' b ' c ______e ' x ' g ' h ' i ' k ' l
+v1In'           a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
+v1in'           a ' b ' c ' d ' e ' x ' g '___' i ' k ' l
+v1an'           a ' b ' c ' d ' e ' x ' g _____ i ' k ' l
+v1An'           a ' b ' c ' d ' e ' x ' g ______i ' k ' l
+v2Il'           a ' _ ' c ' d ' e ' x ' g ' h ' i ' k ' l
+v2il'           a '___' c ' d ' e ' x ' g ' h ' i ' k ' l
+v2al'           a _____ c ' d ' e ' x ' g ' h ' i ' k ' l
+v2Al'           a ______c ' d ' e ' x ' g ' h ' i ' k ' l
 v2I'            a ' b ' c ' d ' e ' _ ' g ' h ' i ' k ' l
 v2i'            a ' b ' c ' d ' e '___' g ' h ' i ' k ' l
 v2a'            a ' b ' c ' d ' e _____ g ' h ' i ' k ' l
 v2A'            a ' b ' c ' d ' e ______g ' h ' i ' k ' l
-v2In'           a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
-v2in'           a ' b ' c ' d ' e ' x ' g '___' i ' k ' l
-v2an'           a ' b ' c ' d ' e ' x ' g _____ i ' k ' l
-v2An'           a ' b ' c ' d ' e ' x ' g ______i ' k ' l
-v2IN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' _ ' l
-v2iN'           a ' b ' c ' d ' e ' x ' g ' h ' i '___' l
-v2aN'           a ' b ' c ' d ' e ' x ' g ' h ' i _____ l
-v2AN'           a ' b ' c ' d ' e ' x ' g ' h ' i ______l
+v2In'           a ' b ' c ' d ' e ' x ' g ' h ' i ' _ ' l
+v2in'           a ' b ' c ' d ' e ' x ' g ' h ' i '___' l
+v2an'           a ' b ' c ' d ' e ' x ' g ' h ' i _____ l
+v2An'           a ' b ' c ' d ' e ' x ' g ' h ' i ______l
 a " b " c " d " e " x " g " h " i " k " l
-cIL"            a " b " c " _ " e " x " g " h " i " k " l
-ciL"            a " b " c "_" e " x " g " h " i " k " l
-caL"            a " b " c _ e " x " g " h " i " k " l
-cAL"            a " b " c _e " x " g " h " i " k " l
-cIl"            a " b " c " d " _ " x " g " h " i " k " l
-cil"            a " b " c " d "_" x " g " h " i " k " l
-cal"            a " b " c " d _ x " g " h " i " k " l
-cAl"            a " b " c " d _x " g " h " i " k " l
+cIl"            a " b " c " _ " e " x " g " h " i " k " l
+cil"            a " b " c "_" e " x " g " h " i " k " l
+cal"            a " b " c _ e " x " g " h " i " k " l
+cAl"            a " b " c _e " x " g " h " i " k " l
 cI"             a " b " c " d " e " _ " g " h " i " k " l
 ci"             a " b " c " d " e "_" g " h " i " k " l
 ca"             a " b " c " d " e _ g " h " i " k " l
 cA"             a " b " c " d " e _g " h " i " k " l
-cIn"            a " b " c " d " e " x " _ " h " i " k " l
-cin"            a " b " c " d " e " x "_" h " i " k " l
-can"            a " b " c " d " e " x _ h " i " k " l
-cAn"            a " b " c " d " e " x _h " i " k " l
-cIN"            a " b " c " d " e " x " g " _ " i " k " l
-ciN"            a " b " c " d " e " x " g "_" i " k " l
-caN"            a " b " c " d " e " x " g _ i " k " l
-cAN"            a " b " c " d " e " x " g _i " k " l
-c1IL"           a " b " c " _ " e " x " g " h " i " k " l
-c1iL"           a " b " c "_" e " x " g " h " i " k " l
-c1aL"           a " b " c _ e " x " g " h " i " k " l
-c1AL"           a " b " c _e " x " g " h " i " k " l
-c1Il"           a " b " c " d " _ " x " g " h " i " k " l
-c1il"           a " b " c " d "_" x " g " h " i " k " l
-c1al"           a " b " c " d _ x " g " h " i " k " l
-c1Al"           a " b " c " d _x " g " h " i " k " l
+cIn"            a " b " c " d " e " x " g " _ " i " k " l
+cin"            a " b " c " d " e " x " g "_" i " k " l
+can"            a " b " c " d " e " x " g _ i " k " l
+cAn"            a " b " c " d " e " x " g _i " k " l
+c1Il"           a " b " c " _ " e " x " g " h " i " k " l
+c1il"           a " b " c "_" e " x " g " h " i " k " l
+c1al"           a " b " c _ e " x " g " h " i " k " l
+c1Al"           a " b " c _e " x " g " h " i " k " l
 c1I"            a " b " c " d " e " _ " g " h " i " k " l
 c1i"            a " b " c " d " e "_" g " h " i " k " l
 c1a"            a " b " c " d " e _ g " h " i " k " l
 c1A"            a " b " c " d " e _g " h " i " k " l
-c1In"           a " b " c " d " e " x " _ " h " i " k " l
-c1in"           a " b " c " d " e " x "_" h " i " k " l
-c1an"           a " b " c " d " e " x _ h " i " k " l
-c1An"           a " b " c " d " e " x _h " i " k " l
-c1IN"           a " b " c " d " e " x " g " _ " i " k " l
-c1iN"           a " b " c " d " e " x " g "_" i " k " l
-c1aN"           a " b " c " d " e " x " g _ i " k " l
-c1AN"           a " b " c " d " e " x " g _i " k " l
-c2IL"           a " _ " c " d " e " x " g " h " i " k " l
-c2iL"           a "_" c " d " e " x " g " h " i " k " l
-c2aL"           a _ c " d " e " x " g " h " i " k " l
-c2AL"           a _c " d " e " x " g " h " i " k " l
-c2Il"           a " b " c " _ " e " x " g " h " i " k " l
-c2il"           a " b " c "_" e " x " g " h " i " k " l
-c2al"           a " b " c _ e " x " g " h " i " k " l
-c2Al"           a " b " c _e " x " g " h " i " k " l
+c1In"           a " b " c " d " e " x " g " _ " i " k " l
+c1in"           a " b " c " d " e " x " g "_" i " k " l
+c1an"           a " b " c " d " e " x " g _ i " k " l
+c1An"           a " b " c " d " e " x " g _i " k " l
+c2Il"           a " _ " c " d " e " x " g " h " i " k " l
+c2il"           a "_" c " d " e " x " g " h " i " k " l
+c2al"           a _ c " d " e " x " g " h " i " k " l
+c2Al"           a _c " d " e " x " g " h " i " k " l
 c2I"            a " b " c " d " e " _ " g " h " i " k " l
 c2i"            a " b " c " d " e "_" g " h " i " k " l
 c2a"            a " b " c " d " e _ g " h " i " k " l
 c2A"            a " b " c " d " e _g " h " i " k " l
-c2In"           a " b " c " d " e " x " g " _ " i " k " l
-c2in"           a " b " c " d " e " x " g "_" i " k " l
-c2an"           a " b " c " d " e " x " g _ i " k " l
-c2An"           a " b " c " d " e " x " g _i " k " l
-c2IN"           a " b " c " d " e " x " g " h " i " _ " l
-c2iN"           a " b " c " d " e " x " g " h " i "_" l
-c2aN"           a " b " c " d " e " x " g " h " i _ l
-c2AN"           a " b " c " d " e " x " g " h " i _l
-dIL"            a " b " c "  " e " x " g " h " i " k " l
-diL"            a " b " c "" e " x " g " h " i " k " l
-daL"            a " b " c  e " x " g " h " i " k " l
-dAL"            a " b " c e " x " g " h " i " k " l
-dIl"            a " b " c " d "  " x " g " h " i " k " l
-dil"            a " b " c " d "" x " g " h " i " k " l
-dal"            a " b " c " d  x " g " h " i " k " l
-dAl"            a " b " c " d x " g " h " i " k " l
+c2In"           a " b " c " d " e " x " g " h " i " _ " l
+c2in"           a " b " c " d " e " x " g " h " i "_" l
+c2an"           a " b " c " d " e " x " g " h " i _ l
+c2An"           a " b " c " d " e " x " g " h " i _l
+dIl"            a " b " c "  " e " x " g " h " i " k " l
+dil"            a " b " c "" e " x " g " h " i " k " l
+dal"            a " b " c  e " x " g " h " i " k " l
+dAl"            a " b " c e " x " g " h " i " k " l
 dI"             a " b " c " d " e "  " g " h " i " k " l
 di"             a " b " c " d " e "" g " h " i " k " l
 da"             a " b " c " d " e  g " h " i " k " l
 dA"             a " b " c " d " e g " h " i " k " l
-dIn"            a " b " c " d " e " x "  " h " i " k " l
-din"            a " b " c " d " e " x "" h " i " k " l
-dan"            a " b " c " d " e " x  h " i " k " l
-dAn"            a " b " c " d " e " x h " i " k " l
-dIN"            a " b " c " d " e " x " g "  " i " k " l
-diN"            a " b " c " d " e " x " g "" i " k " l
-daN"            a " b " c " d " e " x " g  i " k " l
-dAN"            a " b " c " d " e " x " g i " k " l
-d1IL"           a " b " c "  " e " x " g " h " i " k " l
-d1iL"           a " b " c "" e " x " g " h " i " k " l
-d1aL"           a " b " c  e " x " g " h " i " k " l
-d1AL"           a " b " c e " x " g " h " i " k " l
-d1Il"           a " b " c " d "  " x " g " h " i " k " l
-d1il"           a " b " c " d "" x " g " h " i " k " l
-d1al"           a " b " c " d  x " g " h " i " k " l
-d1Al"           a " b " c " d x " g " h " i " k " l
+dIn"            a " b " c " d " e " x " g "  " i " k " l
+din"            a " b " c " d " e " x " g "" i " k " l
+dan"            a " b " c " d " e " x " g  i " k " l
+dAn"            a " b " c " d " e " x " g i " k " l
+d1Il"           a " b " c "  " e " x " g " h " i " k " l
+d1il"           a " b " c "" e " x " g " h " i " k " l
+d1al"           a " b " c  e " x " g " h " i " k " l
+d1Al"           a " b " c e " x " g " h " i " k " l
 d1I"            a " b " c " d " e "  " g " h " i " k " l
 d1i"            a " b " c " d " e "" g " h " i " k " l
 d1a"            a " b " c " d " e  g " h " i " k " l
 d1A"            a " b " c " d " e g " h " i " k " l
-d1In"           a " b " c " d " e " x "  " h " i " k " l
-d1in"           a " b " c " d " e " x "" h " i " k " l
-d1an"           a " b " c " d " e " x  h " i " k " l
-d1An"           a " b " c " d " e " x h " i " k " l
-d1IN"           a " b " c " d " e " x " g "  " i " k " l
-d1iN"           a " b " c " d " e " x " g "" i " k " l
-d1aN"           a " b " c " d " e " x " g  i " k " l
-d1AN"           a " b " c " d " e " x " g i " k " l
-d2IL"           a "  " c " d " e " x " g " h " i " k " l
-d2iL"           a "" c " d " e " x " g " h " i " k " l
-d2aL"           a  c " d " e " x " g " h " i " k " l
-d2AL"           a c " d " e " x " g " h " i " k " l
-d2Il"           a " b " c "  " e " x " g " h " i " k " l
-d2il"           a " b " c "" e " x " g " h " i " k " l
-d2al"           a " b " c  e " x " g " h " i " k " l
-d2Al"           a " b " c e " x " g " h " i " k " l
+d1In"           a " b " c " d " e " x " g "  " i " k " l
+d1in"           a " b " c " d " e " x " g "" i " k " l
+d1an"           a " b " c " d " e " x " g  i " k " l
+d1An"           a " b " c " d " e " x " g i " k " l
+d2Il"           a "  " c " d " e " x " g " h " i " k " l
+d2il"           a "" c " d " e " x " g " h " i " k " l
+d2al"           a  c " d " e " x " g " h " i " k " l
+d2Al"           a c " d " e " x " g " h " i " k " l
 d2I"            a " b " c " d " e "  " g " h " i " k " l
 d2i"            a " b " c " d " e "" g " h " i " k " l
 d2a"            a " b " c " d " e  g " h " i " k " l
 d2A"            a " b " c " d " e g " h " i " k " l
-d2In"           a " b " c " d " e " x " g "  " i " k " l
-d2in"           a " b " c " d " e " x " g "" i " k " l
-d2an"           a " b " c " d " e " x " g  i " k " l
-d2An"           a " b " c " d " e " x " g i " k " l
-d2IN"           a " b " c " d " e " x " g " h " i "  " l
-d2iN"           a " b " c " d " e " x " g " h " i "" l
-d2aN"           a " b " c " d " e " x " g " h " i  l
-d2AN"           a " b " c " d " e " x " g " h " i l
-yIL"            a " b " c " d " e " x " g " h " i " k " l       'd'
-yiL"            a " b " c " d " e " x " g " h " i " k " l       ' d '
-yaL"            a " b " c " d " e " x " g " h " i " k " l       '" d "'
-yAL"            a " b " c " d " e " x " g " h " i " k " l       '" d " '
-yIl"            a " b " c " d " e " x " g " h " i " k " l       'e'
-yil"            a " b " c " d " e " x " g " h " i " k " l       ' e '
-yal"            a " b " c " d " e " x " g " h " i " k " l       '" e "'
-yAl"            a " b " c " d " e " x " g " h " i " k " l       '" e " '
+d2In"           a " b " c " d " e " x " g " h " i "  " l
+d2in"           a " b " c " d " e " x " g " h " i "" l
+d2an"           a " b " c " d " e " x " g " h " i  l
+d2An"           a " b " c " d " e " x " g " h " i l
+yIl"            a " b " c " d " e " x " g " h " i " k " l       'd'
+yil"            a " b " c " d " e " x " g " h " i " k " l       ' d '
+yal"            a " b " c " d " e " x " g " h " i " k " l       '" d "'
+yAl"            a " b " c " d " e " x " g " h " i " k " l       '" d " '
 yI"             a " b " c " d " e " x " g " h " i " k " l       'x'
 yi"             a " b " c " d " e " x " g " h " i " k " l       ' x '
 ya"             a " b " c " d " e " x " g " h " i " k " l       '" x "'
 yA"             a " b " c " d " e " x " g " h " i " k " l       '" x " '
-yIn"            a " b " c " d " e " x " g " h " i " k " l       'g'
-yin"            a " b " c " d " e " x " g " h " i " k " l       ' g '
-yan"            a " b " c " d " e " x " g " h " i " k " l       '" g "'
-yAn"            a " b " c " d " e " x " g " h " i " k " l       '" g " '
-yIN"            a " b " c " d " e " x " g " h " i " k " l       'h'
-yiN"            a " b " c " d " e " x " g " h " i " k " l       ' h '
-yaN"            a " b " c " d " e " x " g " h " i " k " l       '" h "'
-yAN"            a " b " c " d " e " x " g " h " i " k " l       '" h " '
-y1IL"           a " b " c " d " e " x " g " h " i " k " l       'd'
-y1iL"           a " b " c " d " e " x " g " h " i " k " l       ' d '
-y1aL"           a " b " c " d " e " x " g " h " i " k " l       '" d "'
-y1AL"           a " b " c " d " e " x " g " h " i " k " l       '" d " '
-y1Il"           a " b " c " d " e " x " g " h " i " k " l       'e'
-y1il"           a " b " c " d " e " x " g " h " i " k " l       ' e '
-y1al"           a " b " c " d " e " x " g " h " i " k " l       '" e "'
-y1Al"           a " b " c " d " e " x " g " h " i " k " l       '" e " '
+yIn"            a " b " c " d " e " x " g " h " i " k " l       'h'
+yin"            a " b " c " d " e " x " g " h " i " k " l       ' h '
+yan"            a " b " c " d " e " x " g " h " i " k " l       '" h "'
+yAn"            a " b " c " d " e " x " g " h " i " k " l       '" h " '
+y1Il"           a " b " c " d " e " x " g " h " i " k " l       'd'
+y1il"           a " b " c " d " e " x " g " h " i " k " l       ' d '
+y1al"           a " b " c " d " e " x " g " h " i " k " l       '" d "'
+y1Al"           a " b " c " d " e " x " g " h " i " k " l       '" d " '
 y1I"            a " b " c " d " e " x " g " h " i " k " l       'x'
 y1i"            a " b " c " d " e " x " g " h " i " k " l       ' x '
 y1a"            a " b " c " d " e " x " g " h " i " k " l       '" x "'
 y1A"            a " b " c " d " e " x " g " h " i " k " l       '" x " '
-y1In"           a " b " c " d " e " x " g " h " i " k " l       'g'
-y1in"           a " b " c " d " e " x " g " h " i " k " l       ' g '
-y1an"           a " b " c " d " e " x " g " h " i " k " l       '" g "'
-y1An"           a " b " c " d " e " x " g " h " i " k " l       '" g " '
-y1IN"           a " b " c " d " e " x " g " h " i " k " l       'h'
-y1iN"           a " b " c " d " e " x " g " h " i " k " l       ' h '
-y1aN"           a " b " c " d " e " x " g " h " i " k " l       '" h "'
-y1AN"           a " b " c " d " e " x " g " h " i " k " l       '" h " '
-y2IL"           a " b " c " d " e " x " g " h " i " k " l       'b'
-y2iL"           a " b " c " d " e " x " g " h " i " k " l       ' b '
-y2aL"           a " b " c " d " e " x " g " h " i " k " l       '" b "'
-y2AL"           a " b " c " d " e " x " g " h " i " k " l       '" b " '
-y2Il"           a " b " c " d " e " x " g " h " i " k " l       'd'
-y2il"           a " b " c " d " e " x " g " h " i " k " l       ' d '
-y2al"           a " b " c " d " e " x " g " h " i " k " l       '" d "'
-y2Al"           a " b " c " d " e " x " g " h " i " k " l       '" d " '
+y1In"           a " b " c " d " e " x " g " h " i " k " l       'h'
+y1in"           a " b " c " d " e " x " g " h " i " k " l       ' h '
+y1an"           a " b " c " d " e " x " g " h " i " k " l       '" h "'
+y1An"           a " b " c " d " e " x " g " h " i " k " l       '" h " '
+y2Il"           a " b " c " d " e " x " g " h " i " k " l       'b'
+y2il"           a " b " c " d " e " x " g " h " i " k " l       ' b '
+y2al"           a " b " c " d " e " x " g " h " i " k " l       '" b "'
+y2Al"           a " b " c " d " e " x " g " h " i " k " l       '" b " '
 y2I"            a " b " c " d " e " x " g " h " i " k " l       'x'
 y2i"            a " b " c " d " e " x " g " h " i " k " l       ' x '
 y2a"            a " b " c " d " e " x " g " h " i " k " l       '" x "'
 y2A"            a " b " c " d " e " x " g " h " i " k " l       '" x " '
-y2In"           a " b " c " d " e " x " g " h " i " k " l       'h'
-y2in"           a " b " c " d " e " x " g " h " i " k " l       ' h '
-y2an"           a " b " c " d " e " x " g " h " i " k " l       '" h "'
-y2An"           a " b " c " d " e " x " g " h " i " k " l       '" h " '
-y2IN"           a " b " c " d " e " x " g " h " i " k " l       'k'
-y2iN"           a " b " c " d " e " x " g " h " i " k " l       ' k '
-y2aN"           a " b " c " d " e " x " g " h " i " k " l       '" k "'
-y2AN"           a " b " c " d " e " x " g " h " i " k " l       '" k " '
-vIL"            a " b " c " _ " e " x " g " h " i " k " l
-viL"            a " b " c "___" e " x " g " h " i " k " l
-vaL"            a " b " c _____ e " x " g " h " i " k " l
-vAL"            a " b " c ______e " x " g " h " i " k " l
-vIl"            a " b " c " d " _ " x " g " h " i " k " l
-vil"            a " b " c " d "___" x " g " h " i " k " l
-val"            a " b " c " d _____ x " g " h " i " k " l
-vAl"            a " b " c " d ______x " g " h " i " k " l
+y2In"           a " b " c " d " e " x " g " h " i " k " l       'k'
+y2in"           a " b " c " d " e " x " g " h " i " k " l       ' k '
+y2an"           a " b " c " d " e " x " g " h " i " k " l       '" k "'
+y2An"           a " b " c " d " e " x " g " h " i " k " l       '" k " '
+vIl"            a " b " c " _ " e " x " g " h " i " k " l
+vil"            a " b " c "___" e " x " g " h " i " k " l
+val"            a " b " c _____ e " x " g " h " i " k " l
+vAl"            a " b " c ______e " x " g " h " i " k " l
 vI"             a " b " c " d " e " _ " g " h " i " k " l
 vi"             a " b " c " d " e "___" g " h " i " k " l
 va"             a " b " c " d " e _____ g " h " i " k " l
 vA"             a " b " c " d " e ______g " h " i " k " l
-vIn"            a " b " c " d " e " x " _ " h " i " k " l
-vin"            a " b " c " d " e " x "___" h " i " k " l
-van"            a " b " c " d " e " x _____ h " i " k " l
-vAn"            a " b " c " d " e " x ______h " i " k " l
-vIN"            a " b " c " d " e " x " g " _ " i " k " l
-viN"            a " b " c " d " e " x " g "___" i " k " l
-vaN"            a " b " c " d " e " x " g _____ i " k " l
-vAN"            a " b " c " d " e " x " g ______i " k " l
-v1IL"           a " b " c " _ " e " x " g " h " i " k " l
-v1iL"           a " b " c "___" e " x " g " h " i " k " l
-v1aL"           a " b " c _____ e " x " g " h " i " k " l
-v1AL"           a " b " c ______e " x " g " h " i " k " l
-v1Il"           a " b " c " d " _ " x " g " h " i " k " l
-v1il"           a " b " c " d "___" x " g " h " i " k " l
-v1al"           a " b " c " d _____ x " g " h " i " k " l
-v1Al"           a " b " c " d ______x " g " h " i " k " l
+vIn"            a " b " c " d " e " x " g " _ " i " k " l
+vin"            a " b " c " d " e " x " g "___" i " k " l
+van"            a " b " c " d " e " x " g _____ i " k " l
+vAn"            a " b " c " d " e " x " g ______i " k " l
+v1Il"           a " b " c " _ " e " x " g " h " i " k " l
+v1il"           a " b " c "___" e " x " g " h " i " k " l
+v1al"           a " b " c _____ e " x " g " h " i " k " l
+v1Al"           a " b " c ______e " x " g " h " i " k " l
 v1I"            a " b " c " d " e " _ " g " h " i " k " l
 v1i"            a " b " c " d " e "___" g " h " i " k " l
 v1a"            a " b " c " d " e _____ g " h " i " k " l
 v1A"            a " b " c " d " e ______g " h " i " k " l
-v1In"           a " b " c " d " e " x " _ " h " i " k " l
-v1in"           a " b " c " d " e " x "___" h " i " k " l
-v1an"           a " b " c " d " e " x _____ h " i " k " l
-v1An"           a " b " c " d " e " x ______h " i " k " l
-v1IN"           a " b " c " d " e " x " g " _ " i " k " l
-v1iN"           a " b " c " d " e " x " g "___" i " k " l
-v1aN"           a " b " c " d " e " x " g _____ i " k " l
-v1AN"           a " b " c " d " e " x " g ______i " k " l
-v2IL"           a " _ " c " d " e " x " g " h " i " k " l
-v2iL"           a "___" c " d " e " x " g " h " i " k " l
-v2aL"           a _____ c " d " e " x " g " h " i " k " l
-v2AL"           a ______c " d " e " x " g " h " i " k " l
-v2Il"           a " b " c " _ " e " x " g " h " i " k " l
-v2il"           a " b " c "___" e " x " g " h " i " k " l
-v2al"           a " b " c _____ e " x " g " h " i " k " l
-v2Al"           a " b " c ______e " x " g " h " i " k " l
+v1In"           a " b " c " d " e " x " g " _ " i " k " l
+v1in"           a " b " c " d " e " x " g "___" i " k " l
+v1an"           a " b " c " d " e " x " g _____ i " k " l
+v1An"           a " b " c " d " e " x " g ______i " k " l
+v2Il"           a " _ " c " d " e " x " g " h " i " k " l
+v2il"           a "___" c " d " e " x " g " h " i " k " l
+v2al"           a _____ c " d " e " x " g " h " i " k " l
+v2Al"           a ______c " d " e " x " g " h " i " k " l
 v2I"            a " b " c " d " e " _ " g " h " i " k " l
 v2i"            a " b " c " d " e "___" g " h " i " k " l
 v2a"            a " b " c " d " e _____ g " h " i " k " l
 v2A"            a " b " c " d " e ______g " h " i " k " l
-v2In"           a " b " c " d " e " x " g " _ " i " k " l
-v2in"           a " b " c " d " e " x " g "___" i " k " l
-v2an"           a " b " c " d " e " x " g _____ i " k " l
-v2An"           a " b " c " d " e " x " g ______i " k " l
-v2IN"           a " b " c " d " e " x " g " h " i " _ " l
-v2iN"           a " b " c " d " e " x " g " h " i "___" l
-v2aN"           a " b " c " d " e " x " g " h " i _____ l
-v2AN"           a " b " c " d " e " x " g " h " i ______l
+v2In"           a " b " c " d " e " x " g " h " i " _ " l
+v2in"           a " b " c " d " e " x " g " h " i "___" l
+v2an"           a " b " c " d " e " x " g " h " i _____ l
+v2An"           a " b " c " d " e " x " g " h " i ______l
 a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l
-cIL`            a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
-ciL`            a ` b ` c `_` e ` x ` g ` h ` i ` k ` l
-caL`            a ` b ` c _ e ` x ` g ` h ` i ` k ` l
-cAL`            a ` b ` c _e ` x ` g ` h ` i ` k ` l
-cIl`            a ` b ` c ` d ` _ ` x ` g ` h ` i ` k ` l
-cil`            a ` b ` c ` d `_` x ` g ` h ` i ` k ` l
-cal`            a ` b ` c ` d _ x ` g ` h ` i ` k ` l
-cAl`            a ` b ` c ` d _x ` g ` h ` i ` k ` l
+cIl`            a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
+cil`            a ` b ` c `_` e ` x ` g ` h ` i ` k ` l
+cal`            a ` b ` c _ e ` x ` g ` h ` i ` k ` l
+cAl`            a ` b ` c _e ` x ` g ` h ` i ` k ` l
 cI`             a ` b ` c ` d ` e ` _ ` g ` h ` i ` k ` l
 ci`             a ` b ` c ` d ` e `_` g ` h ` i ` k ` l
 ca`             a ` b ` c ` d ` e _ g ` h ` i ` k ` l
 cA`             a ` b ` c ` d ` e _g ` h ` i ` k ` l
-cIn`            a ` b ` c ` d ` e ` x ` _ ` h ` i ` k ` l
-cin`            a ` b ` c ` d ` e ` x `_` h ` i ` k ` l
-can`            a ` b ` c ` d ` e ` x _ h ` i ` k ` l
-cAn`            a ` b ` c ` d ` e ` x _h ` i ` k ` l
-cIN`            a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
-ciN`            a ` b ` c ` d ` e ` x ` g `_` i ` k ` l
-caN`            a ` b ` c ` d ` e ` x ` g _ i ` k ` l
-cAN`            a ` b ` c ` d ` e ` x ` g _i ` k ` l
-c1IL`           a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
-c1iL`           a ` b ` c `_` e ` x ` g ` h ` i ` k ` l
-c1aL`           a ` b ` c _ e ` x ` g ` h ` i ` k ` l
-c1AL`           a ` b ` c _e ` x ` g ` h ` i ` k ` l
-c1Il`           a ` b ` c ` d ` _ ` x ` g ` h ` i ` k ` l
-c1il`           a ` b ` c ` d `_` x ` g ` h ` i ` k ` l
-c1al`           a ` b ` c ` d _ x ` g ` h ` i ` k ` l
-c1Al`           a ` b ` c ` d _x ` g ` h ` i ` k ` l
+cIn`            a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
+cin`            a ` b ` c ` d ` e ` x ` g `_` i ` k ` l
+can`            a ` b ` c ` d ` e ` x ` g _ i ` k ` l
+cAn`            a ` b ` c ` d ` e ` x ` g _i ` k ` l
+c1Il`           a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
+c1il`           a ` b ` c `_` e ` x ` g ` h ` i ` k ` l
+c1al`           a ` b ` c _ e ` x ` g ` h ` i ` k ` l
+c1Al`           a ` b ` c _e ` x ` g ` h ` i ` k ` l
 c1I`            a ` b ` c ` d ` e ` _ ` g ` h ` i ` k ` l
 c1i`            a ` b ` c ` d ` e `_` g ` h ` i ` k ` l
 c1a`            a ` b ` c ` d ` e _ g ` h ` i ` k ` l
 c1A`            a ` b ` c ` d ` e _g ` h ` i ` k ` l
-c1In`           a ` b ` c ` d ` e ` x ` _ ` h ` i ` k ` l
-c1in`           a ` b ` c ` d ` e ` x `_` h ` i ` k ` l
-c1an`           a ` b ` c ` d ` e ` x _ h ` i ` k ` l
-c1An`           a ` b ` c ` d ` e ` x _h ` i ` k ` l
-c1IN`           a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
-c1iN`           a ` b ` c ` d ` e ` x ` g `_` i ` k ` l
-c1aN`           a ` b ` c ` d ` e ` x ` g _ i ` k ` l
-c1AN`           a ` b ` c ` d ` e ` x ` g _i ` k ` l
-c2IL`           a ` _ ` c ` d ` e ` x ` g ` h ` i ` k ` l
-c2iL`           a `_` c ` d ` e ` x ` g ` h ` i ` k ` l
-c2aL`           a _ c ` d ` e ` x ` g ` h ` i ` k ` l
-c2AL`           a _c ` d ` e ` x ` g ` h ` i ` k ` l
-c2Il`           a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
-c2il`           a ` b ` c `_` e ` x ` g ` h ` i ` k ` l
-c2al`           a ` b ` c _ e ` x ` g ` h ` i ` k ` l
-c2Al`           a ` b ` c _e ` x ` g ` h ` i ` k ` l
+c1In`           a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
+c1in`           a ` b ` c ` d ` e ` x ` g `_` i ` k ` l
+c1an`           a ` b ` c ` d ` e ` x ` g _ i ` k ` l
+c1An`           a ` b ` c ` d ` e ` x ` g _i ` k ` l
+c2Il`           a ` _ ` c ` d ` e ` x ` g ` h ` i ` k ` l
+c2il`           a `_` c ` d ` e ` x ` g ` h ` i ` k ` l
+c2al`           a _ c ` d ` e ` x ` g ` h ` i ` k ` l
+c2Al`           a _c ` d ` e ` x ` g ` h ` i ` k ` l
 c2I`            a ` b ` c ` d ` e ` _ ` g ` h ` i ` k ` l
 c2i`            a ` b ` c ` d ` e `_` g ` h ` i ` k ` l
 c2a`            a ` b ` c ` d ` e _ g ` h ` i ` k ` l
 c2A`            a ` b ` c ` d ` e _g ` h ` i ` k ` l
-c2In`           a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
-c2in`           a ` b ` c ` d ` e ` x ` g `_` i ` k ` l
-c2an`           a ` b ` c ` d ` e ` x ` g _ i ` k ` l
-c2An`           a ` b ` c ` d ` e ` x ` g _i ` k ` l
-c2IN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` _ ` l
-c2iN`           a ` b ` c ` d ` e ` x ` g ` h ` i `_` l
-c2aN`           a ` b ` c ` d ` e ` x ` g ` h ` i _ l
-c2AN`           a ` b ` c ` d ` e ` x ` g ` h ` i _l
-dIL`            a ` b ` c `  ` e ` x ` g ` h ` i ` k ` l
-diL`            a ` b ` c `` e ` x ` g ` h ` i ` k ` l
-daL`            a ` b ` c  e ` x ` g ` h ` i ` k ` l
-dAL`            a ` b ` c e ` x ` g ` h ` i ` k ` l
-dIl`            a ` b ` c ` d `  ` x ` g ` h ` i ` k ` l
-dil`            a ` b ` c ` d `` x ` g ` h ` i ` k ` l
-dal`            a ` b ` c ` d  x ` g ` h ` i ` k ` l
-dAl`            a ` b ` c ` d x ` g ` h ` i ` k ` l
+c2In`           a ` b ` c ` d ` e ` x ` g ` h ` i ` _ ` l
+c2in`           a ` b ` c ` d ` e ` x ` g ` h ` i `_` l
+c2an`           a ` b ` c ` d ` e ` x ` g ` h ` i _ l
+c2An`           a ` b ` c ` d ` e ` x ` g ` h ` i _l
+dIl`            a ` b ` c `  ` e ` x ` g ` h ` i ` k ` l
+dil`            a ` b ` c `` e ` x ` g ` h ` i ` k ` l
+dal`            a ` b ` c  e ` x ` g ` h ` i ` k ` l
+dAl`            a ` b ` c e ` x ` g ` h ` i ` k ` l
 dI`             a ` b ` c ` d ` e `  ` g ` h ` i ` k ` l
 di`             a ` b ` c ` d ` e `` g ` h ` i ` k ` l
 da`             a ` b ` c ` d ` e  g ` h ` i ` k ` l
 dA`             a ` b ` c ` d ` e g ` h ` i ` k ` l
-dIn`            a ` b ` c ` d ` e ` x `  ` h ` i ` k ` l
-din`            a ` b ` c ` d ` e ` x `` h ` i ` k ` l
-dan`            a ` b ` c ` d ` e ` x  h ` i ` k ` l
-dAn`            a ` b ` c ` d ` e ` x h ` i ` k ` l
-dIN`            a ` b ` c ` d ` e ` x ` g `  ` i ` k ` l
-diN`            a ` b ` c ` d ` e ` x ` g `` i ` k ` l
-daN`            a ` b ` c ` d ` e ` x ` g  i ` k ` l
-dAN`            a ` b ` c ` d ` e ` x ` g i ` k ` l
-d1IL`           a ` b ` c `  ` e ` x ` g ` h ` i ` k ` l
-d1iL`           a ` b ` c `` e ` x ` g ` h ` i ` k ` l
-d1aL`           a ` b ` c  e ` x ` g ` h ` i ` k ` l
-d1AL`           a ` b ` c e ` x ` g ` h ` i ` k ` l
-d1Il`           a ` b ` c ` d `  ` x ` g ` h ` i ` k ` l
-d1il`           a ` b ` c ` d `` x ` g ` h ` i ` k ` l
-d1al`           a ` b ` c ` d  x ` g ` h ` i ` k ` l
-d1Al`           a ` b ` c ` d x ` g ` h ` i ` k ` l
+dIn`            a ` b ` c ` d ` e ` x ` g `  ` i ` k ` l
+din`            a ` b ` c ` d ` e ` x ` g `` i ` k ` l
+dan`            a ` b ` c ` d ` e ` x ` g  i ` k ` l
+dAn`            a ` b ` c ` d ` e ` x ` g i ` k ` l
+d1Il`           a ` b ` c `  ` e ` x ` g ` h ` i ` k ` l
+d1il`           a ` b ` c `` e ` x ` g ` h ` i ` k ` l
+d1al`           a ` b ` c  e ` x ` g ` h ` i ` k ` l
+d1Al`           a ` b ` c e ` x ` g ` h ` i ` k ` l
 d1I`            a ` b ` c ` d ` e `  ` g ` h ` i ` k ` l
 d1i`            a ` b ` c ` d ` e `` g ` h ` i ` k ` l
 d1a`            a ` b ` c ` d ` e  g ` h ` i ` k ` l
 d1A`            a ` b ` c ` d ` e g ` h ` i ` k ` l
-d1In`           a ` b ` c ` d ` e ` x `  ` h ` i ` k ` l
-d1in`           a ` b ` c ` d ` e ` x `` h ` i ` k ` l
-d1an`           a ` b ` c ` d ` e ` x  h ` i ` k ` l
-d1An`           a ` b ` c ` d ` e ` x h ` i ` k ` l
-d1IN`           a ` b ` c ` d ` e ` x ` g `  ` i ` k ` l
-d1iN`           a ` b ` c ` d ` e ` x ` g `` i ` k ` l
-d1aN`           a ` b ` c ` d ` e ` x ` g  i ` k ` l
-d1AN`           a ` b ` c ` d ` e ` x ` g i ` k ` l
-d2IL`           a `  ` c ` d ` e ` x ` g ` h ` i ` k ` l
-d2iL`           a `` c ` d ` e ` x ` g ` h ` i ` k ` l
-d2aL`           a  c ` d ` e ` x ` g ` h ` i ` k ` l
-d2AL`           a c ` d ` e ` x ` g ` h ` i ` k ` l
-d2Il`           a ` b ` c `  ` e ` x ` g ` h ` i ` k ` l
-d2il`           a ` b ` c `` e ` x ` g ` h ` i ` k ` l
-d2al`           a ` b ` c  e ` x ` g ` h ` i ` k ` l
-d2Al`           a ` b ` c e ` x ` g ` h ` i ` k ` l
+d1In`           a ` b ` c ` d ` e ` x ` g `  ` i ` k ` l
+d1in`           a ` b ` c ` d ` e ` x ` g `` i ` k ` l
+d1an`           a ` b ` c ` d ` e ` x ` g  i ` k ` l
+d1An`           a ` b ` c ` d ` e ` x ` g i ` k ` l
+d2Il`           a `  ` c ` d ` e ` x ` g ` h ` i ` k ` l
+d2il`           a `` c ` d ` e ` x ` g ` h ` i ` k ` l
+d2al`           a  c ` d ` e ` x ` g ` h ` i ` k ` l
+d2Al`           a c ` d ` e ` x ` g ` h ` i ` k ` l
 d2I`            a ` b ` c ` d ` e `  ` g ` h ` i ` k ` l
 d2i`            a ` b ` c ` d ` e `` g ` h ` i ` k ` l
 d2a`            a ` b ` c ` d ` e  g ` h ` i ` k ` l
 d2A`            a ` b ` c ` d ` e g ` h ` i ` k ` l
-d2In`           a ` b ` c ` d ` e ` x ` g `  ` i ` k ` l
-d2in`           a ` b ` c ` d ` e ` x ` g `` i ` k ` l
-d2an`           a ` b ` c ` d ` e ` x ` g  i ` k ` l
-d2An`           a ` b ` c ` d ` e ` x ` g i ` k ` l
-d2IN`           a ` b ` c ` d ` e ` x ` g ` h ` i `  ` l
-d2iN`           a ` b ` c ` d ` e ` x ` g ` h ` i `` l
-d2aN`           a ` b ` c ` d ` e ` x ` g ` h ` i  l
-d2AN`           a ` b ` c ` d ` e ` x ` g ` h ` i l
-yIL`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'd'
-yiL`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' d '
-yaL`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d `'
-yAL`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d ` '
-yIl`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'e'
-yil`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' e '
-yal`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` e `'
-yAl`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` e ` '
+d2In`           a ` b ` c ` d ` e ` x ` g ` h ` i `  ` l
+d2in`           a ` b ` c ` d ` e ` x ` g ` h ` i `` l
+d2an`           a ` b ` c ` d ` e ` x ` g ` h ` i  l
+d2An`           a ` b ` c ` d ` e ` x ` g ` h ` i l
+yIl`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'd'
+yil`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' d '
+yal`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d `'
+yAl`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d ` '
 yI`             a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'x'
 yi`             a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' x '
 ya`             a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` x `'
 yA`             a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` x ` '
-yIn`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'g'
-yin`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' g '
-yan`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` g `'
-yAn`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` g ` '
-yIN`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'h'
-yiN`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' h '
-yaN`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h `'
-yAN`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h ` '
-y1IL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'd'
-y1iL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' d '
-y1aL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d `'
-y1AL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d ` '
-y1Il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'e'
-y1il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' e '
-y1al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` e `'
-y1Al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` e ` '
+yIn`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'h'
+yin`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' h '
+yan`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h `'
+yAn`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h ` '
+y1Il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'd'
+y1il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' d '
+y1al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d `'
+y1Al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d ` '
 y1I`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'x'
 y1i`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' x '
 y1a`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` x `'
 y1A`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` x ` '
-y1In`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'g'
-y1in`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' g '
-y1an`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` g `'
-y1An`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` g ` '
-y1IN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'h'
-y1iN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' h '
-y1aN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h `'
-y1AN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h ` '
-y2IL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'b'
-y2iL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' b '
-y2aL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` b `'
-y2AL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` b ` '
-y2Il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'd'
-y2il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' d '
-y2al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d `'
-y2Al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d ` '
+y1In`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'h'
+y1in`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' h '
+y1an`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h `'
+y1An`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h ` '
+y2Il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'b'
+y2il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' b '
+y2al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` b `'
+y2Al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` b ` '
 y2I`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'x'
 y2i`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' x '
 y2a`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` x `'
 y2A`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` x ` '
-y2In`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'h'
-y2in`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' h '
-y2an`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h `'
-y2An`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h ` '
-y2IN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'k'
-y2iN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' k '
-y2aN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` k `'
-y2AN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` k ` '
-vIL`            a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
-viL`            a ` b ` c `___` e ` x ` g ` h ` i ` k ` l
-vaL`            a ` b ` c _____ e ` x ` g ` h ` i ` k ` l
-vAL`            a ` b ` c ______e ` x ` g ` h ` i ` k ` l
-vIl`            a ` b ` c ` d ` _ ` x ` g ` h ` i ` k ` l
-vil`            a ` b ` c ` d `___` x ` g ` h ` i ` k ` l
-val`            a ` b ` c ` d _____ x ` g ` h ` i ` k ` l
-vAl`            a ` b ` c ` d ______x ` g ` h ` i ` k ` l
+y2In`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'k'
+y2in`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' k '
+y2an`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` k `'
+y2An`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` k ` '
+vIl`            a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
+vil`            a ` b ` c `___` e ` x ` g ` h ` i ` k ` l
+val`            a ` b ` c _____ e ` x ` g ` h ` i ` k ` l
+vAl`            a ` b ` c ______e ` x ` g ` h ` i ` k ` l
 vI`             a ` b ` c ` d ` e ` _ ` g ` h ` i ` k ` l
 vi`             a ` b ` c ` d ` e `___` g ` h ` i ` k ` l
 va`             a ` b ` c ` d ` e _____ g ` h ` i ` k ` l
 vA`             a ` b ` c ` d ` e ______g ` h ` i ` k ` l
-vIn`            a ` b ` c ` d ` e ` x ` _ ` h ` i ` k ` l
-vin`            a ` b ` c ` d ` e ` x `___` h ` i ` k ` l
-van`            a ` b ` c ` d ` e ` x _____ h ` i ` k ` l
-vAn`            a ` b ` c ` d ` e ` x ______h ` i ` k ` l
-vIN`            a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
-viN`            a ` b ` c ` d ` e ` x ` g `___` i ` k ` l
-vaN`            a ` b ` c ` d ` e ` x ` g _____ i ` k ` l
-vAN`            a ` b ` c ` d ` e ` x ` g ______i ` k ` l
-v1IL`           a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
-v1iL`           a ` b ` c `___` e ` x ` g ` h ` i ` k ` l
-v1aL`           a ` b ` c _____ e ` x ` g ` h ` i ` k ` l
-v1AL`           a ` b ` c ______e ` x ` g ` h ` i ` k ` l
-v1Il`           a ` b ` c ` d ` _ ` x ` g ` h ` i ` k ` l
-v1il`           a ` b ` c ` d `___` x ` g ` h ` i ` k ` l
-v1al`           a ` b ` c ` d _____ x ` g ` h ` i ` k ` l
-v1Al`           a ` b ` c ` d ______x ` g ` h ` i ` k ` l
+vIn`            a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
+vin`            a ` b ` c ` d ` e ` x ` g `___` i ` k ` l
+van`            a ` b ` c ` d ` e ` x ` g _____ i ` k ` l
+vAn`            a ` b ` c ` d ` e ` x ` g ______i ` k ` l
+v1Il`           a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
+v1il`           a ` b ` c `___` e ` x ` g ` h ` i ` k ` l
+v1al`           a ` b ` c _____ e ` x ` g ` h ` i ` k ` l
+v1Al`           a ` b ` c ______e ` x ` g ` h ` i ` k ` l
 v1I`            a ` b ` c ` d ` e ` _ ` g ` h ` i ` k ` l
 v1i`            a ` b ` c ` d ` e `___` g ` h ` i ` k ` l
 v1a`            a ` b ` c ` d ` e _____ g ` h ` i ` k ` l
 v1A`            a ` b ` c ` d ` e ______g ` h ` i ` k ` l
-v1In`           a ` b ` c ` d ` e ` x ` _ ` h ` i ` k ` l
-v1in`           a ` b ` c ` d ` e ` x `___` h ` i ` k ` l
-v1an`           a ` b ` c ` d ` e ` x _____ h ` i ` k ` l
-v1An`           a ` b ` c ` d ` e ` x ______h ` i ` k ` l
-v1IN`           a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
-v1iN`           a ` b ` c ` d ` e ` x ` g `___` i ` k ` l
-v1aN`           a ` b ` c ` d ` e ` x ` g _____ i ` k ` l
-v1AN`           a ` b ` c ` d ` e ` x ` g ______i ` k ` l
-v2IL`           a ` _ ` c ` d ` e ` x ` g ` h ` i ` k ` l
-v2iL`           a `___` c ` d ` e ` x ` g ` h ` i ` k ` l
-v2aL`           a _____ c ` d ` e ` x ` g ` h ` i ` k ` l
-v2AL`           a ______c ` d ` e ` x ` g ` h ` i ` k ` l
-v2Il`           a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
-v2il`           a ` b ` c `___` e ` x ` g ` h ` i ` k ` l
-v2al`           a ` b ` c _____ e ` x ` g ` h ` i ` k ` l
-v2Al`           a ` b ` c ______e ` x ` g ` h ` i ` k ` l
+v1In`           a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
+v1in`           a ` b ` c ` d ` e ` x ` g `___` i ` k ` l
+v1an`           a ` b ` c ` d ` e ` x ` g _____ i ` k ` l
+v1An`           a ` b ` c ` d ` e ` x ` g ______i ` k ` l
+v2Il`           a ` _ ` c ` d ` e ` x ` g ` h ` i ` k ` l
+v2il`           a `___` c ` d ` e ` x ` g ` h ` i ` k ` l
+v2al`           a _____ c ` d ` e ` x ` g ` h ` i ` k ` l
+v2Al`           a ______c ` d ` e ` x ` g ` h ` i ` k ` l
 v2I`            a ` b ` c ` d ` e ` _ ` g ` h ` i ` k ` l
 v2i`            a ` b ` c ` d ` e `___` g ` h ` i ` k ` l
 v2a`            a ` b ` c ` d ` e _____ g ` h ` i ` k ` l
 v2A`            a ` b ` c ` d ` e ______g ` h ` i ` k ` l
-v2In`           a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
-v2in`           a ` b ` c ` d ` e ` x ` g `___` i ` k ` l
-v2an`           a ` b ` c ` d ` e ` x ` g _____ i ` k ` l
-v2An`           a ` b ` c ` d ` e ` x ` g ______i ` k ` l
-v2IN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` _ ` l
-v2iN`           a ` b ` c ` d ` e ` x ` g ` h ` i `___` l
-v2aN`           a ` b ` c ` d ` e ` x ` g ` h ` i _____ l
-v2AN`           a ` b ` c ` d ` e ` x ` g ` h ` i ______l
+v2In`           a ` b ` c ` d ` e ` x ` g ` h ` i ` _ ` l
+v2in`           a ` b ` c ` d ` e ` x ` g ` h ` i `___` l
+v2an`           a ` b ` c ` d ` e ` x ` g ` h ` i _____ l
+v2An`           a ` b ` c ` d ` e ` x ` g ` h ` i ______l
 
 a , b , c , d , e , x , g , h , i , k , l
 cIL,            a , b , c , _ , e , x , g , h , i , k , l

--- a/test/test1.out
+++ b/test/test1.out
@@ -1589,728 +1589,440 @@ v2ant           a <a> b </a> <b> c </b> <c> <d> x </d> </c> <e> e </e> _________
 v2Ant           a <a> b </a> <b> c </b> <c> <d> x </d> </c> <e> e </e> ___________g
 
 a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l
-cIL'            a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
-ciL'            a ' b ' c '_' e ' x ' g ' h ' i ' k ' l
-caL'            a ' b ' c _ e ' x ' g ' h ' i ' k ' l
-cAL'            a ' b ' c _e ' x ' g ' h ' i ' k ' l
-cIl'            a ' b ' c ' d ' _ ' x ' g ' h ' i ' k ' l
-cil'            a ' b ' c ' d '_' x ' g ' h ' i ' k ' l
-cal'            a ' b ' c ' d _ x ' g ' h ' i ' k ' l
-cAl'            a ' b ' c ' d _x ' g ' h ' i ' k ' l
+cIl'            a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
+cil'            a ' b ' c '_' e ' x ' g ' h ' i ' k ' l
+cal'            a ' b ' c _ e ' x ' g ' h ' i ' k ' l
+cAl'            a ' b ' c _e ' x ' g ' h ' i ' k ' l
 cI'             a ' b ' c ' d ' e ' _ ' g ' h ' i ' k ' l
 ci'             a ' b ' c ' d ' e '_' g ' h ' i ' k ' l
 ca'             a ' b ' c ' d ' e _ g ' h ' i ' k ' l
 cA'             a ' b ' c ' d ' e _g ' h ' i ' k ' l
-cIn'            a ' b ' c ' d ' e ' x ' _ ' h ' i ' k ' l
-cin'            a ' b ' c ' d ' e ' x '_' h ' i ' k ' l
-can'            a ' b ' c ' d ' e ' x _ h ' i ' k ' l
-cAn'            a ' b ' c ' d ' e ' x _h ' i ' k ' l
-cIN'            a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
-ciN'            a ' b ' c ' d ' e ' x ' g '_' i ' k ' l
-caN'            a ' b ' c ' d ' e ' x ' g _ i ' k ' l
-cAN'            a ' b ' c ' d ' e ' x ' g _i ' k ' l
-c1IL'           a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
-c1iL'           a ' b ' c '_' e ' x ' g ' h ' i ' k ' l
-c1aL'           a ' b ' c _ e ' x ' g ' h ' i ' k ' l
-c1AL'           a ' b ' c _e ' x ' g ' h ' i ' k ' l
-c1Il'           a ' b ' c ' d ' _ ' x ' g ' h ' i ' k ' l
-c1il'           a ' b ' c ' d '_' x ' g ' h ' i ' k ' l
-c1al'           a ' b ' c ' d _ x ' g ' h ' i ' k ' l
-c1Al'           a ' b ' c ' d _x ' g ' h ' i ' k ' l
+cIn'            a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
+cin'            a ' b ' c ' d ' e ' x ' g '_' i ' k ' l
+can'            a ' b ' c ' d ' e ' x ' g _ i ' k ' l
+cAn'            a ' b ' c ' d ' e ' x ' g _i ' k ' l
+c1Il'           a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
+c1il'           a ' b ' c '_' e ' x ' g ' h ' i ' k ' l
+c1al'           a ' b ' c _ e ' x ' g ' h ' i ' k ' l
+c1Al'           a ' b ' c _e ' x ' g ' h ' i ' k ' l
 c1I'            a ' b ' c ' d ' e ' _ ' g ' h ' i ' k ' l
 c1i'            a ' b ' c ' d ' e '_' g ' h ' i ' k ' l
 c1a'            a ' b ' c ' d ' e _ g ' h ' i ' k ' l
 c1A'            a ' b ' c ' d ' e _g ' h ' i ' k ' l
-c1In'           a ' b ' c ' d ' e ' x ' _ ' h ' i ' k ' l
-c1in'           a ' b ' c ' d ' e ' x '_' h ' i ' k ' l
-c1an'           a ' b ' c ' d ' e ' x _ h ' i ' k ' l
-c1An'           a ' b ' c ' d ' e ' x _h ' i ' k ' l
-c1IN'           a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
-c1iN'           a ' b ' c ' d ' e ' x ' g '_' i ' k ' l
-c1aN'           a ' b ' c ' d ' e ' x ' g _ i ' k ' l
-c1AN'           a ' b ' c ' d ' e ' x ' g _i ' k ' l
-c2IL'           a ' _ ' c ' d ' e ' x ' g ' h ' i ' k ' l
-c2iL'           a '_' c ' d ' e ' x ' g ' h ' i ' k ' l
-c2aL'           a _ c ' d ' e ' x ' g ' h ' i ' k ' l
-c2AL'           a _c ' d ' e ' x ' g ' h ' i ' k ' l
-c2Il'           a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
-c2il'           a ' b ' c '_' e ' x ' g ' h ' i ' k ' l
-c2al'           a ' b ' c _ e ' x ' g ' h ' i ' k ' l
-c2Al'           a ' b ' c _e ' x ' g ' h ' i ' k ' l
+c1In'           a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
+c1in'           a ' b ' c ' d ' e ' x ' g '_' i ' k ' l
+c1an'           a ' b ' c ' d ' e ' x ' g _ i ' k ' l
+c1An'           a ' b ' c ' d ' e ' x ' g _i ' k ' l
+c2Il'           a ' _ ' c ' d ' e ' x ' g ' h ' i ' k ' l
+c2il'           a '_' c ' d ' e ' x ' g ' h ' i ' k ' l
+c2al'           a _ c ' d ' e ' x ' g ' h ' i ' k ' l
+c2Al'           a _c ' d ' e ' x ' g ' h ' i ' k ' l
 c2I'            a ' b ' c ' d ' e ' _ ' g ' h ' i ' k ' l
 c2i'            a ' b ' c ' d ' e '_' g ' h ' i ' k ' l
 c2a'            a ' b ' c ' d ' e _ g ' h ' i ' k ' l
 c2A'            a ' b ' c ' d ' e _g ' h ' i ' k ' l
-c2In'           a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
-c2in'           a ' b ' c ' d ' e ' x ' g '_' i ' k ' l
-c2an'           a ' b ' c ' d ' e ' x ' g _ i ' k ' l
-c2An'           a ' b ' c ' d ' e ' x ' g _i ' k ' l
-c2IN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' _ ' l
-c2iN'           a ' b ' c ' d ' e ' x ' g ' h ' i '_' l
-c2aN'           a ' b ' c ' d ' e ' x ' g ' h ' i _ l
-c2AN'           a ' b ' c ' d ' e ' x ' g ' h ' i _l
-dIL'            a ' b ' c '  ' e ' x ' g ' h ' i ' k ' l
-diL'            a ' b ' c '' e ' x ' g ' h ' i ' k ' l
-daL'            a ' b ' c  e ' x ' g ' h ' i ' k ' l
-dAL'            a ' b ' c e ' x ' g ' h ' i ' k ' l
-dIl'            a ' b ' c ' d '  ' x ' g ' h ' i ' k ' l
-dil'            a ' b ' c ' d '' x ' g ' h ' i ' k ' l
-dal'            a ' b ' c ' d  x ' g ' h ' i ' k ' l
-dAl'            a ' b ' c ' d x ' g ' h ' i ' k ' l
+c2In'           a ' b ' c ' d ' e ' x ' g ' h ' i ' _ ' l
+c2in'           a ' b ' c ' d ' e ' x ' g ' h ' i '_' l
+c2an'           a ' b ' c ' d ' e ' x ' g ' h ' i _ l
+c2An'           a ' b ' c ' d ' e ' x ' g ' h ' i _l
+dIl'            a ' b ' c '  ' e ' x ' g ' h ' i ' k ' l
+dil'            a ' b ' c '' e ' x ' g ' h ' i ' k ' l
+dal'            a ' b ' c  e ' x ' g ' h ' i ' k ' l
+dAl'            a ' b ' c e ' x ' g ' h ' i ' k ' l
 dI'             a ' b ' c ' d ' e '  ' g ' h ' i ' k ' l
 di'             a ' b ' c ' d ' e '' g ' h ' i ' k ' l
 da'             a ' b ' c ' d ' e  g ' h ' i ' k ' l
 dA'             a ' b ' c ' d ' e g ' h ' i ' k ' l
-dIn'            a ' b ' c ' d ' e ' x '  ' h ' i ' k ' l
-din'            a ' b ' c ' d ' e ' x '' h ' i ' k ' l
-dan'            a ' b ' c ' d ' e ' x  h ' i ' k ' l
-dAn'            a ' b ' c ' d ' e ' x h ' i ' k ' l
-dIN'            a ' b ' c ' d ' e ' x ' g '  ' i ' k ' l
-diN'            a ' b ' c ' d ' e ' x ' g '' i ' k ' l
-daN'            a ' b ' c ' d ' e ' x ' g  i ' k ' l
-dAN'            a ' b ' c ' d ' e ' x ' g i ' k ' l
-d1IL'           a ' b ' c '  ' e ' x ' g ' h ' i ' k ' l
-d1iL'           a ' b ' c '' e ' x ' g ' h ' i ' k ' l
-d1aL'           a ' b ' c  e ' x ' g ' h ' i ' k ' l
-d1AL'           a ' b ' c e ' x ' g ' h ' i ' k ' l
-d1Il'           a ' b ' c ' d '  ' x ' g ' h ' i ' k ' l
-d1il'           a ' b ' c ' d '' x ' g ' h ' i ' k ' l
-d1al'           a ' b ' c ' d  x ' g ' h ' i ' k ' l
-d1Al'           a ' b ' c ' d x ' g ' h ' i ' k ' l
+dIn'            a ' b ' c ' d ' e ' x ' g '  ' i ' k ' l
+din'            a ' b ' c ' d ' e ' x ' g '' i ' k ' l
+dan'            a ' b ' c ' d ' e ' x ' g  i ' k ' l
+dAn'            a ' b ' c ' d ' e ' x ' g i ' k ' l
+d1Il'           a ' b ' c '  ' e ' x ' g ' h ' i ' k ' l
+d1il'           a ' b ' c '' e ' x ' g ' h ' i ' k ' l
+d1al'           a ' b ' c  e ' x ' g ' h ' i ' k ' l
+d1Al'           a ' b ' c e ' x ' g ' h ' i ' k ' l
 d1I'            a ' b ' c ' d ' e '  ' g ' h ' i ' k ' l
 d1i'            a ' b ' c ' d ' e '' g ' h ' i ' k ' l
 d1a'            a ' b ' c ' d ' e  g ' h ' i ' k ' l
 d1A'            a ' b ' c ' d ' e g ' h ' i ' k ' l
-d1In'           a ' b ' c ' d ' e ' x '  ' h ' i ' k ' l
-d1in'           a ' b ' c ' d ' e ' x '' h ' i ' k ' l
-d1an'           a ' b ' c ' d ' e ' x  h ' i ' k ' l
-d1An'           a ' b ' c ' d ' e ' x h ' i ' k ' l
-d1IN'           a ' b ' c ' d ' e ' x ' g '  ' i ' k ' l
-d1iN'           a ' b ' c ' d ' e ' x ' g '' i ' k ' l
-d1aN'           a ' b ' c ' d ' e ' x ' g  i ' k ' l
-d1AN'           a ' b ' c ' d ' e ' x ' g i ' k ' l
-d2IL'           a '  ' c ' d ' e ' x ' g ' h ' i ' k ' l
-d2iL'           a '' c ' d ' e ' x ' g ' h ' i ' k ' l
-d2aL'           a  c ' d ' e ' x ' g ' h ' i ' k ' l
-d2AL'           a c ' d ' e ' x ' g ' h ' i ' k ' l
-d2Il'           a ' b ' c '  ' e ' x ' g ' h ' i ' k ' l
-d2il'           a ' b ' c '' e ' x ' g ' h ' i ' k ' l
-d2al'           a ' b ' c  e ' x ' g ' h ' i ' k ' l
-d2Al'           a ' b ' c e ' x ' g ' h ' i ' k ' l
+d1In'           a ' b ' c ' d ' e ' x ' g '  ' i ' k ' l
+d1in'           a ' b ' c ' d ' e ' x ' g '' i ' k ' l
+d1an'           a ' b ' c ' d ' e ' x ' g  i ' k ' l
+d1An'           a ' b ' c ' d ' e ' x ' g i ' k ' l
+d2Il'           a '  ' c ' d ' e ' x ' g ' h ' i ' k ' l
+d2il'           a '' c ' d ' e ' x ' g ' h ' i ' k ' l
+d2al'           a  c ' d ' e ' x ' g ' h ' i ' k ' l
+d2Al'           a c ' d ' e ' x ' g ' h ' i ' k ' l
 d2I'            a ' b ' c ' d ' e '  ' g ' h ' i ' k ' l
 d2i'            a ' b ' c ' d ' e '' g ' h ' i ' k ' l
 d2a'            a ' b ' c ' d ' e  g ' h ' i ' k ' l
 d2A'            a ' b ' c ' d ' e g ' h ' i ' k ' l
-d2In'           a ' b ' c ' d ' e ' x ' g '  ' i ' k ' l
-d2in'           a ' b ' c ' d ' e ' x ' g '' i ' k ' l
-d2an'           a ' b ' c ' d ' e ' x ' g  i ' k ' l
-d2An'           a ' b ' c ' d ' e ' x ' g i ' k ' l
-d2IN'           a ' b ' c ' d ' e ' x ' g ' h ' i '  ' l
-d2iN'           a ' b ' c ' d ' e ' x ' g ' h ' i '' l
-d2aN'           a ' b ' c ' d ' e ' x ' g ' h ' i  l
-d2AN'           a ' b ' c ' d ' e ' x ' g ' h ' i l
-yIL'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'd'
-yiL'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' d '
-yaL'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ''
-yAL'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ' '
-yIl'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'e'
-yil'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' e '
-yal'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' e ''
-yAl'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' e ' '
+d2In'           a ' b ' c ' d ' e ' x ' g ' h ' i '  ' l
+d2in'           a ' b ' c ' d ' e ' x ' g ' h ' i '' l
+d2an'           a ' b ' c ' d ' e ' x ' g ' h ' i  l
+d2An'           a ' b ' c ' d ' e ' x ' g ' h ' i l
+yIl'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'd'
+yil'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' d '
+yal'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ''
+yAl'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ' '
 yI'             a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'x'
 yi'             a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' x '
 ya'             a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' x ''
 yA'             a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' x ' '
-yIn'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'g'
-yin'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' g '
-yan'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' g ''
-yAn'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' g ' '
-yIN'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'h'
-yiN'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' h '
-yaN'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ''
-yAN'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ' '
-y1IL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'd'
-y1iL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' d '
-y1aL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ''
-y1AL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ' '
-y1Il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'e'
-y1il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' e '
-y1al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' e ''
-y1Al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' e ' '
+yIn'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'h'
+yin'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' h '
+yan'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ''
+yAn'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ' '
+y1Il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'd'
+y1il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' d '
+y1al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ''
+y1Al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ' '
 y1I'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'x'
 y1i'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' x '
 y1a'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' x ''
 y1A'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' x ' '
-y1In'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'g'
-y1in'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' g '
-y1an'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' g ''
-y1An'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' g ' '
-y1IN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'h'
-y1iN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' h '
-y1aN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ''
-y1AN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ' '
-y2IL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'b'
-y2iL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' b '
-y2aL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' b ''
-y2AL'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' b ' '
-y2Il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'd'
-y2il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' d '
-y2al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ''
-y2Al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' d ' '
+y1In'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'h'
+y1in'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' h '
+y1an'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ''
+y1An'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ' '
+y2Il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'b'
+y2il'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' b '
+y2al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' b ''
+y2Al'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' b ' '
 y2I'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'x'
 y2i'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' x '
 y2a'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' x ''
 y2A'            a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' x ' '
-y2In'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'h'
-y2in'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' h '
-y2an'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ''
-y2An'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' h ' '
-y2IN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'k'
-y2iN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' k '
-y2aN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' k ''
-y2AN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' k ' '
-vIL'            a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
-viL'            a ' b ' c '___' e ' x ' g ' h ' i ' k ' l
-vaL'            a ' b ' c _____ e ' x ' g ' h ' i ' k ' l
-vAL'            a ' b ' c ______e ' x ' g ' h ' i ' k ' l
-vIl'            a ' b ' c ' d ' _ ' x ' g ' h ' i ' k ' l
-vil'            a ' b ' c ' d '___' x ' g ' h ' i ' k ' l
-val'            a ' b ' c ' d _____ x ' g ' h ' i ' k ' l
-vAl'            a ' b ' c ' d ______x ' g ' h ' i ' k ' l
+y2In'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       'k'
+y2in'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       ' k '
+y2an'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' k ''
+y2An'           a ' b ' c ' d ' e ' x ' g ' h ' i ' k ' l       '' k ' '
+vIl'            a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
+vil'            a ' b ' c '___' e ' x ' g ' h ' i ' k ' l
+val'            a ' b ' c _____ e ' x ' g ' h ' i ' k ' l
+vAl'            a ' b ' c ______e ' x ' g ' h ' i ' k ' l
 vI'             a ' b ' c ' d ' e ' _ ' g ' h ' i ' k ' l
 vi'             a ' b ' c ' d ' e '___' g ' h ' i ' k ' l
 va'             a ' b ' c ' d ' e _____ g ' h ' i ' k ' l
 vA'             a ' b ' c ' d ' e ______g ' h ' i ' k ' l
-vIn'            a ' b ' c ' d ' e ' x ' _ ' h ' i ' k ' l
-vin'            a ' b ' c ' d ' e ' x '___' h ' i ' k ' l
-van'            a ' b ' c ' d ' e ' x _____ h ' i ' k ' l
-vAn'            a ' b ' c ' d ' e ' x ______h ' i ' k ' l
-vIN'            a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
-viN'            a ' b ' c ' d ' e ' x ' g '___' i ' k ' l
-vaN'            a ' b ' c ' d ' e ' x ' g _____ i ' k ' l
-vAN'            a ' b ' c ' d ' e ' x ' g ______i ' k ' l
-v1IL'           a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
-v1iL'           a ' b ' c '___' e ' x ' g ' h ' i ' k ' l
-v1aL'           a ' b ' c _____ e ' x ' g ' h ' i ' k ' l
-v1AL'           a ' b ' c ______e ' x ' g ' h ' i ' k ' l
-v1Il'           a ' b ' c ' d ' _ ' x ' g ' h ' i ' k ' l
-v1il'           a ' b ' c ' d '___' x ' g ' h ' i ' k ' l
-v1al'           a ' b ' c ' d _____ x ' g ' h ' i ' k ' l
-v1Al'           a ' b ' c ' d ______x ' g ' h ' i ' k ' l
+vIn'            a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
+vin'            a ' b ' c ' d ' e ' x ' g '___' i ' k ' l
+van'            a ' b ' c ' d ' e ' x ' g _____ i ' k ' l
+vAn'            a ' b ' c ' d ' e ' x ' g ______i ' k ' l
+v1Il'           a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
+v1il'           a ' b ' c '___' e ' x ' g ' h ' i ' k ' l
+v1al'           a ' b ' c _____ e ' x ' g ' h ' i ' k ' l
+v1Al'           a ' b ' c ______e ' x ' g ' h ' i ' k ' l
 v1I'            a ' b ' c ' d ' e ' _ ' g ' h ' i ' k ' l
 v1i'            a ' b ' c ' d ' e '___' g ' h ' i ' k ' l
 v1a'            a ' b ' c ' d ' e _____ g ' h ' i ' k ' l
 v1A'            a ' b ' c ' d ' e ______g ' h ' i ' k ' l
-v1In'           a ' b ' c ' d ' e ' x ' _ ' h ' i ' k ' l
-v1in'           a ' b ' c ' d ' e ' x '___' h ' i ' k ' l
-v1an'           a ' b ' c ' d ' e ' x _____ h ' i ' k ' l
-v1An'           a ' b ' c ' d ' e ' x ______h ' i ' k ' l
-v1IN'           a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
-v1iN'           a ' b ' c ' d ' e ' x ' g '___' i ' k ' l
-v1aN'           a ' b ' c ' d ' e ' x ' g _____ i ' k ' l
-v1AN'           a ' b ' c ' d ' e ' x ' g ______i ' k ' l
-v2IL'           a ' _ ' c ' d ' e ' x ' g ' h ' i ' k ' l
-v2iL'           a '___' c ' d ' e ' x ' g ' h ' i ' k ' l
-v2aL'           a _____ c ' d ' e ' x ' g ' h ' i ' k ' l
-v2AL'           a ______c ' d ' e ' x ' g ' h ' i ' k ' l
-v2Il'           a ' b ' c ' _ ' e ' x ' g ' h ' i ' k ' l
-v2il'           a ' b ' c '___' e ' x ' g ' h ' i ' k ' l
-v2al'           a ' b ' c _____ e ' x ' g ' h ' i ' k ' l
-v2Al'           a ' b ' c ______e ' x ' g ' h ' i ' k ' l
+v1In'           a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
+v1in'           a ' b ' c ' d ' e ' x ' g '___' i ' k ' l
+v1an'           a ' b ' c ' d ' e ' x ' g _____ i ' k ' l
+v1An'           a ' b ' c ' d ' e ' x ' g ______i ' k ' l
+v2Il'           a ' _ ' c ' d ' e ' x ' g ' h ' i ' k ' l
+v2il'           a '___' c ' d ' e ' x ' g ' h ' i ' k ' l
+v2al'           a _____ c ' d ' e ' x ' g ' h ' i ' k ' l
+v2Al'           a ______c ' d ' e ' x ' g ' h ' i ' k ' l
 v2I'            a ' b ' c ' d ' e ' _ ' g ' h ' i ' k ' l
 v2i'            a ' b ' c ' d ' e '___' g ' h ' i ' k ' l
 v2a'            a ' b ' c ' d ' e _____ g ' h ' i ' k ' l
 v2A'            a ' b ' c ' d ' e ______g ' h ' i ' k ' l
-v2In'           a ' b ' c ' d ' e ' x ' g ' _ ' i ' k ' l
-v2in'           a ' b ' c ' d ' e ' x ' g '___' i ' k ' l
-v2an'           a ' b ' c ' d ' e ' x ' g _____ i ' k ' l
-v2An'           a ' b ' c ' d ' e ' x ' g ______i ' k ' l
-v2IN'           a ' b ' c ' d ' e ' x ' g ' h ' i ' _ ' l
-v2iN'           a ' b ' c ' d ' e ' x ' g ' h ' i '___' l
-v2aN'           a ' b ' c ' d ' e ' x ' g ' h ' i _____ l
-v2AN'           a ' b ' c ' d ' e ' x ' g ' h ' i ______l
+v2In'           a ' b ' c ' d ' e ' x ' g ' h ' i ' _ ' l
+v2in'           a ' b ' c ' d ' e ' x ' g ' h ' i '___' l
+v2an'           a ' b ' c ' d ' e ' x ' g ' h ' i _____ l
+v2An'           a ' b ' c ' d ' e ' x ' g ' h ' i ______l
 a " b " c " d " e " x " g " h " i " k " l
-cIL"            a " b " c " _ " e " x " g " h " i " k " l
-ciL"            a " b " c "_" e " x " g " h " i " k " l
-caL"            a " b " c _ e " x " g " h " i " k " l
-cAL"            a " b " c _e " x " g " h " i " k " l
-cIl"            a " b " c " d " _ " x " g " h " i " k " l
-cil"            a " b " c " d "_" x " g " h " i " k " l
-cal"            a " b " c " d _ x " g " h " i " k " l
-cAl"            a " b " c " d _x " g " h " i " k " l
+cIl"            a " b " c " _ " e " x " g " h " i " k " l
+cil"            a " b " c "_" e " x " g " h " i " k " l
+cal"            a " b " c _ e " x " g " h " i " k " l
+cAl"            a " b " c _e " x " g " h " i " k " l
 cI"             a " b " c " d " e " _ " g " h " i " k " l
 ci"             a " b " c " d " e "_" g " h " i " k " l
 ca"             a " b " c " d " e _ g " h " i " k " l
 cA"             a " b " c " d " e _g " h " i " k " l
-cIn"            a " b " c " d " e " x " _ " h " i " k " l
-cin"            a " b " c " d " e " x "_" h " i " k " l
-can"            a " b " c " d " e " x _ h " i " k " l
-cAn"            a " b " c " d " e " x _h " i " k " l
-cIN"            a " b " c " d " e " x " g " _ " i " k " l
-ciN"            a " b " c " d " e " x " g "_" i " k " l
-caN"            a " b " c " d " e " x " g _ i " k " l
-cAN"            a " b " c " d " e " x " g _i " k " l
-c1IL"           a " b " c " _ " e " x " g " h " i " k " l
-c1iL"           a " b " c "_" e " x " g " h " i " k " l
-c1aL"           a " b " c _ e " x " g " h " i " k " l
-c1AL"           a " b " c _e " x " g " h " i " k " l
-c1Il"           a " b " c " d " _ " x " g " h " i " k " l
-c1il"           a " b " c " d "_" x " g " h " i " k " l
-c1al"           a " b " c " d _ x " g " h " i " k " l
-c1Al"           a " b " c " d _x " g " h " i " k " l
+cIn"            a " b " c " d " e " x " g " _ " i " k " l
+cin"            a " b " c " d " e " x " g "_" i " k " l
+can"            a " b " c " d " e " x " g _ i " k " l
+cAn"            a " b " c " d " e " x " g _i " k " l
+c1Il"           a " b " c " _ " e " x " g " h " i " k " l
+c1il"           a " b " c "_" e " x " g " h " i " k " l
+c1al"           a " b " c _ e " x " g " h " i " k " l
+c1Al"           a " b " c _e " x " g " h " i " k " l
 c1I"            a " b " c " d " e " _ " g " h " i " k " l
 c1i"            a " b " c " d " e "_" g " h " i " k " l
 c1a"            a " b " c " d " e _ g " h " i " k " l
 c1A"            a " b " c " d " e _g " h " i " k " l
-c1In"           a " b " c " d " e " x " _ " h " i " k " l
-c1in"           a " b " c " d " e " x "_" h " i " k " l
-c1an"           a " b " c " d " e " x _ h " i " k " l
-c1An"           a " b " c " d " e " x _h " i " k " l
-c1IN"           a " b " c " d " e " x " g " _ " i " k " l
-c1iN"           a " b " c " d " e " x " g "_" i " k " l
-c1aN"           a " b " c " d " e " x " g _ i " k " l
-c1AN"           a " b " c " d " e " x " g _i " k " l
-c2IL"           a " _ " c " d " e " x " g " h " i " k " l
-c2iL"           a "_" c " d " e " x " g " h " i " k " l
-c2aL"           a _ c " d " e " x " g " h " i " k " l
-c2AL"           a _c " d " e " x " g " h " i " k " l
-c2Il"           a " b " c " _ " e " x " g " h " i " k " l
-c2il"           a " b " c "_" e " x " g " h " i " k " l
-c2al"           a " b " c _ e " x " g " h " i " k " l
-c2Al"           a " b " c _e " x " g " h " i " k " l
+c1In"           a " b " c " d " e " x " g " _ " i " k " l
+c1in"           a " b " c " d " e " x " g "_" i " k " l
+c1an"           a " b " c " d " e " x " g _ i " k " l
+c1An"           a " b " c " d " e " x " g _i " k " l
+c2Il"           a " _ " c " d " e " x " g " h " i " k " l
+c2il"           a "_" c " d " e " x " g " h " i " k " l
+c2al"           a _ c " d " e " x " g " h " i " k " l
+c2Al"           a _c " d " e " x " g " h " i " k " l
 c2I"            a " b " c " d " e " _ " g " h " i " k " l
 c2i"            a " b " c " d " e "_" g " h " i " k " l
 c2a"            a " b " c " d " e _ g " h " i " k " l
 c2A"            a " b " c " d " e _g " h " i " k " l
-c2In"           a " b " c " d " e " x " g " _ " i " k " l
-c2in"           a " b " c " d " e " x " g "_" i " k " l
-c2an"           a " b " c " d " e " x " g _ i " k " l
-c2An"           a " b " c " d " e " x " g _i " k " l
-c2IN"           a " b " c " d " e " x " g " h " i " _ " l
-c2iN"           a " b " c " d " e " x " g " h " i "_" l
-c2aN"           a " b " c " d " e " x " g " h " i _ l
-c2AN"           a " b " c " d " e " x " g " h " i _l
-dIL"            a " b " c "  " e " x " g " h " i " k " l
-diL"            a " b " c "" e " x " g " h " i " k " l
-daL"            a " b " c  e " x " g " h " i " k " l
-dAL"            a " b " c e " x " g " h " i " k " l
-dIl"            a " b " c " d "  " x " g " h " i " k " l
-dil"            a " b " c " d "" x " g " h " i " k " l
-dal"            a " b " c " d  x " g " h " i " k " l
-dAl"            a " b " c " d x " g " h " i " k " l
+c2In"           a " b " c " d " e " x " g " h " i " _ " l
+c2in"           a " b " c " d " e " x " g " h " i "_" l
+c2an"           a " b " c " d " e " x " g " h " i _ l
+c2An"           a " b " c " d " e " x " g " h " i _l
+dIl"            a " b " c "  " e " x " g " h " i " k " l
+dil"            a " b " c "" e " x " g " h " i " k " l
+dal"            a " b " c  e " x " g " h " i " k " l
+dAl"            a " b " c e " x " g " h " i " k " l
 dI"             a " b " c " d " e "  " g " h " i " k " l
 di"             a " b " c " d " e "" g " h " i " k " l
 da"             a " b " c " d " e  g " h " i " k " l
 dA"             a " b " c " d " e g " h " i " k " l
-dIn"            a " b " c " d " e " x "  " h " i " k " l
-din"            a " b " c " d " e " x "" h " i " k " l
-dan"            a " b " c " d " e " x  h " i " k " l
-dAn"            a " b " c " d " e " x h " i " k " l
-dIN"            a " b " c " d " e " x " g "  " i " k " l
-diN"            a " b " c " d " e " x " g "" i " k " l
-daN"            a " b " c " d " e " x " g  i " k " l
-dAN"            a " b " c " d " e " x " g i " k " l
-d1IL"           a " b " c "  " e " x " g " h " i " k " l
-d1iL"           a " b " c "" e " x " g " h " i " k " l
-d1aL"           a " b " c  e " x " g " h " i " k " l
-d1AL"           a " b " c e " x " g " h " i " k " l
-d1Il"           a " b " c " d "  " x " g " h " i " k " l
-d1il"           a " b " c " d "" x " g " h " i " k " l
-d1al"           a " b " c " d  x " g " h " i " k " l
-d1Al"           a " b " c " d x " g " h " i " k " l
+dIn"            a " b " c " d " e " x " g "  " i " k " l
+din"            a " b " c " d " e " x " g "" i " k " l
+dan"            a " b " c " d " e " x " g  i " k " l
+dAn"            a " b " c " d " e " x " g i " k " l
+d1Il"           a " b " c "  " e " x " g " h " i " k " l
+d1il"           a " b " c "" e " x " g " h " i " k " l
+d1al"           a " b " c  e " x " g " h " i " k " l
+d1Al"           a " b " c e " x " g " h " i " k " l
 d1I"            a " b " c " d " e "  " g " h " i " k " l
 d1i"            a " b " c " d " e "" g " h " i " k " l
 d1a"            a " b " c " d " e  g " h " i " k " l
 d1A"            a " b " c " d " e g " h " i " k " l
-d1In"           a " b " c " d " e " x "  " h " i " k " l
-d1in"           a " b " c " d " e " x "" h " i " k " l
-d1an"           a " b " c " d " e " x  h " i " k " l
-d1An"           a " b " c " d " e " x h " i " k " l
-d1IN"           a " b " c " d " e " x " g "  " i " k " l
-d1iN"           a " b " c " d " e " x " g "" i " k " l
-d1aN"           a " b " c " d " e " x " g  i " k " l
-d1AN"           a " b " c " d " e " x " g i " k " l
-d2IL"           a "  " c " d " e " x " g " h " i " k " l
-d2iL"           a "" c " d " e " x " g " h " i " k " l
-d2aL"           a  c " d " e " x " g " h " i " k " l
-d2AL"           a c " d " e " x " g " h " i " k " l
-d2Il"           a " b " c "  " e " x " g " h " i " k " l
-d2il"           a " b " c "" e " x " g " h " i " k " l
-d2al"           a " b " c  e " x " g " h " i " k " l
-d2Al"           a " b " c e " x " g " h " i " k " l
+d1In"           a " b " c " d " e " x " g "  " i " k " l
+d1in"           a " b " c " d " e " x " g "" i " k " l
+d1an"           a " b " c " d " e " x " g  i " k " l
+d1An"           a " b " c " d " e " x " g i " k " l
+d2Il"           a "  " c " d " e " x " g " h " i " k " l
+d2il"           a "" c " d " e " x " g " h " i " k " l
+d2al"           a  c " d " e " x " g " h " i " k " l
+d2Al"           a c " d " e " x " g " h " i " k " l
 d2I"            a " b " c " d " e "  " g " h " i " k " l
 d2i"            a " b " c " d " e "" g " h " i " k " l
 d2a"            a " b " c " d " e  g " h " i " k " l
 d2A"            a " b " c " d " e g " h " i " k " l
-d2In"           a " b " c " d " e " x " g "  " i " k " l
-d2in"           a " b " c " d " e " x " g "" i " k " l
-d2an"           a " b " c " d " e " x " g  i " k " l
-d2An"           a " b " c " d " e " x " g i " k " l
-d2IN"           a " b " c " d " e " x " g " h " i "  " l
-d2iN"           a " b " c " d " e " x " g " h " i "" l
-d2aN"           a " b " c " d " e " x " g " h " i  l
-d2AN"           a " b " c " d " e " x " g " h " i l
-yIL"            a " b " c " d " e " x " g " h " i " k " l       'd'
-yiL"            a " b " c " d " e " x " g " h " i " k " l       ' d '
-yaL"            a " b " c " d " e " x " g " h " i " k " l       '" d "'
-yAL"            a " b " c " d " e " x " g " h " i " k " l       '" d " '
-yIl"            a " b " c " d " e " x " g " h " i " k " l       'e'
-yil"            a " b " c " d " e " x " g " h " i " k " l       ' e '
-yal"            a " b " c " d " e " x " g " h " i " k " l       '" e "'
-yAl"            a " b " c " d " e " x " g " h " i " k " l       '" e " '
+d2In"           a " b " c " d " e " x " g " h " i "  " l
+d2in"           a " b " c " d " e " x " g " h " i "" l
+d2an"           a " b " c " d " e " x " g " h " i  l
+d2An"           a " b " c " d " e " x " g " h " i l
+yIl"            a " b " c " d " e " x " g " h " i " k " l       'd'
+yil"            a " b " c " d " e " x " g " h " i " k " l       ' d '
+yal"            a " b " c " d " e " x " g " h " i " k " l       '" d "'
+yAl"            a " b " c " d " e " x " g " h " i " k " l       '" d " '
 yI"             a " b " c " d " e " x " g " h " i " k " l       'x'
 yi"             a " b " c " d " e " x " g " h " i " k " l       ' x '
 ya"             a " b " c " d " e " x " g " h " i " k " l       '" x "'
 yA"             a " b " c " d " e " x " g " h " i " k " l       '" x " '
-yIn"            a " b " c " d " e " x " g " h " i " k " l       'g'
-yin"            a " b " c " d " e " x " g " h " i " k " l       ' g '
-yan"            a " b " c " d " e " x " g " h " i " k " l       '" g "'
-yAn"            a " b " c " d " e " x " g " h " i " k " l       '" g " '
-yIN"            a " b " c " d " e " x " g " h " i " k " l       'h'
-yiN"            a " b " c " d " e " x " g " h " i " k " l       ' h '
-yaN"            a " b " c " d " e " x " g " h " i " k " l       '" h "'
-yAN"            a " b " c " d " e " x " g " h " i " k " l       '" h " '
-y1IL"           a " b " c " d " e " x " g " h " i " k " l       'd'
-y1iL"           a " b " c " d " e " x " g " h " i " k " l       ' d '
-y1aL"           a " b " c " d " e " x " g " h " i " k " l       '" d "'
-y1AL"           a " b " c " d " e " x " g " h " i " k " l       '" d " '
-y1Il"           a " b " c " d " e " x " g " h " i " k " l       'e'
-y1il"           a " b " c " d " e " x " g " h " i " k " l       ' e '
-y1al"           a " b " c " d " e " x " g " h " i " k " l       '" e "'
-y1Al"           a " b " c " d " e " x " g " h " i " k " l       '" e " '
+yIn"            a " b " c " d " e " x " g " h " i " k " l       'h'
+yin"            a " b " c " d " e " x " g " h " i " k " l       ' h '
+yan"            a " b " c " d " e " x " g " h " i " k " l       '" h "'
+yAn"            a " b " c " d " e " x " g " h " i " k " l       '" h " '
+y1Il"           a " b " c " d " e " x " g " h " i " k " l       'd'
+y1il"           a " b " c " d " e " x " g " h " i " k " l       ' d '
+y1al"           a " b " c " d " e " x " g " h " i " k " l       '" d "'
+y1Al"           a " b " c " d " e " x " g " h " i " k " l       '" d " '
 y1I"            a " b " c " d " e " x " g " h " i " k " l       'x'
 y1i"            a " b " c " d " e " x " g " h " i " k " l       ' x '
 y1a"            a " b " c " d " e " x " g " h " i " k " l       '" x "'
 y1A"            a " b " c " d " e " x " g " h " i " k " l       '" x " '
-y1In"           a " b " c " d " e " x " g " h " i " k " l       'g'
-y1in"           a " b " c " d " e " x " g " h " i " k " l       ' g '
-y1an"           a " b " c " d " e " x " g " h " i " k " l       '" g "'
-y1An"           a " b " c " d " e " x " g " h " i " k " l       '" g " '
-y1IN"           a " b " c " d " e " x " g " h " i " k " l       'h'
-y1iN"           a " b " c " d " e " x " g " h " i " k " l       ' h '
-y1aN"           a " b " c " d " e " x " g " h " i " k " l       '" h "'
-y1AN"           a " b " c " d " e " x " g " h " i " k " l       '" h " '
-y2IL"           a " b " c " d " e " x " g " h " i " k " l       'b'
-y2iL"           a " b " c " d " e " x " g " h " i " k " l       ' b '
-y2aL"           a " b " c " d " e " x " g " h " i " k " l       '" b "'
-y2AL"           a " b " c " d " e " x " g " h " i " k " l       '" b " '
-y2Il"           a " b " c " d " e " x " g " h " i " k " l       'd'
-y2il"           a " b " c " d " e " x " g " h " i " k " l       ' d '
-y2al"           a " b " c " d " e " x " g " h " i " k " l       '" d "'
-y2Al"           a " b " c " d " e " x " g " h " i " k " l       '" d " '
+y1In"           a " b " c " d " e " x " g " h " i " k " l       'h'
+y1in"           a " b " c " d " e " x " g " h " i " k " l       ' h '
+y1an"           a " b " c " d " e " x " g " h " i " k " l       '" h "'
+y1An"           a " b " c " d " e " x " g " h " i " k " l       '" h " '
+y2Il"           a " b " c " d " e " x " g " h " i " k " l       'b'
+y2il"           a " b " c " d " e " x " g " h " i " k " l       ' b '
+y2al"           a " b " c " d " e " x " g " h " i " k " l       '" b "'
+y2Al"           a " b " c " d " e " x " g " h " i " k " l       '" b " '
 y2I"            a " b " c " d " e " x " g " h " i " k " l       'x'
 y2i"            a " b " c " d " e " x " g " h " i " k " l       ' x '
 y2a"            a " b " c " d " e " x " g " h " i " k " l       '" x "'
 y2A"            a " b " c " d " e " x " g " h " i " k " l       '" x " '
-y2In"           a " b " c " d " e " x " g " h " i " k " l       'h'
-y2in"           a " b " c " d " e " x " g " h " i " k " l       ' h '
-y2an"           a " b " c " d " e " x " g " h " i " k " l       '" h "'
-y2An"           a " b " c " d " e " x " g " h " i " k " l       '" h " '
-y2IN"           a " b " c " d " e " x " g " h " i " k " l       'k'
-y2iN"           a " b " c " d " e " x " g " h " i " k " l       ' k '
-y2aN"           a " b " c " d " e " x " g " h " i " k " l       '" k "'
-y2AN"           a " b " c " d " e " x " g " h " i " k " l       '" k " '
-vIL"            a " b " c " _ " e " x " g " h " i " k " l
-viL"            a " b " c "___" e " x " g " h " i " k " l
-vaL"            a " b " c _____ e " x " g " h " i " k " l
-vAL"            a " b " c ______e " x " g " h " i " k " l
-vIl"            a " b " c " d " _ " x " g " h " i " k " l
-vil"            a " b " c " d "___" x " g " h " i " k " l
-val"            a " b " c " d _____ x " g " h " i " k " l
-vAl"            a " b " c " d ______x " g " h " i " k " l
+y2In"           a " b " c " d " e " x " g " h " i " k " l       'k'
+y2in"           a " b " c " d " e " x " g " h " i " k " l       ' k '
+y2an"           a " b " c " d " e " x " g " h " i " k " l       '" k "'
+y2An"           a " b " c " d " e " x " g " h " i " k " l       '" k " '
+vIl"            a " b " c " _ " e " x " g " h " i " k " l
+vil"            a " b " c "___" e " x " g " h " i " k " l
+val"            a " b " c _____ e " x " g " h " i " k " l
+vAl"            a " b " c ______e " x " g " h " i " k " l
 vI"             a " b " c " d " e " _ " g " h " i " k " l
 vi"             a " b " c " d " e "___" g " h " i " k " l
 va"             a " b " c " d " e _____ g " h " i " k " l
 vA"             a " b " c " d " e ______g " h " i " k " l
-vIn"            a " b " c " d " e " x " _ " h " i " k " l
-vin"            a " b " c " d " e " x "___" h " i " k " l
-van"            a " b " c " d " e " x _____ h " i " k " l
-vAn"            a " b " c " d " e " x ______h " i " k " l
-vIN"            a " b " c " d " e " x " g " _ " i " k " l
-viN"            a " b " c " d " e " x " g "___" i " k " l
-vaN"            a " b " c " d " e " x " g _____ i " k " l
-vAN"            a " b " c " d " e " x " g ______i " k " l
-v1IL"           a " b " c " _ " e " x " g " h " i " k " l
-v1iL"           a " b " c "___" e " x " g " h " i " k " l
-v1aL"           a " b " c _____ e " x " g " h " i " k " l
-v1AL"           a " b " c ______e " x " g " h " i " k " l
-v1Il"           a " b " c " d " _ " x " g " h " i " k " l
-v1il"           a " b " c " d "___" x " g " h " i " k " l
-v1al"           a " b " c " d _____ x " g " h " i " k " l
-v1Al"           a " b " c " d ______x " g " h " i " k " l
+vIn"            a " b " c " d " e " x " g " _ " i " k " l
+vin"            a " b " c " d " e " x " g "___" i " k " l
+van"            a " b " c " d " e " x " g _____ i " k " l
+vAn"            a " b " c " d " e " x " g ______i " k " l
+v1Il"           a " b " c " _ " e " x " g " h " i " k " l
+v1il"           a " b " c "___" e " x " g " h " i " k " l
+v1al"           a " b " c _____ e " x " g " h " i " k " l
+v1Al"           a " b " c ______e " x " g " h " i " k " l
 v1I"            a " b " c " d " e " _ " g " h " i " k " l
 v1i"            a " b " c " d " e "___" g " h " i " k " l
 v1a"            a " b " c " d " e _____ g " h " i " k " l
 v1A"            a " b " c " d " e ______g " h " i " k " l
-v1In"           a " b " c " d " e " x " _ " h " i " k " l
-v1in"           a " b " c " d " e " x "___" h " i " k " l
-v1an"           a " b " c " d " e " x _____ h " i " k " l
-v1An"           a " b " c " d " e " x ______h " i " k " l
-v1IN"           a " b " c " d " e " x " g " _ " i " k " l
-v1iN"           a " b " c " d " e " x " g "___" i " k " l
-v1aN"           a " b " c " d " e " x " g _____ i " k " l
-v1AN"           a " b " c " d " e " x " g ______i " k " l
-v2IL"           a " _ " c " d " e " x " g " h " i " k " l
-v2iL"           a "___" c " d " e " x " g " h " i " k " l
-v2aL"           a _____ c " d " e " x " g " h " i " k " l
-v2AL"           a ______c " d " e " x " g " h " i " k " l
-v2Il"           a " b " c " _ " e " x " g " h " i " k " l
-v2il"           a " b " c "___" e " x " g " h " i " k " l
-v2al"           a " b " c _____ e " x " g " h " i " k " l
-v2Al"           a " b " c ______e " x " g " h " i " k " l
+v1In"           a " b " c " d " e " x " g " _ " i " k " l
+v1in"           a " b " c " d " e " x " g "___" i " k " l
+v1an"           a " b " c " d " e " x " g _____ i " k " l
+v1An"           a " b " c " d " e " x " g ______i " k " l
+v2Il"           a " _ " c " d " e " x " g " h " i " k " l
+v2il"           a "___" c " d " e " x " g " h " i " k " l
+v2al"           a _____ c " d " e " x " g " h " i " k " l
+v2Al"           a ______c " d " e " x " g " h " i " k " l
 v2I"            a " b " c " d " e " _ " g " h " i " k " l
 v2i"            a " b " c " d " e "___" g " h " i " k " l
 v2a"            a " b " c " d " e _____ g " h " i " k " l
 v2A"            a " b " c " d " e ______g " h " i " k " l
-v2In"           a " b " c " d " e " x " g " _ " i " k " l
-v2in"           a " b " c " d " e " x " g "___" i " k " l
-v2an"           a " b " c " d " e " x " g _____ i " k " l
-v2An"           a " b " c " d " e " x " g ______i " k " l
-v2IN"           a " b " c " d " e " x " g " h " i " _ " l
-v2iN"           a " b " c " d " e " x " g " h " i "___" l
-v2aN"           a " b " c " d " e " x " g " h " i _____ l
-v2AN"           a " b " c " d " e " x " g " h " i ______l
+v2In"           a " b " c " d " e " x " g " h " i " _ " l
+v2in"           a " b " c " d " e " x " g " h " i "___" l
+v2an"           a " b " c " d " e " x " g " h " i _____ l
+v2An"           a " b " c " d " e " x " g " h " i ______l
 a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l
-cIL`            a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
-ciL`            a ` b ` c `_` e ` x ` g ` h ` i ` k ` l
-caL`            a ` b ` c _ e ` x ` g ` h ` i ` k ` l
-cAL`            a ` b ` c _e ` x ` g ` h ` i ` k ` l
-cIl`            a ` b ` c ` d ` _ ` x ` g ` h ` i ` k ` l
-cil`            a ` b ` c ` d `_` x ` g ` h ` i ` k ` l
-cal`            a ` b ` c ` d _ x ` g ` h ` i ` k ` l
-cAl`            a ` b ` c ` d _x ` g ` h ` i ` k ` l
+cIl`            a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
+cil`            a ` b ` c `_` e ` x ` g ` h ` i ` k ` l
+cal`            a ` b ` c _ e ` x ` g ` h ` i ` k ` l
+cAl`            a ` b ` c _e ` x ` g ` h ` i ` k ` l
 cI`             a ` b ` c ` d ` e ` _ ` g ` h ` i ` k ` l
 ci`             a ` b ` c ` d ` e `_` g ` h ` i ` k ` l
 ca`             a ` b ` c ` d ` e _ g ` h ` i ` k ` l
 cA`             a ` b ` c ` d ` e _g ` h ` i ` k ` l
-cIn`            a ` b ` c ` d ` e ` x ` _ ` h ` i ` k ` l
-cin`            a ` b ` c ` d ` e ` x `_` h ` i ` k ` l
-can`            a ` b ` c ` d ` e ` x _ h ` i ` k ` l
-cAn`            a ` b ` c ` d ` e ` x _h ` i ` k ` l
-cIN`            a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
-ciN`            a ` b ` c ` d ` e ` x ` g `_` i ` k ` l
-caN`            a ` b ` c ` d ` e ` x ` g _ i ` k ` l
-cAN`            a ` b ` c ` d ` e ` x ` g _i ` k ` l
-c1IL`           a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
-c1iL`           a ` b ` c `_` e ` x ` g ` h ` i ` k ` l
-c1aL`           a ` b ` c _ e ` x ` g ` h ` i ` k ` l
-c1AL`           a ` b ` c _e ` x ` g ` h ` i ` k ` l
-c1Il`           a ` b ` c ` d ` _ ` x ` g ` h ` i ` k ` l
-c1il`           a ` b ` c ` d `_` x ` g ` h ` i ` k ` l
-c1al`           a ` b ` c ` d _ x ` g ` h ` i ` k ` l
-c1Al`           a ` b ` c ` d _x ` g ` h ` i ` k ` l
+cIn`            a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
+cin`            a ` b ` c ` d ` e ` x ` g `_` i ` k ` l
+can`            a ` b ` c ` d ` e ` x ` g _ i ` k ` l
+cAn`            a ` b ` c ` d ` e ` x ` g _i ` k ` l
+c1Il`           a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
+c1il`           a ` b ` c `_` e ` x ` g ` h ` i ` k ` l
+c1al`           a ` b ` c _ e ` x ` g ` h ` i ` k ` l
+c1Al`           a ` b ` c _e ` x ` g ` h ` i ` k ` l
 c1I`            a ` b ` c ` d ` e ` _ ` g ` h ` i ` k ` l
 c1i`            a ` b ` c ` d ` e `_` g ` h ` i ` k ` l
 c1a`            a ` b ` c ` d ` e _ g ` h ` i ` k ` l
 c1A`            a ` b ` c ` d ` e _g ` h ` i ` k ` l
-c1In`           a ` b ` c ` d ` e ` x ` _ ` h ` i ` k ` l
-c1in`           a ` b ` c ` d ` e ` x `_` h ` i ` k ` l
-c1an`           a ` b ` c ` d ` e ` x _ h ` i ` k ` l
-c1An`           a ` b ` c ` d ` e ` x _h ` i ` k ` l
-c1IN`           a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
-c1iN`           a ` b ` c ` d ` e ` x ` g `_` i ` k ` l
-c1aN`           a ` b ` c ` d ` e ` x ` g _ i ` k ` l
-c1AN`           a ` b ` c ` d ` e ` x ` g _i ` k ` l
-c2IL`           a ` _ ` c ` d ` e ` x ` g ` h ` i ` k ` l
-c2iL`           a `_` c ` d ` e ` x ` g ` h ` i ` k ` l
-c2aL`           a _ c ` d ` e ` x ` g ` h ` i ` k ` l
-c2AL`           a _c ` d ` e ` x ` g ` h ` i ` k ` l
-c2Il`           a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
-c2il`           a ` b ` c `_` e ` x ` g ` h ` i ` k ` l
-c2al`           a ` b ` c _ e ` x ` g ` h ` i ` k ` l
-c2Al`           a ` b ` c _e ` x ` g ` h ` i ` k ` l
+c1In`           a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
+c1in`           a ` b ` c ` d ` e ` x ` g `_` i ` k ` l
+c1an`           a ` b ` c ` d ` e ` x ` g _ i ` k ` l
+c1An`           a ` b ` c ` d ` e ` x ` g _i ` k ` l
+c2Il`           a ` _ ` c ` d ` e ` x ` g ` h ` i ` k ` l
+c2il`           a `_` c ` d ` e ` x ` g ` h ` i ` k ` l
+c2al`           a _ c ` d ` e ` x ` g ` h ` i ` k ` l
+c2Al`           a _c ` d ` e ` x ` g ` h ` i ` k ` l
 c2I`            a ` b ` c ` d ` e ` _ ` g ` h ` i ` k ` l
 c2i`            a ` b ` c ` d ` e `_` g ` h ` i ` k ` l
 c2a`            a ` b ` c ` d ` e _ g ` h ` i ` k ` l
 c2A`            a ` b ` c ` d ` e _g ` h ` i ` k ` l
-c2In`           a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
-c2in`           a ` b ` c ` d ` e ` x ` g `_` i ` k ` l
-c2an`           a ` b ` c ` d ` e ` x ` g _ i ` k ` l
-c2An`           a ` b ` c ` d ` e ` x ` g _i ` k ` l
-c2IN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` _ ` l
-c2iN`           a ` b ` c ` d ` e ` x ` g ` h ` i `_` l
-c2aN`           a ` b ` c ` d ` e ` x ` g ` h ` i _ l
-c2AN`           a ` b ` c ` d ` e ` x ` g ` h ` i _l
-dIL`            a ` b ` c `  ` e ` x ` g ` h ` i ` k ` l
-diL`            a ` b ` c `` e ` x ` g ` h ` i ` k ` l
-daL`            a ` b ` c  e ` x ` g ` h ` i ` k ` l
-dAL`            a ` b ` c e ` x ` g ` h ` i ` k ` l
-dIl`            a ` b ` c ` d `  ` x ` g ` h ` i ` k ` l
-dil`            a ` b ` c ` d `` x ` g ` h ` i ` k ` l
-dal`            a ` b ` c ` d  x ` g ` h ` i ` k ` l
-dAl`            a ` b ` c ` d x ` g ` h ` i ` k ` l
+c2In`           a ` b ` c ` d ` e ` x ` g ` h ` i ` _ ` l
+c2in`           a ` b ` c ` d ` e ` x ` g ` h ` i `_` l
+c2an`           a ` b ` c ` d ` e ` x ` g ` h ` i _ l
+c2An`           a ` b ` c ` d ` e ` x ` g ` h ` i _l
+dIl`            a ` b ` c `  ` e ` x ` g ` h ` i ` k ` l
+dil`            a ` b ` c `` e ` x ` g ` h ` i ` k ` l
+dal`            a ` b ` c  e ` x ` g ` h ` i ` k ` l
+dAl`            a ` b ` c e ` x ` g ` h ` i ` k ` l
 dI`             a ` b ` c ` d ` e `  ` g ` h ` i ` k ` l
 di`             a ` b ` c ` d ` e `` g ` h ` i ` k ` l
 da`             a ` b ` c ` d ` e  g ` h ` i ` k ` l
 dA`             a ` b ` c ` d ` e g ` h ` i ` k ` l
-dIn`            a ` b ` c ` d ` e ` x `  ` h ` i ` k ` l
-din`            a ` b ` c ` d ` e ` x `` h ` i ` k ` l
-dan`            a ` b ` c ` d ` e ` x  h ` i ` k ` l
-dAn`            a ` b ` c ` d ` e ` x h ` i ` k ` l
-dIN`            a ` b ` c ` d ` e ` x ` g `  ` i ` k ` l
-diN`            a ` b ` c ` d ` e ` x ` g `` i ` k ` l
-daN`            a ` b ` c ` d ` e ` x ` g  i ` k ` l
-dAN`            a ` b ` c ` d ` e ` x ` g i ` k ` l
-d1IL`           a ` b ` c `  ` e ` x ` g ` h ` i ` k ` l
-d1iL`           a ` b ` c `` e ` x ` g ` h ` i ` k ` l
-d1aL`           a ` b ` c  e ` x ` g ` h ` i ` k ` l
-d1AL`           a ` b ` c e ` x ` g ` h ` i ` k ` l
-d1Il`           a ` b ` c ` d `  ` x ` g ` h ` i ` k ` l
-d1il`           a ` b ` c ` d `` x ` g ` h ` i ` k ` l
-d1al`           a ` b ` c ` d  x ` g ` h ` i ` k ` l
-d1Al`           a ` b ` c ` d x ` g ` h ` i ` k ` l
+dIn`            a ` b ` c ` d ` e ` x ` g `  ` i ` k ` l
+din`            a ` b ` c ` d ` e ` x ` g `` i ` k ` l
+dan`            a ` b ` c ` d ` e ` x ` g  i ` k ` l
+dAn`            a ` b ` c ` d ` e ` x ` g i ` k ` l
+d1Il`           a ` b ` c `  ` e ` x ` g ` h ` i ` k ` l
+d1il`           a ` b ` c `` e ` x ` g ` h ` i ` k ` l
+d1al`           a ` b ` c  e ` x ` g ` h ` i ` k ` l
+d1Al`           a ` b ` c e ` x ` g ` h ` i ` k ` l
 d1I`            a ` b ` c ` d ` e `  ` g ` h ` i ` k ` l
 d1i`            a ` b ` c ` d ` e `` g ` h ` i ` k ` l
 d1a`            a ` b ` c ` d ` e  g ` h ` i ` k ` l
 d1A`            a ` b ` c ` d ` e g ` h ` i ` k ` l
-d1In`           a ` b ` c ` d ` e ` x `  ` h ` i ` k ` l
-d1in`           a ` b ` c ` d ` e ` x `` h ` i ` k ` l
-d1an`           a ` b ` c ` d ` e ` x  h ` i ` k ` l
-d1An`           a ` b ` c ` d ` e ` x h ` i ` k ` l
-d1IN`           a ` b ` c ` d ` e ` x ` g `  ` i ` k ` l
-d1iN`           a ` b ` c ` d ` e ` x ` g `` i ` k ` l
-d1aN`           a ` b ` c ` d ` e ` x ` g  i ` k ` l
-d1AN`           a ` b ` c ` d ` e ` x ` g i ` k ` l
-d2IL`           a `  ` c ` d ` e ` x ` g ` h ` i ` k ` l
-d2iL`           a `` c ` d ` e ` x ` g ` h ` i ` k ` l
-d2aL`           a  c ` d ` e ` x ` g ` h ` i ` k ` l
-d2AL`           a c ` d ` e ` x ` g ` h ` i ` k ` l
-d2Il`           a ` b ` c `  ` e ` x ` g ` h ` i ` k ` l
-d2il`           a ` b ` c `` e ` x ` g ` h ` i ` k ` l
-d2al`           a ` b ` c  e ` x ` g ` h ` i ` k ` l
-d2Al`           a ` b ` c e ` x ` g ` h ` i ` k ` l
+d1In`           a ` b ` c ` d ` e ` x ` g `  ` i ` k ` l
+d1in`           a ` b ` c ` d ` e ` x ` g `` i ` k ` l
+d1an`           a ` b ` c ` d ` e ` x ` g  i ` k ` l
+d1An`           a ` b ` c ` d ` e ` x ` g i ` k ` l
+d2Il`           a `  ` c ` d ` e ` x ` g ` h ` i ` k ` l
+d2il`           a `` c ` d ` e ` x ` g ` h ` i ` k ` l
+d2al`           a  c ` d ` e ` x ` g ` h ` i ` k ` l
+d2Al`           a c ` d ` e ` x ` g ` h ` i ` k ` l
 d2I`            a ` b ` c ` d ` e `  ` g ` h ` i ` k ` l
 d2i`            a ` b ` c ` d ` e `` g ` h ` i ` k ` l
 d2a`            a ` b ` c ` d ` e  g ` h ` i ` k ` l
 d2A`            a ` b ` c ` d ` e g ` h ` i ` k ` l
-d2In`           a ` b ` c ` d ` e ` x ` g `  ` i ` k ` l
-d2in`           a ` b ` c ` d ` e ` x ` g `` i ` k ` l
-d2an`           a ` b ` c ` d ` e ` x ` g  i ` k ` l
-d2An`           a ` b ` c ` d ` e ` x ` g i ` k ` l
-d2IN`           a ` b ` c ` d ` e ` x ` g ` h ` i `  ` l
-d2iN`           a ` b ` c ` d ` e ` x ` g ` h ` i `` l
-d2aN`           a ` b ` c ` d ` e ` x ` g ` h ` i  l
-d2AN`           a ` b ` c ` d ` e ` x ` g ` h ` i l
-yIL`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'd'
-yiL`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' d '
-yaL`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d `'
-yAL`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d ` '
-yIl`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'e'
-yil`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' e '
-yal`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` e `'
-yAl`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` e ` '
+d2In`           a ` b ` c ` d ` e ` x ` g ` h ` i `  ` l
+d2in`           a ` b ` c ` d ` e ` x ` g ` h ` i `` l
+d2an`           a ` b ` c ` d ` e ` x ` g ` h ` i  l
+d2An`           a ` b ` c ` d ` e ` x ` g ` h ` i l
+yIl`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'd'
+yil`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' d '
+yal`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d `'
+yAl`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d ` '
 yI`             a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'x'
 yi`             a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' x '
 ya`             a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` x `'
 yA`             a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` x ` '
-yIn`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'g'
-yin`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' g '
-yan`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` g `'
-yAn`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` g ` '
-yIN`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'h'
-yiN`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' h '
-yaN`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h `'
-yAN`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h ` '
-y1IL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'd'
-y1iL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' d '
-y1aL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d `'
-y1AL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d ` '
-y1Il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'e'
-y1il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' e '
-y1al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` e `'
-y1Al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` e ` '
+yIn`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'h'
+yin`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' h '
+yan`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h `'
+yAn`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h ` '
+y1Il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'd'
+y1il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' d '
+y1al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d `'
+y1Al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d ` '
 y1I`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'x'
 y1i`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' x '
 y1a`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` x `'
 y1A`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` x ` '
-y1In`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'g'
-y1in`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' g '
-y1an`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` g `'
-y1An`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` g ` '
-y1IN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'h'
-y1iN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' h '
-y1aN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h `'
-y1AN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h ` '
-y2IL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'b'
-y2iL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' b '
-y2aL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` b `'
-y2AL`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` b ` '
-y2Il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'd'
-y2il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' d '
-y2al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d `'
-y2Al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` d ` '
+y1In`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'h'
+y1in`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' h '
+y1an`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h `'
+y1An`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h ` '
+y2Il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'b'
+y2il`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' b '
+y2al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` b `'
+y2Al`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` b ` '
 y2I`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'x'
 y2i`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' x '
 y2a`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` x `'
 y2A`            a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` x ` '
-y2In`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'h'
-y2in`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' h '
-y2an`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h `'
-y2An`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` h ` '
-y2IN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'k'
-y2iN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' k '
-y2aN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` k `'
-y2AN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` k ` '
-vIL`            a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
-viL`            a ` b ` c `___` e ` x ` g ` h ` i ` k ` l
-vaL`            a ` b ` c _____ e ` x ` g ` h ` i ` k ` l
-vAL`            a ` b ` c ______e ` x ` g ` h ` i ` k ` l
-vIl`            a ` b ` c ` d ` _ ` x ` g ` h ` i ` k ` l
-vil`            a ` b ` c ` d `___` x ` g ` h ` i ` k ` l
-val`            a ` b ` c ` d _____ x ` g ` h ` i ` k ` l
-vAl`            a ` b ` c ` d ______x ` g ` h ` i ` k ` l
+y2In`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       'k'
+y2in`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       ' k '
+y2an`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` k `'
+y2An`           a ` b ` c ` d ` e ` x ` g ` h ` i ` k ` l       '` k ` '
+vIl`            a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
+vil`            a ` b ` c `___` e ` x ` g ` h ` i ` k ` l
+val`            a ` b ` c _____ e ` x ` g ` h ` i ` k ` l
+vAl`            a ` b ` c ______e ` x ` g ` h ` i ` k ` l
 vI`             a ` b ` c ` d ` e ` _ ` g ` h ` i ` k ` l
 vi`             a ` b ` c ` d ` e `___` g ` h ` i ` k ` l
 va`             a ` b ` c ` d ` e _____ g ` h ` i ` k ` l
 vA`             a ` b ` c ` d ` e ______g ` h ` i ` k ` l
-vIn`            a ` b ` c ` d ` e ` x ` _ ` h ` i ` k ` l
-vin`            a ` b ` c ` d ` e ` x `___` h ` i ` k ` l
-van`            a ` b ` c ` d ` e ` x _____ h ` i ` k ` l
-vAn`            a ` b ` c ` d ` e ` x ______h ` i ` k ` l
-vIN`            a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
-viN`            a ` b ` c ` d ` e ` x ` g `___` i ` k ` l
-vaN`            a ` b ` c ` d ` e ` x ` g _____ i ` k ` l
-vAN`            a ` b ` c ` d ` e ` x ` g ______i ` k ` l
-v1IL`           a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
-v1iL`           a ` b ` c `___` e ` x ` g ` h ` i ` k ` l
-v1aL`           a ` b ` c _____ e ` x ` g ` h ` i ` k ` l
-v1AL`           a ` b ` c ______e ` x ` g ` h ` i ` k ` l
-v1Il`           a ` b ` c ` d ` _ ` x ` g ` h ` i ` k ` l
-v1il`           a ` b ` c ` d `___` x ` g ` h ` i ` k ` l
-v1al`           a ` b ` c ` d _____ x ` g ` h ` i ` k ` l
-v1Al`           a ` b ` c ` d ______x ` g ` h ` i ` k ` l
+vIn`            a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
+vin`            a ` b ` c ` d ` e ` x ` g `___` i ` k ` l
+van`            a ` b ` c ` d ` e ` x ` g _____ i ` k ` l
+vAn`            a ` b ` c ` d ` e ` x ` g ______i ` k ` l
+v1Il`           a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
+v1il`           a ` b ` c `___` e ` x ` g ` h ` i ` k ` l
+v1al`           a ` b ` c _____ e ` x ` g ` h ` i ` k ` l
+v1Al`           a ` b ` c ______e ` x ` g ` h ` i ` k ` l
 v1I`            a ` b ` c ` d ` e ` _ ` g ` h ` i ` k ` l
 v1i`            a ` b ` c ` d ` e `___` g ` h ` i ` k ` l
 v1a`            a ` b ` c ` d ` e _____ g ` h ` i ` k ` l
 v1A`            a ` b ` c ` d ` e ______g ` h ` i ` k ` l
-v1In`           a ` b ` c ` d ` e ` x ` _ ` h ` i ` k ` l
-v1in`           a ` b ` c ` d ` e ` x `___` h ` i ` k ` l
-v1an`           a ` b ` c ` d ` e ` x _____ h ` i ` k ` l
-v1An`           a ` b ` c ` d ` e ` x ______h ` i ` k ` l
-v1IN`           a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
-v1iN`           a ` b ` c ` d ` e ` x ` g `___` i ` k ` l
-v1aN`           a ` b ` c ` d ` e ` x ` g _____ i ` k ` l
-v1AN`           a ` b ` c ` d ` e ` x ` g ______i ` k ` l
-v2IL`           a ` _ ` c ` d ` e ` x ` g ` h ` i ` k ` l
-v2iL`           a `___` c ` d ` e ` x ` g ` h ` i ` k ` l
-v2aL`           a _____ c ` d ` e ` x ` g ` h ` i ` k ` l
-v2AL`           a ______c ` d ` e ` x ` g ` h ` i ` k ` l
-v2Il`           a ` b ` c ` _ ` e ` x ` g ` h ` i ` k ` l
-v2il`           a ` b ` c `___` e ` x ` g ` h ` i ` k ` l
-v2al`           a ` b ` c _____ e ` x ` g ` h ` i ` k ` l
-v2Al`           a ` b ` c ______e ` x ` g ` h ` i ` k ` l
+v1In`           a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
+v1in`           a ` b ` c ` d ` e ` x ` g `___` i ` k ` l
+v1an`           a ` b ` c ` d ` e ` x ` g _____ i ` k ` l
+v1An`           a ` b ` c ` d ` e ` x ` g ______i ` k ` l
+v2Il`           a ` _ ` c ` d ` e ` x ` g ` h ` i ` k ` l
+v2il`           a `___` c ` d ` e ` x ` g ` h ` i ` k ` l
+v2al`           a _____ c ` d ` e ` x ` g ` h ` i ` k ` l
+v2Al`           a ______c ` d ` e ` x ` g ` h ` i ` k ` l
 v2I`            a ` b ` c ` d ` e ` _ ` g ` h ` i ` k ` l
 v2i`            a ` b ` c ` d ` e `___` g ` h ` i ` k ` l
 v2a`            a ` b ` c ` d ` e _____ g ` h ` i ` k ` l
 v2A`            a ` b ` c ` d ` e ______g ` h ` i ` k ` l
-v2In`           a ` b ` c ` d ` e ` x ` g ` _ ` i ` k ` l
-v2in`           a ` b ` c ` d ` e ` x ` g `___` i ` k ` l
-v2an`           a ` b ` c ` d ` e ` x ` g _____ i ` k ` l
-v2An`           a ` b ` c ` d ` e ` x ` g ______i ` k ` l
-v2IN`           a ` b ` c ` d ` e ` x ` g ` h ` i ` _ ` l
-v2iN`           a ` b ` c ` d ` e ` x ` g ` h ` i `___` l
-v2aN`           a ` b ` c ` d ` e ` x ` g ` h ` i _____ l
-v2AN`           a ` b ` c ` d ` e ` x ` g ` h ` i ______l
+v2In`           a ` b ` c ` d ` e ` x ` g ` h ` i ` _ ` l
+v2in`           a ` b ` c ` d ` e ` x ` g ` h ` i `___` l
+v2an`           a ` b ` c ` d ` e ` x ` g ` h ` i _____ l
+v2An`           a ` b ` c ` d ` e ` x ` g ` h ` i ______l
 
 a , b , c , d , e , x , g , h , i , k , l
 cIL,            a , b , c , _ , e , x , g , h , i , k , l

--- a/test/test7.in
+++ b/test/test7.in
@@ -1,0 +1,16 @@
+x "a" "b" c
+x "a" "b" c
+x "a" "b" c
+a "b" "c" x "d" "e" f
+a "b" "c" x "d" "e" f
+a "b" "c" x "d" "e" f
+a "b" "c" x "d" "e" f
+a "b" "c" x "d" "e" f
+a "b" "c" "x" "d" "e" f
+a "b" "c" "x" "d" "e" f
+a "b" "c" "x" "d" "e" f
+a "b" "c" "x" "d" "e" f
+a "b" "c" "x" "d" "e" f
+a "b" "c" x
+a "b" "c" x
+a "b" "c" x

--- a/test/test7.ok
+++ b/test/test7.ok
@@ -1,0 +1,16 @@
+x "A" "b" c
+x "A" "b" c
+x "a" "B" c
+a "b" "c" x "D" "e" f
+a "b" "c" x "D" "e" f
+a "b" "c" x "d" "E" f
+a "b" "C" x "d" "e" f
+a "B" "c" x "d" "e" f
+a "b" "c" "X" "d" "e" f
+a "b" "c" "x" "D" "e" f
+a "b" "c" "x" "d" "E" f
+a "b" "C" "x" "d" "e" f
+a "B" "c" "x" "d" "e" f
+a "b" "C" x
+a "b" "C" x
+a "B" "c" x

--- a/test/test7.out
+++ b/test/test7.out
@@ -1,0 +1,16 @@
+x "A" "b" c
+x "A" "b" c
+x "a" "B" c
+a "b" "c" x "D" "e" f
+a "b" "c" x "D" "e" f
+a "b" "c" x "d" "E" f
+a "b" "C" x "d" "e" f
+a "B" "c" x "d" "e" f
+a "b" "c" "X" "d" "e" f
+a "b" "c" "x" "D" "e" f
+a "b" "c" "x" "d" "E" f
+a "b" "C" "x" "d" "e" f
+a "B" "c" "x" "d" "e" f
+a "b" "C" x
+a "b" "C" x
+a "B" "c" x


### PR DESCRIPTION
This PR tries to improve quote text by improving its seeking behavior.

Stock Vim already allows you to seek into a quote text object to the right:
```vim
echo "Hello " . world
```
With the cursor on `echo` typing `ci"` seeks into the quote to change `Hello`.

targets.vim already added seeking to the left, so the same as above would also work with the cursor on `world` (which in Stock Vim doesn't work).

targets.vim also does the same for pair text objects:
```vim
return (a+b), c
```
With the cursor on `return` or `c`, type `ci(` (or `cib`) to change `a+b`.

Since pairs of braces have a direction that can be used to match each other, seeking from within pair text objects also works:
```vim
return (pair1), s, (pair2)
```
With the cursor on `s`, `cib` seeks to the right to change `pair2`.

And the same works for argument text objects too, and basically any text object targets.vim provides. For separator text objects this doesn't apply because the end of one of those is the beginning of the next one.

The only place where this didn't work previously was quote text objects:
```vim
return "quote1", s, "quote2"
```
With the cursor again on `s`, typing `ci"` would change the false quote `, s, `, leaving you with
```vim
return "quote1""quote2"
```

This PR changes the quote text objects to seek into the next proper quote to the right in that case, leaving you with
```vim
return "quote1", s, ""
```

So the idea is that target.vim checks the local quotation marks to decide what is a proper quote and what isn't. And then tries to only operate on those proper quote text objects.

If you find any real use case where this fails or works in a surprising way, please let me know.