### PR TITLE
Add another seekRanges example to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,11 @@ beginning or ending on the cursor are preferred over everything else.
 
 Some other useful example settings:
 
+Prefer multiline targets around cursor over distant targets within cursor line:
+```vim
+let g:targets_seekRanges = 'cr cb cB lc ac Ac lr lb ar ab lB Ar aB Ab AB rr ll rb al rB Al bb aa bB Aa BB AA'
+```
+
 Never seek backwards:
 ```vim
 let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr lb ar ab lB Ar aB Ab AB rb rB bb bB BB'

--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -242,6 +242,11 @@ beginning or ending on the cursor are preferred over everything else.
 
 Some other useful example settings:
 
+Prefer multiline targets around cursor over distant targets within cursor line:
+```vim
+let g:targets_seekRanges = 'cr cb cB lc ac Ac lr lb ar ab lB Ar aB Ab AB rr ll rb al rB Al bb aa bB Aa BB AA'
+```
+
 Never seek backwards:
 ```vim
 let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr lb ar ab lB Ar aB Ab AB rb rB bb bB BB'

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -699,6 +699,9 @@ beginning or ending on the cursor are preferred over everything else.
 
 Some other useful example settings (or build your own!):
 
+Prefer multiline targets around cursor over distant targets within cursor line:
+    let g:targets_seekRanges = 'cr cb cB lc ac Ac lr lb ar ab lB Ar aB Ab AB rr ll rb al rB Al bb aa bB Aa BB AA' ~
+
 Never seek backwards:
     let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr lb ar ab lB Ar aB Ab AB rb rB bb bB BB' ~
 


### PR DESCRIPTION
> For always preferring targets around cursor over distant cursorline targets.

For cases like #163 and #167.