### PR TITLE
175 Fix expand of tight blocks

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -38,14 +38,17 @@ call s:setup()
 " a:count is unused here, but added for consistency with targets#x
 function! targets#o(trigger, count)
     call s:init()
-    let mapmode = 'o'
-    let oldpos = getpos('.')
+    let context = {
+        \ 'mapmode': 'o',
+        \ 'oldpos': getpos('.'),
+        \ }
+
     let [delimiter, which, modifier] = split(a:trigger, '\zs')
-    let [target, rawTarget] = s:findTarget(mapmode, oldpos, delimiter, which, modifier, v:count1)
+    let [target, rawTarget] = s:findTarget(context, delimiter, which, modifier, v:count1)
     if target.state().isInvalid()
         return s:cleanUp()
     endif
-    call s:handleTarget(mapmode, oldpos, target, rawTarget)
+    call s:handleTarget(context, target, rawTarget)
     call s:clearCommandLine()
     call s:prepareRepeat(delimiter, which, modifier)
     call s:cleanUp()
@@ -86,16 +89,18 @@ endfunction
 " 'x' is for visual (as in :xnoremap, not in select mode)
 function! targets#x(trigger, count)
     call s:initX(a:trigger)
-    let mapmode = 'x'
-    let oldpos = getpos('.')
+    let context = {
+        \ 'mapmode': 'x',
+        \ 'oldpos': getpos('.'),
+        \ }
 
     let [delimiter, which, modifier] = split(a:trigger, '\zs')
-    let [target, rawTarget] = s:findTarget(mapmode, oldpos, delimiter, which, modifier, a:count)
+    let [target, rawTarget] = s:findTarget(context, delimiter, which, modifier, a:count)
     if target.state().isInvalid()
-        call s:abortMatch(mapmode, oldpos, '#x: ' . target.error)
+        call s:abortMatch(context, '#x: ' . target.error)
         return s:cleanUp()
     endif
-    if s:handleTarget(mapmode, oldpos, target, rawTarget) == 0
+    if s:handleTarget(context, target, rawTarget) == 0
         let s:lastTrigger = a:trigger
         let s:lastTarget = target
     endif
@@ -144,7 +149,7 @@ function! s:cleanUp()
     let &whichwrap = s:whichwrap
 endfunction
 
-function! s:findTarget(mapmode, oldpos, delimiter, which, modifier, count)
+function! s:findTarget(context, delimiter, which, modifier, count)
     let [kind, s:opening, s:closing, err] = s:getDelimiters(a:delimiter)
     if err
         let errorTarget = targets#target#withError("failed to find delimiter")
@@ -152,16 +157,16 @@ function! s:findTarget(mapmode, oldpos, delimiter, which, modifier, count)
     endif
 
     let view = winsaveview()
-    let rawTarget = s:findRawTarget(a:mapmode, a:oldpos, kind, a:which, a:count)
+    let rawTarget = s:findRawTarget(a:context, kind, a:which, a:count)
     let target = s:modifyTarget(rawTarget, kind, a:modifier)
     call winrestview(view)
     return [target, rawTarget]
 endfunction
 
-function! s:findRawTarget(mapmode, oldpos, kind, which, count)
+function! s:findRawTarget(context, kind, which, count)
     if a:kind ==# 'p'
         if a:which ==# 'c'
-            return s:seekselectp(a:count + s:grow(a:mapmode))
+            return s:seekselectp(a:count + s:grow(a:context))
         elseif a:which ==# 'n'
             call s:search(a:count, s:opening, 'W')
             return s:selectp()
@@ -204,7 +209,7 @@ function! s:findRawTarget(mapmode, oldpos, kind, which, count)
 
     elseif a:kind ==# 't'
         if a:which ==# 'c'
-            return s:seekselectp(a:count + s:grow(a:mapmode), '<\a', '</\a', 't')
+            return s:seekselectp(a:count + s:grow(a:context), '<\a', '</\a', 't')
         elseif a:which ==# 'n'
             call s:search(a:count, '<\a', 'W')
             return s:selectp()
@@ -217,11 +222,11 @@ function! s:findRawTarget(mapmode, oldpos, kind, which, count)
 
     elseif a:kind ==# 'a'
         if a:which ==# 'c'
-            return s:seekselecta(a:oldpos, a:count + s:grow(a:mapmode))
+            return s:seekselecta(a:context, a:count + s:grow(a:context))
         elseif a:which ==# 'n'
-            return s:nextselecta(a:oldpos, a:count)
+            return s:nextselecta(a:context, a:count)
         elseif a:which ==# 'l'
-            return s:lastselecta(a:oldpos, a:count)
+            return s:lastselecta(a:context, a:count)
         else
             return targets#target#withError('findRawTarget a')
         endif
@@ -421,31 +426,31 @@ function! s:clearCommandLine()
 endfunction
 
 " handle the match by either selecting or aborting it
-function! s:handleTarget(mapmode, oldpos, target, rawTarget)
+function! s:handleTarget(context, target, rawTarget)
     if a:target.state().isInvalid()
-        return s:abortMatch(a:mapmode, a:oldpos, 'handleTarget')
+        return s:abortMatch(a:context, 'handleTarget')
     elseif a:target.state().isEmpty()
-        return s:handleEmptyMatch(a:mapmode, a:oldpos, a:target)
+        return s:handleEmptyMatch(a:context, a:target)
     else
-        return s:selectTarget(a:oldpos, a:target, a:rawTarget)
+        return s:selectTarget(a:context, a:target, a:rawTarget)
     endif
 endfunction
 
 " select a proper match
-function! s:selectTarget(oldpos, target, rawTarget)
+function! s:selectTarget(context, target, rawTarget)
     " add old position to jump list
-    if s:addToJumplist(a:oldpos, a:rawTarget)
-        call setpos('.', a:oldpos)
+    if s:addToJumplist(a:context, a:rawTarget)
+        call setpos('.', a:context.oldpos)
         normal! m'
     endif
 
     call s:selectRegion(a:target)
 endfunction
 
-function! s:addToJumplist(oldpos, target)
+function! s:addToJumplist(context, target)
     let min = line('w0')
     let max = line('w$')
-    let range = a:target.range(a:oldpos, min, max)
+    let range = a:target.range(a:context.oldpos, min, max)
     return get(s:rangeJumps, range)
 endfunction
 
@@ -463,9 +468,9 @@ endfunction
 " empty matches can't visually be selected
 " most operators would like to move to the end delimiter
 " for change or delete, insert temporary character that will be operated on
-function! s:handleEmptyMatch(mapmode, oldpos, target)
-    if a:mapmode !=# 'o' || v:operator !~# "^[cd]$"
-        return s:abortMatch(a:mapmode, a:oldpos, 'handleEmptyMatch')
+function! s:handleEmptyMatch(context, target)
+    if a:context.mapmode !=# 'o' || v:operator !~# "^[cd]$"
+        return s:abortMatch(a:context, 'handleEmptyMatch')
     endif
 
     " move cursor to delimiter after zero width match
@@ -481,19 +486,19 @@ function! s:handleEmptyMatch(mapmode, oldpos, target)
 endfunction
 
 " abort when no match was found
-function! s:abortMatch(mapmode, oldpos, message)
+function! s:abortMatch(context, message)
     " get into normal mode and beep
     if !exists("*getcmdwintype") || getcmdwintype() ==# ""
         call feedkeys("\<C-\>\<C-N>\<Esc>", 'n')
     endif
 
-    call s:prepareReselect(a:mapmode)
-    call setpos('.', a:oldpos)
+    call s:prepareReselect(a:context)
+    call setpos('.', a:context.oldpos)
 
     " undo partial command
     call s:triggerUndo()
     " trigger reselect if called from xmap
-    call s:triggerReselect(a:mapmode)
+    call s:triggerReselect(a:context)
 
     return s:fail(a:message)
 endfunction
@@ -507,15 +512,15 @@ function! s:triggerUndo()
 endfunction
 
 " temporarily select original selection to reselect later
-function! s:prepareReselect(mapmode)
-    if a:mapmode ==# 'x'
+function! s:prepareReselect(context)
+    if a:context.mapmode ==# 'x'
         call s:selectRegion(s:visualTarget)
     endif
 endfunction
 
 " feed keys to reselect the last visual selection if called with mapmode x
-function! s:triggerReselect(mapmode)
-    if a:mapmode ==# 'x'
+function! s:triggerReselect(context)
+    if a:context.mapmode ==# 'x'
         call feedkeys("gv", 'n')
     endif
 endfunction
@@ -867,7 +872,7 @@ function! s:findArgBoundary(...)
 endfunction
 
 " selects and argument, supports growing and seeking
-function! s:seekselecta(oldpos, count)
+function! s:seekselecta(context, count)
     if a:count > 1
         if s:getchar() =~# g:targets_argClosing
             let [cnt, message] = [a:count - 2, 'seekselecta 1']
@@ -894,19 +899,19 @@ function! s:seekselecta(oldpos, count)
 
     call setpos('.', oldpos)
 
-    let last = s:lastselecta(a:oldpos)
+    let last = s:lastselecta(a:context.oldpos)
 
     call setpos('.', oldpos)
 
-    let next = s:nextselecta(a:oldpos)
+    let next = s:nextselecta(a:context.oldpos)
 
     return s:bestSeekTarget([around, next, last], oldpos, min, max, 'seekselecta')
 endfunction
 
 " try to select a next argument, supports count and optional stopline
-" args (oldpos, count=1, stopline=0)
+" args (context, count=1, stopline=0)
 function! s:nextselecta(...)
-    let oldpos   =            a:1 " required
+    let context  =            a:1 " required
     let cnt      = a:0 >= 2 ? a:2 : 1
     let stopline = a:0 >= 3 ? a:3 : 0
 
@@ -924,7 +929,7 @@ function! s:nextselecta(...)
         return targets#target#withError('nextselecta 2')
     endif
 
-    call setpos('.', oldpos)
+    call setpos('.', context.oldpos)
     let opening = g:targets_argOpening
     if s:search(cnt, opening, 'W', stopline) > 0 " no start found
         return targets#target#withError('nextselecta 3')
@@ -939,9 +944,9 @@ function! s:nextselecta(...)
 endfunction
 
 " try to select a last argument, supports count and optional stopline
-" args (oldpos, count=1, stopline=0)
+" args (context, count=1, stopline=0)
 function! s:lastselecta(...)
-    let oldpos   =            a:1 " required
+    let context  =            a:1 " required
     let cnt      = a:0 >= 2 ? a:2 : 1
     let stopline = a:0 >= 3 ? a:3 : 0
 
@@ -968,7 +973,7 @@ function! s:lastselecta(...)
         return targets#target#withError('lastselecta 2')
     endif
 
-    call setpos('.', a:oldpos)
+    call setpos('.', context.oldpos)
     let closing = g:targets_argClosing
     if s:search(cnt, closing, 'bW', stopline) > 0 " no start found
         return targets#target#withError('lastselecta 3')
@@ -1237,8 +1242,8 @@ endfunction
 
 " return 1 if count should be increased by one to grow selection on repeated
 " invocations
-function! s:grow(mapmode)
-    if a:mapmode ==# 'o' || !s:shouldGrow
+function! s:grow(context)
+    if a:context.mapmode ==# 'o' || !s:shouldGrow
         return 0
     endif
 

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -103,6 +103,7 @@ function! targets#x(trigger, count)
     if s:handleTarget(context, target, rawTarget) == 0
         let s:lastTrigger = a:trigger
         let s:lastTarget = target
+        let s:lastRawTarget = rawTarget
     endif
     call s:cleanUp()
 endfunction
@@ -1246,6 +1247,10 @@ function! s:grow(context)
     if a:context.mapmode ==# 'o' || !s:shouldGrow
         return 0
     endif
+
+    " move cursor to boundary of last raw target
+    " to handle expansion in tight boundaries like (((x)))
+    call s:lastRawTarget.cursorE()
 
     return 1
 endfunction

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,3 +8,4 @@ all:
 	@git diff --no-index test5.ok test5.out && echo "test5 OK" || echo "test5 failed"
 	@git diff --no-index test6.ok test6.out && echo "test6 OK" || echo "test6 failed"
 	@git diff --no-index test7.ok test7.out && echo "test7 OK" || echo "test7 failed"
+	@git diff --no-index test8.ok test8.out && echo "test8 OK" || echo "test8 failed"

--- a/test/test.vim
+++ b/test/test.vim
@@ -112,20 +112,20 @@ function! s:testMultiline()
 
     execute "normal /comment 1\<CR>"
     set autoindent
-    execute "normal cin{foo\<Esc>"
+    execute "normal cin{foo\<Esc>''A bar"
     set autoindent&
 
     execute "normal /comment 2\<CR>"
-    execute "normal din{"
+    execute "normal din{''A bar"
 
     execute "normal /comment 3\<CR>"
-    execute "normal cin;foo\<Esc>"
+    execute "normal cin;foo\<Esc>''A bar"
 
     execute "normal /comment 4\<CR>"
-    execute "normal cin`foo\<Esc>"
+    execute "normal cin`foo\<Esc>''A bar"
 
     execute "normal /comment 5\<CR>"
-    execute "normal cI{foo\<Esc>"
+    execute "normal cI{foo\<Esc>''A bar"
 
     write! test2.out
 endfunction

--- a/test/test.vim
+++ b/test/test.vim
@@ -242,6 +242,19 @@ function s:testQuotes()
     write! test7.out
 endfunction
 
+function s:testReselect()
+    edit! test8.in
+    normal gg0
+
+    " select a word, then try to select a block, which fails
+    " should still be selecting word, so the first word should be changed
+    normal viw
+    normal ab
+    normal cfoo
+
+    write! test8.out
+endfunction
+
 call s:testBasic()
 call s:testMultiline()
 call s:testSeeking()
@@ -249,5 +262,6 @@ call s:testVisual()
 call s:testModifiers()
 call s:testEmpty()
 call s:testQuotes()
+call s:testReselect()
 
 quit!

--- a/test/test2.ok
+++ b/test/test2.ok
@@ -1,20 +1,20 @@
-// comment 1
+// comment 1 bar
 function f() {
         foo
     }
 
-// comment 2
+// comment 2 bar
 function f() {
     }
 
-// comment 3
+// comment 3 bar
 int a = 5;
 foo;
 
-// comment 4
+// comment 4 bar
 string x = `foo`;
 
-// comment 5
+// comment 5 bar
 function f() {
     foo
 }

--- a/test/test2.out
+++ b/test/test2.out
@@ -1,20 +1,20 @@
-// comment 1
+// comment 1 bar
 function f() {
         foo
     }
 
-// comment 2
+// comment 2 bar
 function f() {
     }
 
-// comment 3
+// comment 3 bar
 int a = 5;
 foo;
 
-// comment 4
+// comment 4 bar
 string x = `foo`;
 
-// comment 5
+// comment 5 bar
 function f() {
     foo
 }

--- a/test/test8.in
+++ b/test/test8.in
@@ -1,0 +1,1 @@
+word another

--- a/test/test8.ok
+++ b/test/test8.ok
@@ -1,0 +1,1 @@
+foo another

--- a/test/test8.out
+++ b/test/test8.out
@@ -1,0 +1,1 @@
+foo another


### PR DESCRIPTION
In examples like `(((x)))` with the cursor on `x` typing `vibibib` didn't manage to properly expand the selection. This PR fixes that. (and includes some unrelated refactorings)

Close #175