### PR TITLE
174 Deprecate N and L modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ a ' bbbbbbbb ' c ' d ' e
 
 ### Next and Last Quote
 
-`in' In' An' il' Il' Al' iN' IN' AN' iL' IL' AL' ...`
+`in' In' An' il' Il' Al' ...`
 
 Work directly on distant quotes without moving there separately.
 
@@ -240,19 +240,14 @@ including the letter `n`. The command `in'` selects inside of the next
 single quotes. Use the letter `l` instead to work on the previous (last)
 quote. Uses a count to skip multiple quotation characters.
 
-Use uppercase `N` and `L` to jump from within one quote into the next
-proper quote, instead of into the pseudo quote in between. (Using `N`
-instead of `n` is actually just doubling the count to achieve this.)
-
 See our [Cheat Sheet][cheatsheet] for a chart summarizing all quote mappings.
 
 ### Quote Seek
 
-If any of the normal quote commands (not containing `n`, `l`, `N` or `L`) is
-executed when the cursor is not positioned inside a quote, it seeks for quotes
-before or after the cursor by searching for the appropriate delimiter on the
-current line. This is similar to using the explicit version containing `n` or
-`l`.
+If any of the normal quote commands (not containing `n` or `l`) is executed
+when the cursor is not positioned inside a quote, it seeks for quotes before or
+after the cursor by searching for the appropriate delimiter on the current
+line. This is similar to using the explicit version containing `n` or `l`.
 
 ## Separator Text Objects
 
@@ -328,7 +323,7 @@ a , b , cccccccc , d , e
 
 ### Next and Last Separator
 
-`in, an, In, An, il, al, Il, Al, iN, aN, IN, AN, iL, aL, IL, AL, ...`
+`in, an, In, An, il, al, Il, Al, ...`
 
 Work directly on distant separators without moving there separately.
 
@@ -336,10 +331,6 @@ All the above separator text objects can be shifted to the next separator by
 including the letter `n`. The command `in,` selects inside of the next commas.
 Use the letter `l` instead to work on the previous (last) separators. Uses the
 count to skip multiple separator characters.
-
-Use uppercase `N` and `L` to jump from within one pair of separators into
-the next distinct pair, instead of into the adjacent one. (Using `N`
-instead of `n` is actually just doubling the count to achieve this.)
 
 See our [Cheat Sheet][cheatsheet] for a chart summarizing all separator mappings.
 
@@ -474,7 +465,7 @@ Available options:
 
 ```vim
 g:targets_aiAI
-g:targets_nlNL
+g:targets_nl
 g:targets_pairs
 g:targets_quotes
 g:targets_separators
@@ -499,26 +490,23 @@ Controls the normal mode operator mode maps that get created for In Pair (`i`),
 A Pair (`a`), Inside Pair (`I`), and Around Pair (`A`). Required to be a 4
 character long list. Use a space to deactivate a mode.
 
-### g:targets_nlNL
+### g:targets_nl
 
 Default:
 
 ```vim
-let g:targets_nlNL = 'nlNL'
+let g:targets_nl = 'nl'
 ```
 
 Controls the keys used in maps for seeking next and last text objects. For
-example, if you don't wish to use the `N` and `L` seeks, and instead wish for
-`n` to always search for the next object and `N` to search for the last, you
-could set:
+example, if you want `n` to always search for the next object and `N` to search
+for the last, you could set:
 
 ```vim
-let g:targets_nlNL = 'nN  '
+let g:targets_nl = 'nN'
 ```
 
-Note that two extra spaces are still required on the end, indicating you wish
-to disable the default functionality of `N` and `L`. Required to be a 4
-character long list.
+Required to be a 4 character long list. Use a space to deactivate a direction.
 
 ### g:targets_pairs
 

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -64,11 +64,11 @@ function! targets#e(modifier)
     let char1 = nr2char(getchar())
     let [delimiter, which, chars] = [char1, 'c', char1]
     let i = 0
-    while i < 4
-        if g:targets_nlNL[i] ==# delimiter
+    while i < 2
+        if g:targets_nl[i] ==# delimiter
             " delimiter was which, get another char for delimiter
             let char2 = nr2char(getchar())
-            let [delimiter, which, chars] = [char2, 'nlNL'[i], chars . char2]
+            let [delimiter, which, chars] = [char2, 'nl'[i], chars . char2]
             break
         endif
         let i = i + 1
@@ -200,10 +200,6 @@ function! s:findRawTarget(context, kind, which, count)
             return s:nextselect(a:count)
         elseif a:which ==# 'l'
             return s:lastselect(a:count)
-        elseif a:which ==# 'N'
-            return s:nextselect(a:count * 2)
-        elseif a:which ==# 'L'
-            return s:lastselect(a:count * 2)
         else
             return targets#target#withError('findRawTarget s')
         endif

--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -48,10 +48,10 @@ a ( b ( cccccccc ) d ) ( e ( ffffff ) g ) ( h ( iiiiiiii ) j ) k
 Available mappings
 
 ```
- i'  i"  i`    in' in" in`    il' il" il`    iL' iL" iL`
- a'  a"  a`    an' an" an`    al' al" al`    aL' aL" aL`
- I'  I"  I`    In' In" In`    Il' Il" Il`    IL' IL" IL`
- A'  A"  A`    An' An" An`    Al' Al" Al`    AL' AL" AL`
+ i'  i"  i`    in' in" in`    il' il" il`
+ a'  a"  a`    an' an" an`    al' al" al`
+ I'  I"  I`    In' In" In`    Il' Il" Il`
+ A'  A"  A`    An' An" An`    Al' Al" Al`
 ```
 
 Chart for a list of quotes
@@ -84,28 +84,18 @@ il, il. il; il: il+ il- il= il~ il_ il* il# il/ il| il\ il& il$
 al, al. al; al: al+ al- al= al~ al_ al* al# al/ al| al\ al& al$
 Il, Il. Il; Il: Il+ Il- Il= Il~ Il_ Il* Il# Il/ Il| Il\ Il& Il$
 Al, Al. Al; Al: Al+ Al- Al= Al~ Al_ Al* Al# Al/ Al| Al\ Al& Al$
-
-iN, iN. iN; iN: iN+ iN- iN= iN~ iN_ iN* iN# iN/ iN| iN\ iN& iN$
-aN, aN. aN; aN: aN+ aN- aN= aN~ aN_ aN* aN# aN/ aN| aN\ aN& aN$
-IN, IN. IN; IN: IN+ IN- IN= IN~ IN_ IN* IN# IN/ IN| IN\ IN& IN$
-AN, AN. AN; AN: AN+ AN- AN= AN~ AN_ AN* AN# AN/ AN| AN\ AN& AN$
-
-iL, iL. iL; iL: iL+ iL- iL= iL~ iL_ iL* iL# iL/ iL| iL\ iL& iL$
-aL, aL. aL; aL: aL+ aL- aL= aL~ aL_ aL* aL# aL/ aL| aL\ aL& aL$
-IL, IL. IL; IL: IL+ IL- IL= IL~ IL_ IL* IL# IL/ IL| IL\ IL& IL$
-AL, AL. AL; AL: AL+ AL- AL= AL~ AL_ AL* AL# AL/ AL| AL\ AL& AL$
 ```
 
 Chart for a list of separators
 
 ```
-                      .........
-a , bbbbbbb , ccccccc , dddddd , eeeeeee , fffffff , g
-  ││└ IL, ┘│││└ Il, ┘│││└ I, ┘│││└ In, ┘│││└ IN, ┘│ │
-  │└─ iL, ─┤│├─ il, ─┤│├─ i, ─┤│├─ in, ─┤│├─ iN, ─┤ │
-  ├── aL, ─┘├┼─ al, ─┘├┼─ a, ─┘├┼─ an, ─┘├┼─ aN, ─┘ │
-  └── AL, ──┼┘        └┼─ A, ──┼┘        └┼─ AN, ───┘
-            └─  Al,  ──┘       └─  An,  ──┘
+                       .........
+a , bbbbbbbb , ccccccc , dddddd , eeeeeee , ffffffff , g
+  ││└ 2Il, ┘│││└ Il, ┘│││└ I, ┘│││└ In, ┘│││└ 2In, ┘│ │
+  │└─ 2il, ─┤│├─ il, ─┤│├─ i, ─┤│├─ in, ─┤│├─ 2in, ─┤ │
+  ├── 2al, ─┘├┼─ al, ─┘├┼─ a, ─┘├┼─ an, ─┘├┼─ 2an, ─┘ │
+  └── 2Al, ──┼┘        └┼─ A, ──┼┘        └┼─ 2An, ───┘
+             └─  Al,  ──┘       └─  An,  ──┘
 ```
 
 ## Argument mappings

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -242,17 +242,10 @@ Work directly on distant quotes without moving there separately.
 in' in" in` il' il" il`            *in`* *in'* *inquote* *il`* *il'* *ilquote*
 an' an" an` al' al" al`            *an`* *an'* *anquote* *al`* *al'* *alquote*
 In' In" In` Il' Il" Il`            *In`* *In'* *Inquote* *Il`* *Il'* *Ilquote*
-iN' iN" iN` iL' iL" iL`            *iN`* *iN'* *iNquote* *iL`* *iL'* *iLquote*
-aN' aN" aN` aL' aL" aL`            *aN`* *aN'* *aNquote* *aL`* *aL'* *aLquote*
-IN' IN" IN` IL' IL" IL`            *IN`* *IN'* *INquote* *IL`* *IL'* *ILquote*
     All the above pair text objects can be shifted to the next quote by
     including the letter `n`. The command `in'` selects inside of the next
     single quotes. Use the letter `l` instead to work on the previous (last)
     quote. Uses a [count] to skip multiple quotation characters.
-
-    Use uppercase `N` and `L` to jump from within one quote into the next
-    proper quote, instead of into the pseudo quote in between. (Using `N`
-    instead of `n` is actually just doubling the count to achieve this.)
 
                                                          *targets-quote-chart*
 The following chart summarizes all quote mappings:
@@ -267,10 +260,10 @@ The following chart summarizes all quote mappings:
 ------------------------------------------------------------------------------
 QUOTE SEEK                                                *targets-quote-seek*
 
-If any of the normal quote commands (not containing `n`, `l`, `N` or `L`) is
-executed when the cursor is not positioned inside a quote, it seeks for quotes
-before or after the cursor by searching for the appropriate delimiter on the
-current line. Similar to using the explicit version containing `n` or `l`.
+If any of the normal quote commands (not containing `n` or `l`) is executed
+when the cursor is not positioned inside a quote, it seeks for quotes before
+or after the cursor by searching for the appropriate delimiter on the current
+line. Similar to using the explicit version containing `n` or `l`.
 
 ==============================================================================
 SEPARATOR TEXT OBJECTS                        *targets-separator-text-objects*
@@ -340,14 +333,6 @@ Work directly on distant separators without moving there separately.
                             *al,* *al.* *al;* *al:* *al+* *al-* *al=* *al~*
                             *Il,* *Il.* *Il;* *Il:* *Il+* *Il-* *Il=* *Il~*
                             *Al,* *Al.* *Al;* *Al:* *Al+* *Al-* *Al=* *Al~*
-                            *iN,* *iN.* *iN;* *iN:* *iN+* *iN-* *iN=* *iN~*
-                            *aN,* *aN.* *aN;* *aN:* *aN+* *aN-* *aN=* *aN~*
-                            *IN,* *IN.* *IN;* *IN:* *IN+* *IN-* *IN=* *IN~*
-                            *AN,* *AN.* *AN;* *AN:* *AN+* *AN-* *AN=* *AN~*
-                            *iL,* *iL.* *iL;* *iL:* *iL+* *iL-* *iL=* *iL~*
-                            *aL,* *aL.* *aL;* *aL:* *aL+* *aL-* *aL=* *aL~*
-                            *IL,* *IL.* *IL;* *IL:* *IL+* *IL-* *IL=* *IL~*
-                            *AL,* *AL.* *AL;* *AL:* *AL+* *AL-* *AL=* *AL~*
 
                             *in_* *in/* *in|* *in\* *in&* *in$* *in#* *instar*
                             *an_* *an/* *an|* *an\* *an&* *an$* *an#* *anstar*
@@ -357,14 +342,6 @@ Work directly on distant separators without moving there separately.
                             *al_* *al/* *al|* *al\* *al&* *al$* *al#* *alstar*
                             *Il_* *Il/* *Il|* *Il\* *Il&* *Il$* *Il#* *Ilstar*
                             *Al_* *Al/* *Al|* *Al\* *Al&* *Al$* *Al#* *Alstar*
-                            *iN_* *iN/* *iN|* *iN\* *iN&* *iN$* *iN#* *iNstar*
-                            *aN_* *aN/* *aN|* *aN\* *aN&* *aN$* *aN#* *aNstar*
-                            *IN_* *IN/* *IN|* *IN\* *IN&* *IN$* *IN#* *INstar*
-                            *AN_* *AN/* *AN|* *AN\* *AN&* *AN$* *AN#* *ANstar*
-                            *iL_* *iL/* *iL|* *iL\* *iL&* *iL$* *iL#* *iLstar*
-                            *aL_* *aL/* *aL|* *aL\* *aL&* *aL$* *aL#* *aLstar*
-                            *IL_* *IL/* *IL|* *IL\* *IL&* *IL$* *IL#* *ILstar*
-                            *AL_* *AL/* *AL|* *AL\* *AL&* *AL$* *AL#* *ALstar*
 
 in, in. in; in: in+ in- in= in~ in_ in/ in| in\ in& in$ in# in*
 an, an. an; an: an+ an- an= an~ an_ an/ an| an\ an& an$ an# an*
@@ -374,34 +351,22 @@ il, il. il; il: il+ il- il= il~ il_ il/ il| il\ il& il$ il# il*
 al, al. al; al: al+ al- al= al~ al_ al/ al| al\ al& al$ al# al*
 Il, Il. Il; Il: Il+ Il- Il= Il~ Il_ Il/ Il| Il\ Il& Il$ Il# Il*
 Al, Al. Al; Al: Al+ Al- Al= Al~ Al_ Al/ Al| Al\ Al& Al$ Al# Al*
-iN, iN. iN; iN: iN+ iN- iN= iN~ iN_ iN/ iN| iN\ iN& iN$ iN# iN*
-aN, aN. aN; aN: aN+ aN- aN= aN~ aN_ aN/ aN| aN\ aN& aN$ aN# aN*
-IN, IN. IN; IN: IN+ IN- IN= IN~ IN_ IN/ IN| IN\ IN& IN$ IN# IN*
-AN, AN. AN; AN: AN+ AN- AN= AN~ AN_ AN/ AN| AN\ AN& AN$ AN# AN*
-iL, iL. iL; iL: iL+ iL- iL= iL~ iL_ iL/ iL| iL\ iL& iL$ iL# iL*
-aL, aL. aL; aL: aL+ aL- aL= aL~ aL_ aL/ aL| aL\ aL& aL$ aL# aL*
-IL, IL. IL; IL: IL+ IL- IL= IL~ IL_ IL/ IL| IL\ IL& IL$ IL# IL*
-AL, AL. AL; AL: AL+ AL- AL= AL~ AL_ AL/ AL| AL\ AL& AL$ AL# AL*
 
     All the above separator text objects can be shifted to the next separator
     by including the letter `n`. The command `in,` selects inside of the next
     commas. Use the letter `l` instead to work on the previous (last)
     separators. Uses a [count] to skip multiple separator characters.
 
-    Use uppercase `N` and `L` to jump from within one pair of separators into
-    the next distinct pair, instead of into the adjacent one. (Using `N`
-    instead of `n` is actually just doubling the count to achieve this.)
-
                                                      *targets-separator-chart*
 The following chart summarizes all separator mappings:
 
-                          .........
-    a , bbbbbbb , ccccccc , dddddd , eeeeeee , fffffff , g ~
-      ││└ IL, ┘│││└ Il, ┘│││└ I, ┘│││└ In, ┘│││└ IN, ┘│ │
-      │└─ iL, ─┤│├─ il, ─┤│├─ i, ─┤│├─ in, ─┤│├─ iN, ─┤ │
-      ├── aL, ─┘├┼─ al, ─┘├┼─ a, ─┘├┼─ an, ─┘├┼─ aN, ─┘ │
-      └── AL, ──┼┘        └┼─ A, ──┼┘        └┼─ AN, ───┘
-                └─  Al,  ──┘       └─  An,  ──┘
+                           .........
+    a , bbbbbbbb , ccccccc , dddddd , eeeeeee , ffffffff , g ~
+      ││└ 2Il, ┘│││└ Il, ┘│││└ I, ┘│││└ In, ┘│││└ 2In, ┘│ │
+      │└─ 2il, ─┤│├─ il, ─┤│├─ i, ─┤│├─ in, ─┤│├─ 2in, ─┤ │
+      ├── 2al, ─┘├┼─ al, ─┘├┼─ a, ─┘├┼─ an, ─┘├┼─ 2an, ─┘ │
+      └── 2Al, ──┼┘        └┼─ A, ──┼┘        └┼─ 2An, ───┘
+                 └─  Al,  ──┘       └─  An,  ──┘
 
 ------------------------------------------------------------------------------
 SEPARATOR SEEK                                        *targets-separator-seek*
@@ -506,7 +471,7 @@ The provided examples also indicate the default values.
 Available options: ~
 
     |g:targets_aiAI|
-    |g:targets_nlNL|
+    |g:targets_nl|
     |g:targets_pairs|
     |g:targets_quotes|
     |g:targets_separators|
@@ -527,20 +492,17 @@ Controls the normal mode operator mode maps that get created for In Pair (i),
 A Pair (a), Inside Pair (I), and Around Pair (A). Required to be a 4 character
 long list. Use a space to deactivate a mode.
 
-                                                              *g:targets_nlNL*
+                                                                *g:targets_nl*
 Default:
-    let g:targets_nlNL = 'nlNL' ~
+    let g:targets_nl = 'nl' ~
 
 Controls the keys used in maps for seeking next and last text objects. For
-example, if you don't wish to use the N and L seeks, and instead wish for 'n'
-to always search for the next object and `N` to search for the last, you could
-set:
+example, if you want 'n' to always search for the next object and `N` to
+search for the last, you could set:
 
-    let g:targets_nlNL = 'nN  ' ~
+    let g:targets_nl = 'nN' ~
 
-Note that two extra spaces are still required on the end, indicating you wish
-to disable the default functionality of N and L. Required to be a 4 character
-long list.
+Required to be a 4 character long list. Use a space to deactivate a direction.
 
                                                              *g:targets_pairs*
 Default:

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -15,9 +15,9 @@ function! s:addMapping1(mapType, mapping, aiAI)
     endif
 endfunction
 
-function! s:addMapping2(mapType, mapping, aiAI, nlNL)
-    if a:aiAI !=# ' ' && a:nlNL !=# ' '
-        silent! execute a:mapType . 'noremap <silent> <unique>' . a:aiAI . a:nlNL . a:mapping
+function! s:addMapping2(mapType, mapping, aiAI, nl)
+    if a:aiAI !=# ' ' && a:nl !=# ' '
+        silent! execute a:mapType . 'noremap <silent> <unique>' . a:aiAI . a:nl . a:mapping
     endif
 endfunction
 
@@ -153,14 +153,6 @@ function! s:createSeparatorTextObjects(mapType)
         call s:addMapping2(a:mapType, triggerMap . "la', v:count1)<CR>", s:a, s:l)
         call s:addMapping2(a:mapType, triggerMap . "lI', v:count1)<CR>", s:I, s:l)
         call s:addMapping2(a:mapType, triggerMap . "lA', v:count1)<CR>", s:A, s:l)
-        call s:addMapping2(a:mapType, triggerMap . "Ni', v:count1)<CR>", s:i, s:N)
-        call s:addMapping2(a:mapType, triggerMap . "Na', v:count1)<CR>", s:a, s:N)
-        call s:addMapping2(a:mapType, triggerMap . "NI', v:count1)<CR>", s:I, s:N)
-        call s:addMapping2(a:mapType, triggerMap . "NA', v:count1)<CR>", s:A, s:N)
-        call s:addMapping2(a:mapType, triggerMap . "Li', v:count1)<CR>", s:i, s:L)
-        call s:addMapping2(a:mapType, triggerMap . "La', v:count1)<CR>", s:a, s:L)
-        call s:addMapping2(a:mapType, triggerMap . "LI', v:count1)<CR>", s:I, s:L)
-        call s:addMapping2(a:mapType, triggerMap . "LA', v:count1)<CR>", s:A, s:L)
     endfor
 endfunction
 
@@ -215,8 +207,12 @@ function! s:loadSettings()
     if !exists('g:targets_aiAI')
         let g:targets_aiAI = 'aiAI'
     endif
-    if !exists('g:targets_nlNL')
-        let g:targets_nlNL = 'nlNL'
+    if !exists('g:targets_nl')
+        if exists('g:targets_nlNL')
+            let g:targets_nl = g:targets_nlNL[0:2] " legacy fallback
+        else
+            let g:targets_nl = 'nl'
+        endif
     endif
     if !exists('g:targets_pairs')
         let g:targets_pairs = '()b {}B [] <>'
@@ -250,7 +246,7 @@ function! s:loadSettings()
     endif
 
     let [s:a, s:i, s:A, s:I] = split(g:targets_aiAI, '\zs')
-    let [s:n, s:l, s:N, s:L] = split(g:targets_nlNL, '\zs')
+    let [s:n, s:l] = split(g:targets_nl, '\zs')
 endfunction
 
 call s:loadSettings()

--- a/test/test.vim
+++ b/test/test.vim
@@ -57,10 +57,10 @@ function! s:testBasic()
 
         for op in [ 'c', 'd', 'y', 'v' ]
             for cnt in [ '', '1', '2' ]
-                for LlnN in [ 'l', '', 'n' ]
+                for ln in [ 'l', '', 'n' ]
                     for iaIA in [ 'I', 'i', 'a', 'A' ]
                         execute "normal \"lpfx"
-                        call s:execute(op, cnt . iaIA . LlnN . del)
+                        call s:execute(op, cnt . iaIA . ln . del)
                     endfor
                 endfor
             endfor
@@ -76,10 +76,10 @@ function! s:testBasic()
 
         for op in [ 'c', 'd', 'y', 'v' ]
             for cnt in [ '', '1', '2' ]
-                for LlnN in [ 'L', 'l', '', 'n', 'N' ]
+                for ln in [ 'l', '', 'n' ]
                     for iaIA in [ 'I', 'i', 'a', 'A' ]
                         execute "normal \"lpfx"
-                        call s:execute(op, cnt . iaIA . LlnN . del)
+                        call s:execute(op, cnt . iaIA . ln . del)
                     endfor
                 endfor
             endfor

--- a/test/test1.ok
+++ b/test/test1.ok
@@ -2025,10 +2025,6 @@ v2an`           a ` b ` c ` d ` e ` x ` g ` h ` i _____ l
 v2An`           a ` b ` c ` d ` e ` x ` g ` h ` i ______l
 
 a , b , c , d , e , x , g , h , i , k , l
-cIL,            a , b , c , _ , e , x , g , h , i , k , l
-ciL,            a , b , c ,_, e , x , g , h , i , k , l
-caL,            a , b , c _, e , x , g , h , i , k , l
-cAL,            a , b , c _e , x , g , h , i , k , l
 cIl,            a , b , c , d , _ , x , g , h , i , k , l
 cil,            a , b , c , d ,_, x , g , h , i , k , l
 cal,            a , b , c , d _, x , g , h , i , k , l
@@ -2041,14 +2037,6 @@ cIn,            a , b , c , d , e , x , _ , h , i , k , l
 cin,            a , b , c , d , e , x ,_, h , i , k , l
 can,            a , b , c , d , e , x _, h , i , k , l
 cAn,            a , b , c , d , e , x _h , i , k , l
-cIN,            a , b , c , d , e , x , g , _ , i , k , l
-ciN,            a , b , c , d , e , x , g ,_, i , k , l
-caN,            a , b , c , d , e , x , g _, i , k , l
-cAN,            a , b , c , d , e , x , g _i , k , l
-c1IL,           a , b , c , _ , e , x , g , h , i , k , l
-c1iL,           a , b , c ,_, e , x , g , h , i , k , l
-c1aL,           a , b , c _, e , x , g , h , i , k , l
-c1AL,           a , b , c _e , x , g , h , i , k , l
 c1Il,           a , b , c , d , _ , x , g , h , i , k , l
 c1il,           a , b , c , d ,_, x , g , h , i , k , l
 c1al,           a , b , c , d _, x , g , h , i , k , l
@@ -2061,14 +2049,6 @@ c1In,           a , b , c , d , e , x , _ , h , i , k , l
 c1in,           a , b , c , d , e , x ,_, h , i , k , l
 c1an,           a , b , c , d , e , x _, h , i , k , l
 c1An,           a , b , c , d , e , x _h , i , k , l
-c1IN,           a , b , c , d , e , x , g , _ , i , k , l
-c1iN,           a , b , c , d , e , x , g ,_, i , k , l
-c1aN,           a , b , c , d , e , x , g _, i , k , l
-c1AN,           a , b , c , d , e , x , g _i , k , l
-c2IL,           a , _ , c , d , e , x , g , h , i , k , l
-c2iL,           a ,_, c , d , e , x , g , h , i , k , l
-c2aL,           a _, c , d , e , x , g , h , i , k , l
-c2AL,           a _c , d , e , x , g , h , i , k , l
 c2Il,           a , b , c , _ , e , x , g , h , i , k , l
 c2il,           a , b , c ,_, e , x , g , h , i , k , l
 c2al,           a , b , c _, e , x , g , h , i , k , l
@@ -2081,14 +2061,6 @@ c2In,           a , b , c , d , e , x , g , _ , i , k , l
 c2in,           a , b , c , d , e , x , g ,_, i , k , l
 c2an,           a , b , c , d , e , x , g _, i , k , l
 c2An,           a , b , c , d , e , x , g _i , k , l
-c2IN,           a , b , c , d , e , x , g , h , i , _ , l
-c2iN,           a , b , c , d , e , x , g , h , i ,_, l
-c2aN,           a , b , c , d , e , x , g , h , i _, l
-c2AN,           a , b , c , d , e , x , g , h , i _l
-dIL,            a , b , c ,  , e , x , g , h , i , k , l
-diL,            a , b , c ,, e , x , g , h , i , k , l
-daL,            a , b , c , e , x , g , h , i , k , l
-dAL,            a , b , c e , x , g , h , i , k , l
 dIl,            a , b , c , d ,  , x , g , h , i , k , l
 dil,            a , b , c , d ,, x , g , h , i , k , l
 dal,            a , b , c , d , x , g , h , i , k , l
@@ -2101,14 +2073,6 @@ dIn,            a , b , c , d , e , x ,  , h , i , k , l
 din,            a , b , c , d , e , x ,, h , i , k , l
 dan,            a , b , c , d , e , x , h , i , k , l
 dAn,            a , b , c , d , e , x h , i , k , l
-dIN,            a , b , c , d , e , x , g ,  , i , k , l
-diN,            a , b , c , d , e , x , g ,, i , k , l
-daN,            a , b , c , d , e , x , g , i , k , l
-dAN,            a , b , c , d , e , x , g i , k , l
-d1IL,           a , b , c ,  , e , x , g , h , i , k , l
-d1iL,           a , b , c ,, e , x , g , h , i , k , l
-d1aL,           a , b , c , e , x , g , h , i , k , l
-d1AL,           a , b , c e , x , g , h , i , k , l
 d1Il,           a , b , c , d ,  , x , g , h , i , k , l
 d1il,           a , b , c , d ,, x , g , h , i , k , l
 d1al,           a , b , c , d , x , g , h , i , k , l
@@ -2121,14 +2085,6 @@ d1In,           a , b , c , d , e , x ,  , h , i , k , l
 d1in,           a , b , c , d , e , x ,, h , i , k , l
 d1an,           a , b , c , d , e , x , h , i , k , l
 d1An,           a , b , c , d , e , x h , i , k , l
-d1IN,           a , b , c , d , e , x , g ,  , i , k , l
-d1iN,           a , b , c , d , e , x , g ,, i , k , l
-d1aN,           a , b , c , d , e , x , g , i , k , l
-d1AN,           a , b , c , d , e , x , g i , k , l
-d2IL,           a ,  , c , d , e , x , g , h , i , k , l
-d2iL,           a ,, c , d , e , x , g , h , i , k , l
-d2aL,           a , c , d , e , x , g , h , i , k , l
-d2AL,           a c , d , e , x , g , h , i , k , l
 d2Il,           a , b , c ,  , e , x , g , h , i , k , l
 d2il,           a , b , c ,, e , x , g , h , i , k , l
 d2al,           a , b , c , e , x , g , h , i , k , l
@@ -2141,14 +2097,6 @@ d2In,           a , b , c , d , e , x , g ,  , i , k , l
 d2in,           a , b , c , d , e , x , g ,, i , k , l
 d2an,           a , b , c , d , e , x , g , i , k , l
 d2An,           a , b , c , d , e , x , g i , k , l
-d2IN,           a , b , c , d , e , x , g , h , i ,  , l
-d2iN,           a , b , c , d , e , x , g , h , i ,, l
-d2aN,           a , b , c , d , e , x , g , h , i , l
-d2AN,           a , b , c , d , e , x , g , h , i l
-yIL,            a , b , c , d , e , x , g , h , i , k , l       'd'
-yiL,            a , b , c , d , e , x , g , h , i , k , l       ' d '
-yaL,            a , b , c , d , e , x , g , h , i , k , l       ', d '
-yAL,            a , b , c , d , e , x , g , h , i , k , l       ', d , '
 yIl,            a , b , c , d , e , x , g , h , i , k , l       'e'
 yil,            a , b , c , d , e , x , g , h , i , k , l       ' e '
 yal,            a , b , c , d , e , x , g , h , i , k , l       ', e '
@@ -2161,14 +2109,6 @@ yIn,            a , b , c , d , e , x , g , h , i , k , l       'g'
 yin,            a , b , c , d , e , x , g , h , i , k , l       ' g '
 yan,            a , b , c , d , e , x , g , h , i , k , l       ', g '
 yAn,            a , b , c , d , e , x , g , h , i , k , l       ', g , '
-yIN,            a , b , c , d , e , x , g , h , i , k , l       'h'
-yiN,            a , b , c , d , e , x , g , h , i , k , l       ' h '
-yaN,            a , b , c , d , e , x , g , h , i , k , l       ', h '
-yAN,            a , b , c , d , e , x , g , h , i , k , l       ', h , '
-y1IL,           a , b , c , d , e , x , g , h , i , k , l       'd'
-y1iL,           a , b , c , d , e , x , g , h , i , k , l       ' d '
-y1aL,           a , b , c , d , e , x , g , h , i , k , l       ', d '
-y1AL,           a , b , c , d , e , x , g , h , i , k , l       ', d , '
 y1Il,           a , b , c , d , e , x , g , h , i , k , l       'e'
 y1il,           a , b , c , d , e , x , g , h , i , k , l       ' e '
 y1al,           a , b , c , d , e , x , g , h , i , k , l       ', e '
@@ -2181,14 +2121,6 @@ y1In,           a , b , c , d , e , x , g , h , i , k , l       'g'
 y1in,           a , b , c , d , e , x , g , h , i , k , l       ' g '
 y1an,           a , b , c , d , e , x , g , h , i , k , l       ', g '
 y1An,           a , b , c , d , e , x , g , h , i , k , l       ', g , '
-y1IN,           a , b , c , d , e , x , g , h , i , k , l       'h'
-y1iN,           a , b , c , d , e , x , g , h , i , k , l       ' h '
-y1aN,           a , b , c , d , e , x , g , h , i , k , l       ', h '
-y1AN,           a , b , c , d , e , x , g , h , i , k , l       ', h , '
-y2IL,           a , b , c , d , e , x , g , h , i , k , l       'b'
-y2iL,           a , b , c , d , e , x , g , h , i , k , l       ' b '
-y2aL,           a , b , c , d , e , x , g , h , i , k , l       ', b '
-y2AL,           a , b , c , d , e , x , g , h , i , k , l       ', b , '
 y2Il,           a , b , c , d , e , x , g , h , i , k , l       'd'
 y2il,           a , b , c , d , e , x , g , h , i , k , l       ' d '
 y2al,           a , b , c , d , e , x , g , h , i , k , l       ', d '
@@ -2201,14 +2133,6 @@ y2In,           a , b , c , d , e , x , g , h , i , k , l       'h'
 y2in,           a , b , c , d , e , x , g , h , i , k , l       ' h '
 y2an,           a , b , c , d , e , x , g , h , i , k , l       ', h '
 y2An,           a , b , c , d , e , x , g , h , i , k , l       ', h , '
-y2IN,           a , b , c , d , e , x , g , h , i , k , l       'k'
-y2iN,           a , b , c , d , e , x , g , h , i , k , l       ' k '
-y2aN,           a , b , c , d , e , x , g , h , i , k , l       ', k '
-y2AN,           a , b , c , d , e , x , g , h , i , k , l       ', k , '
-vIL,            a , b , c , _ , e , x , g , h , i , k , l
-viL,            a , b , c ,___, e , x , g , h , i , k , l
-vaL,            a , b , c ____, e , x , g , h , i , k , l
-vAL,            a , b , c ______e , x , g , h , i , k , l
 vIl,            a , b , c , d , _ , x , g , h , i , k , l
 vil,            a , b , c , d ,___, x , g , h , i , k , l
 val,            a , b , c , d ____, x , g , h , i , k , l
@@ -2221,14 +2145,6 @@ vIn,            a , b , c , d , e , x , _ , h , i , k , l
 vin,            a , b , c , d , e , x ,___, h , i , k , l
 van,            a , b , c , d , e , x ____, h , i , k , l
 vAn,            a , b , c , d , e , x ______h , i , k , l
-vIN,            a , b , c , d , e , x , g , _ , i , k , l
-viN,            a , b , c , d , e , x , g ,___, i , k , l
-vaN,            a , b , c , d , e , x , g ____, i , k , l
-vAN,            a , b , c , d , e , x , g ______i , k , l
-v1IL,           a , b , c , _ , e , x , g , h , i , k , l
-v1iL,           a , b , c ,___, e , x , g , h , i , k , l
-v1aL,           a , b , c ____, e , x , g , h , i , k , l
-v1AL,           a , b , c ______e , x , g , h , i , k , l
 v1Il,           a , b , c , d , _ , x , g , h , i , k , l
 v1il,           a , b , c , d ,___, x , g , h , i , k , l
 v1al,           a , b , c , d ____, x , g , h , i , k , l
@@ -2241,14 +2157,6 @@ v1In,           a , b , c , d , e , x , _ , h , i , k , l
 v1in,           a , b , c , d , e , x ,___, h , i , k , l
 v1an,           a , b , c , d , e , x ____, h , i , k , l
 v1An,           a , b , c , d , e , x ______h , i , k , l
-v1IN,           a , b , c , d , e , x , g , _ , i , k , l
-v1iN,           a , b , c , d , e , x , g ,___, i , k , l
-v1aN,           a , b , c , d , e , x , g ____, i , k , l
-v1AN,           a , b , c , d , e , x , g ______i , k , l
-v2IL,           a , _ , c , d , e , x , g , h , i , k , l
-v2iL,           a ,___, c , d , e , x , g , h , i , k , l
-v2aL,           a ____, c , d , e , x , g , h , i , k , l
-v2AL,           a ______c , d , e , x , g , h , i , k , l
 v2Il,           a , b , c , _ , e , x , g , h , i , k , l
 v2il,           a , b , c ,___, e , x , g , h , i , k , l
 v2al,           a , b , c ____, e , x , g , h , i , k , l
@@ -2261,15 +2169,7 @@ v2In,           a , b , c , d , e , x , g , _ , i , k , l
 v2in,           a , b , c , d , e , x , g ,___, i , k , l
 v2an,           a , b , c , d , e , x , g ____, i , k , l
 v2An,           a , b , c , d , e , x , g ______i , k , l
-v2IN,           a , b , c , d , e , x , g , h , i , _ , l
-v2iN,           a , b , c , d , e , x , g , h , i ,___, l
-v2aN,           a , b , c , d , e , x , g , h , i ____, l
-v2AN,           a , b , c , d , e , x , g , h , i ______l
 a . b . c . d . e . x . g . h . i . k . l
-cIL.            a . b . c . _ . e . x . g . h . i . k . l
-ciL.            a . b . c ._. e . x . g . h . i . k . l
-caL.            a . b . c _. e . x . g . h . i . k . l
-cAL.            a . b . c _e . x . g . h . i . k . l
 cIl.            a . b . c . d . _ . x . g . h . i . k . l
 cil.            a . b . c . d ._. x . g . h . i . k . l
 cal.            a . b . c . d _. x . g . h . i . k . l
@@ -2282,14 +2182,6 @@ cIn.            a . b . c . d . e . x . _ . h . i . k . l
 cin.            a . b . c . d . e . x ._. h . i . k . l
 can.            a . b . c . d . e . x _. h . i . k . l
 cAn.            a . b . c . d . e . x _h . i . k . l
-cIN.            a . b . c . d . e . x . g . _ . i . k . l
-ciN.            a . b . c . d . e . x . g ._. i . k . l
-caN.            a . b . c . d . e . x . g _. i . k . l
-cAN.            a . b . c . d . e . x . g _i . k . l
-c1IL.           a . b . c . _ . e . x . g . h . i . k . l
-c1iL.           a . b . c ._. e . x . g . h . i . k . l
-c1aL.           a . b . c _. e . x . g . h . i . k . l
-c1AL.           a . b . c _e . x . g . h . i . k . l
 c1Il.           a . b . c . d . _ . x . g . h . i . k . l
 c1il.           a . b . c . d ._. x . g . h . i . k . l
 c1al.           a . b . c . d _. x . g . h . i . k . l
@@ -2302,14 +2194,6 @@ c1In.           a . b . c . d . e . x . _ . h . i . k . l
 c1in.           a . b . c . d . e . x ._. h . i . k . l
 c1an.           a . b . c . d . e . x _. h . i . k . l
 c1An.           a . b . c . d . e . x _h . i . k . l
-c1IN.           a . b . c . d . e . x . g . _ . i . k . l
-c1iN.           a . b . c . d . e . x . g ._. i . k . l
-c1aN.           a . b . c . d . e . x . g _. i . k . l
-c1AN.           a . b . c . d . e . x . g _i . k . l
-c2IL.           a . _ . c . d . e . x . g . h . i . k . l
-c2iL.           a ._. c . d . e . x . g . h . i . k . l
-c2aL.           a _. c . d . e . x . g . h . i . k . l
-c2AL.           a _c . d . e . x . g . h . i . k . l
 c2Il.           a . b . c . _ . e . x . g . h . i . k . l
 c2il.           a . b . c ._. e . x . g . h . i . k . l
 c2al.           a . b . c _. e . x . g . h . i . k . l
@@ -2322,14 +2206,6 @@ c2In.           a . b . c . d . e . x . g . _ . i . k . l
 c2in.           a . b . c . d . e . x . g ._. i . k . l
 c2an.           a . b . c . d . e . x . g _. i . k . l
 c2An.           a . b . c . d . e . x . g _i . k . l
-c2IN.           a . b . c . d . e . x . g . h . i . _ . l
-c2iN.           a . b . c . d . e . x . g . h . i ._. l
-c2aN.           a . b . c . d . e . x . g . h . i _. l
-c2AN.           a . b . c . d . e . x . g . h . i _l
-dIL.            a . b . c .  . e . x . g . h . i . k . l
-diL.            a . b . c .. e . x . g . h . i . k . l
-daL.            a . b . c . e . x . g . h . i . k . l
-dAL.            a . b . c e . x . g . h . i . k . l
 dIl.            a . b . c . d .  . x . g . h . i . k . l
 dil.            a . b . c . d .. x . g . h . i . k . l
 dal.            a . b . c . d . x . g . h . i . k . l
@@ -2342,14 +2218,6 @@ dIn.            a . b . c . d . e . x .  . h . i . k . l
 din.            a . b . c . d . e . x .. h . i . k . l
 dan.            a . b . c . d . e . x . h . i . k . l
 dAn.            a . b . c . d . e . x h . i . k . l
-dIN.            a . b . c . d . e . x . g .  . i . k . l
-diN.            a . b . c . d . e . x . g .. i . k . l
-daN.            a . b . c . d . e . x . g . i . k . l
-dAN.            a . b . c . d . e . x . g i . k . l
-d1IL.           a . b . c .  . e . x . g . h . i . k . l
-d1iL.           a . b . c .. e . x . g . h . i . k . l
-d1aL.           a . b . c . e . x . g . h . i . k . l
-d1AL.           a . b . c e . x . g . h . i . k . l
 d1Il.           a . b . c . d .  . x . g . h . i . k . l
 d1il.           a . b . c . d .. x . g . h . i . k . l
 d1al.           a . b . c . d . x . g . h . i . k . l
@@ -2362,14 +2230,6 @@ d1In.           a . b . c . d . e . x .  . h . i . k . l
 d1in.           a . b . c . d . e . x .. h . i . k . l
 d1an.           a . b . c . d . e . x . h . i . k . l
 d1An.           a . b . c . d . e . x h . i . k . l
-d1IN.           a . b . c . d . e . x . g .  . i . k . l
-d1iN.           a . b . c . d . e . x . g .. i . k . l
-d1aN.           a . b . c . d . e . x . g . i . k . l
-d1AN.           a . b . c . d . e . x . g i . k . l
-d2IL.           a .  . c . d . e . x . g . h . i . k . l
-d2iL.           a .. c . d . e . x . g . h . i . k . l
-d2aL.           a . c . d . e . x . g . h . i . k . l
-d2AL.           a c . d . e . x . g . h . i . k . l
 d2Il.           a . b . c .  . e . x . g . h . i . k . l
 d2il.           a . b . c .. e . x . g . h . i . k . l
 d2al.           a . b . c . e . x . g . h . i . k . l
@@ -2382,14 +2242,6 @@ d2In.           a . b . c . d . e . x . g .  . i . k . l
 d2in.           a . b . c . d . e . x . g .. i . k . l
 d2an.           a . b . c . d . e . x . g . i . k . l
 d2An.           a . b . c . d . e . x . g i . k . l
-d2IN.           a . b . c . d . e . x . g . h . i .  . l
-d2iN.           a . b . c . d . e . x . g . h . i .. l
-d2aN.           a . b . c . d . e . x . g . h . i . l
-d2AN.           a . b . c . d . e . x . g . h . i l
-yIL.            a . b . c . d . e . x . g . h . i . k . l       'd'
-yiL.            a . b . c . d . e . x . g . h . i . k . l       ' d '
-yaL.            a . b . c . d . e . x . g . h . i . k . l       '. d '
-yAL.            a . b . c . d . e . x . g . h . i . k . l       '. d . '
 yIl.            a . b . c . d . e . x . g . h . i . k . l       'e'
 yil.            a . b . c . d . e . x . g . h . i . k . l       ' e '
 yal.            a . b . c . d . e . x . g . h . i . k . l       '. e '
@@ -2402,14 +2254,6 @@ yIn.            a . b . c . d . e . x . g . h . i . k . l       'g'
 yin.            a . b . c . d . e . x . g . h . i . k . l       ' g '
 yan.            a . b . c . d . e . x . g . h . i . k . l       '. g '
 yAn.            a . b . c . d . e . x . g . h . i . k . l       '. g . '
-yIN.            a . b . c . d . e . x . g . h . i . k . l       'h'
-yiN.            a . b . c . d . e . x . g . h . i . k . l       ' h '
-yaN.            a . b . c . d . e . x . g . h . i . k . l       '. h '
-yAN.            a . b . c . d . e . x . g . h . i . k . l       '. h . '
-y1IL.           a . b . c . d . e . x . g . h . i . k . l       'd'
-y1iL.           a . b . c . d . e . x . g . h . i . k . l       ' d '
-y1aL.           a . b . c . d . e . x . g . h . i . k . l       '. d '
-y1AL.           a . b . c . d . e . x . g . h . i . k . l       '. d . '
 y1Il.           a . b . c . d . e . x . g . h . i . k . l       'e'
 y1il.           a . b . c . d . e . x . g . h . i . k . l       ' e '
 y1al.           a . b . c . d . e . x . g . h . i . k . l       '. e '
@@ -2422,14 +2266,6 @@ y1In.           a . b . c . d . e . x . g . h . i . k . l       'g'
 y1in.           a . b . c . d . e . x . g . h . i . k . l       ' g '
 y1an.           a . b . c . d . e . x . g . h . i . k . l       '. g '
 y1An.           a . b . c . d . e . x . g . h . i . k . l       '. g . '
-y1IN.           a . b . c . d . e . x . g . h . i . k . l       'h'
-y1iN.           a . b . c . d . e . x . g . h . i . k . l       ' h '
-y1aN.           a . b . c . d . e . x . g . h . i . k . l       '. h '
-y1AN.           a . b . c . d . e . x . g . h . i . k . l       '. h . '
-y2IL.           a . b . c . d . e . x . g . h . i . k . l       'b'
-y2iL.           a . b . c . d . e . x . g . h . i . k . l       ' b '
-y2aL.           a . b . c . d . e . x . g . h . i . k . l       '. b '
-y2AL.           a . b . c . d . e . x . g . h . i . k . l       '. b . '
 y2Il.           a . b . c . d . e . x . g . h . i . k . l       'd'
 y2il.           a . b . c . d . e . x . g . h . i . k . l       ' d '
 y2al.           a . b . c . d . e . x . g . h . i . k . l       '. d '
@@ -2442,14 +2278,6 @@ y2In.           a . b . c . d . e . x . g . h . i . k . l       'h'
 y2in.           a . b . c . d . e . x . g . h . i . k . l       ' h '
 y2an.           a . b . c . d . e . x . g . h . i . k . l       '. h '
 y2An.           a . b . c . d . e . x . g . h . i . k . l       '. h . '
-y2IN.           a . b . c . d . e . x . g . h . i . k . l       'k'
-y2iN.           a . b . c . d . e . x . g . h . i . k . l       ' k '
-y2aN.           a . b . c . d . e . x . g . h . i . k . l       '. k '
-y2AN.           a . b . c . d . e . x . g . h . i . k . l       '. k . '
-vIL.            a . b . c . _ . e . x . g . h . i . k . l
-viL.            a . b . c .___. e . x . g . h . i . k . l
-vaL.            a . b . c ____. e . x . g . h . i . k . l
-vAL.            a . b . c ______e . x . g . h . i . k . l
 vIl.            a . b . c . d . _ . x . g . h . i . k . l
 vil.            a . b . c . d .___. x . g . h . i . k . l
 val.            a . b . c . d ____. x . g . h . i . k . l
@@ -2462,14 +2290,6 @@ vIn.            a . b . c . d . e . x . _ . h . i . k . l
 vin.            a . b . c . d . e . x .___. h . i . k . l
 van.            a . b . c . d . e . x ____. h . i . k . l
 vAn.            a . b . c . d . e . x ______h . i . k . l
-vIN.            a . b . c . d . e . x . g . _ . i . k . l
-viN.            a . b . c . d . e . x . g .___. i . k . l
-vaN.            a . b . c . d . e . x . g ____. i . k . l
-vAN.            a . b . c . d . e . x . g ______i . k . l
-v1IL.           a . b . c . _ . e . x . g . h . i . k . l
-v1iL.           a . b . c .___. e . x . g . h . i . k . l
-v1aL.           a . b . c ____. e . x . g . h . i . k . l
-v1AL.           a . b . c ______e . x . g . h . i . k . l
 v1Il.           a . b . c . d . _ . x . g . h . i . k . l
 v1il.           a . b . c . d .___. x . g . h . i . k . l
 v1al.           a . b . c . d ____. x . g . h . i . k . l
@@ -2482,14 +2302,6 @@ v1In.           a . b . c . d . e . x . _ . h . i . k . l
 v1in.           a . b . c . d . e . x .___. h . i . k . l
 v1an.           a . b . c . d . e . x ____. h . i . k . l
 v1An.           a . b . c . d . e . x ______h . i . k . l
-v1IN.           a . b . c . d . e . x . g . _ . i . k . l
-v1iN.           a . b . c . d . e . x . g .___. i . k . l
-v1aN.           a . b . c . d . e . x . g ____. i . k . l
-v1AN.           a . b . c . d . e . x . g ______i . k . l
-v2IL.           a . _ . c . d . e . x . g . h . i . k . l
-v2iL.           a .___. c . d . e . x . g . h . i . k . l
-v2aL.           a ____. c . d . e . x . g . h . i . k . l
-v2AL.           a ______c . d . e . x . g . h . i . k . l
 v2Il.           a . b . c . _ . e . x . g . h . i . k . l
 v2il.           a . b . c .___. e . x . g . h . i . k . l
 v2al.           a . b . c ____. e . x . g . h . i . k . l
@@ -2502,15 +2314,7 @@ v2In.           a . b . c . d . e . x . g . _ . i . k . l
 v2in.           a . b . c . d . e . x . g .___. i . k . l
 v2an.           a . b . c . d . e . x . g ____. i . k . l
 v2An.           a . b . c . d . e . x . g ______i . k . l
-v2IN.           a . b . c . d . e . x . g . h . i . _ . l
-v2iN.           a . b . c . d . e . x . g . h . i .___. l
-v2aN.           a . b . c . d . e . x . g . h . i ____. l
-v2AN.           a . b . c . d . e . x . g . h . i ______l
 a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l
-cIL;            a ; b ; c ; _ ; e ; x ; g ; h ; i ; k ; l
-ciL;            a ; b ; c ;_; e ; x ; g ; h ; i ; k ; l
-caL;            a ; b ; c _; e ; x ; g ; h ; i ; k ; l
-cAL;            a ; b ; c _e ; x ; g ; h ; i ; k ; l
 cIl;            a ; b ; c ; d ; _ ; x ; g ; h ; i ; k ; l
 cil;            a ; b ; c ; d ;_; x ; g ; h ; i ; k ; l
 cal;            a ; b ; c ; d _; x ; g ; h ; i ; k ; l
@@ -2523,14 +2327,6 @@ cIn;            a ; b ; c ; d ; e ; x ; _ ; h ; i ; k ; l
 cin;            a ; b ; c ; d ; e ; x ;_; h ; i ; k ; l
 can;            a ; b ; c ; d ; e ; x _; h ; i ; k ; l
 cAn;            a ; b ; c ; d ; e ; x _h ; i ; k ; l
-cIN;            a ; b ; c ; d ; e ; x ; g ; _ ; i ; k ; l
-ciN;            a ; b ; c ; d ; e ; x ; g ;_; i ; k ; l
-caN;            a ; b ; c ; d ; e ; x ; g _; i ; k ; l
-cAN;            a ; b ; c ; d ; e ; x ; g _i ; k ; l
-c1IL;           a ; b ; c ; _ ; e ; x ; g ; h ; i ; k ; l
-c1iL;           a ; b ; c ;_; e ; x ; g ; h ; i ; k ; l
-c1aL;           a ; b ; c _; e ; x ; g ; h ; i ; k ; l
-c1AL;           a ; b ; c _e ; x ; g ; h ; i ; k ; l
 c1Il;           a ; b ; c ; d ; _ ; x ; g ; h ; i ; k ; l
 c1il;           a ; b ; c ; d ;_; x ; g ; h ; i ; k ; l
 c1al;           a ; b ; c ; d _; x ; g ; h ; i ; k ; l
@@ -2543,14 +2339,6 @@ c1In;           a ; b ; c ; d ; e ; x ; _ ; h ; i ; k ; l
 c1in;           a ; b ; c ; d ; e ; x ;_; h ; i ; k ; l
 c1an;           a ; b ; c ; d ; e ; x _; h ; i ; k ; l
 c1An;           a ; b ; c ; d ; e ; x _h ; i ; k ; l
-c1IN;           a ; b ; c ; d ; e ; x ; g ; _ ; i ; k ; l
-c1iN;           a ; b ; c ; d ; e ; x ; g ;_; i ; k ; l
-c1aN;           a ; b ; c ; d ; e ; x ; g _; i ; k ; l
-c1AN;           a ; b ; c ; d ; e ; x ; g _i ; k ; l
-c2IL;           a ; _ ; c ; d ; e ; x ; g ; h ; i ; k ; l
-c2iL;           a ;_; c ; d ; e ; x ; g ; h ; i ; k ; l
-c2aL;           a _; c ; d ; e ; x ; g ; h ; i ; k ; l
-c2AL;           a _c ; d ; e ; x ; g ; h ; i ; k ; l
 c2Il;           a ; b ; c ; _ ; e ; x ; g ; h ; i ; k ; l
 c2il;           a ; b ; c ;_; e ; x ; g ; h ; i ; k ; l
 c2al;           a ; b ; c _; e ; x ; g ; h ; i ; k ; l
@@ -2563,14 +2351,6 @@ c2In;           a ; b ; c ; d ; e ; x ; g ; _ ; i ; k ; l
 c2in;           a ; b ; c ; d ; e ; x ; g ;_; i ; k ; l
 c2an;           a ; b ; c ; d ; e ; x ; g _; i ; k ; l
 c2An;           a ; b ; c ; d ; e ; x ; g _i ; k ; l
-c2IN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; _ ; l
-c2iN;           a ; b ; c ; d ; e ; x ; g ; h ; i ;_; l
-c2aN;           a ; b ; c ; d ; e ; x ; g ; h ; i _; l
-c2AN;           a ; b ; c ; d ; e ; x ; g ; h ; i _l
-dIL;            a ; b ; c ;  ; e ; x ; g ; h ; i ; k ; l
-diL;            a ; b ; c ;; e ; x ; g ; h ; i ; k ; l
-daL;            a ; b ; c ; e ; x ; g ; h ; i ; k ; l
-dAL;            a ; b ; c e ; x ; g ; h ; i ; k ; l
 dIl;            a ; b ; c ; d ;  ; x ; g ; h ; i ; k ; l
 dil;            a ; b ; c ; d ;; x ; g ; h ; i ; k ; l
 dal;            a ; b ; c ; d ; x ; g ; h ; i ; k ; l
@@ -2583,14 +2363,6 @@ dIn;            a ; b ; c ; d ; e ; x ;  ; h ; i ; k ; l
 din;            a ; b ; c ; d ; e ; x ;; h ; i ; k ; l
 dan;            a ; b ; c ; d ; e ; x ; h ; i ; k ; l
 dAn;            a ; b ; c ; d ; e ; x h ; i ; k ; l
-dIN;            a ; b ; c ; d ; e ; x ; g ;  ; i ; k ; l
-diN;            a ; b ; c ; d ; e ; x ; g ;; i ; k ; l
-daN;            a ; b ; c ; d ; e ; x ; g ; i ; k ; l
-dAN;            a ; b ; c ; d ; e ; x ; g i ; k ; l
-d1IL;           a ; b ; c ;  ; e ; x ; g ; h ; i ; k ; l
-d1iL;           a ; b ; c ;; e ; x ; g ; h ; i ; k ; l
-d1aL;           a ; b ; c ; e ; x ; g ; h ; i ; k ; l
-d1AL;           a ; b ; c e ; x ; g ; h ; i ; k ; l
 d1Il;           a ; b ; c ; d ;  ; x ; g ; h ; i ; k ; l
 d1il;           a ; b ; c ; d ;; x ; g ; h ; i ; k ; l
 d1al;           a ; b ; c ; d ; x ; g ; h ; i ; k ; l
@@ -2603,14 +2375,6 @@ d1In;           a ; b ; c ; d ; e ; x ;  ; h ; i ; k ; l
 d1in;           a ; b ; c ; d ; e ; x ;; h ; i ; k ; l
 d1an;           a ; b ; c ; d ; e ; x ; h ; i ; k ; l
 d1An;           a ; b ; c ; d ; e ; x h ; i ; k ; l
-d1IN;           a ; b ; c ; d ; e ; x ; g ;  ; i ; k ; l
-d1iN;           a ; b ; c ; d ; e ; x ; g ;; i ; k ; l
-d1aN;           a ; b ; c ; d ; e ; x ; g ; i ; k ; l
-d1AN;           a ; b ; c ; d ; e ; x ; g i ; k ; l
-d2IL;           a ;  ; c ; d ; e ; x ; g ; h ; i ; k ; l
-d2iL;           a ;; c ; d ; e ; x ; g ; h ; i ; k ; l
-d2aL;           a ; c ; d ; e ; x ; g ; h ; i ; k ; l
-d2AL;           a c ; d ; e ; x ; g ; h ; i ; k ; l
 d2Il;           a ; b ; c ;  ; e ; x ; g ; h ; i ; k ; l
 d2il;           a ; b ; c ;; e ; x ; g ; h ; i ; k ; l
 d2al;           a ; b ; c ; e ; x ; g ; h ; i ; k ; l
@@ -2623,14 +2387,6 @@ d2In;           a ; b ; c ; d ; e ; x ; g ;  ; i ; k ; l
 d2in;           a ; b ; c ; d ; e ; x ; g ;; i ; k ; l
 d2an;           a ; b ; c ; d ; e ; x ; g ; i ; k ; l
 d2An;           a ; b ; c ; d ; e ; x ; g i ; k ; l
-d2IN;           a ; b ; c ; d ; e ; x ; g ; h ; i ;  ; l
-d2iN;           a ; b ; c ; d ; e ; x ; g ; h ; i ;; l
-d2aN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; l
-d2AN;           a ; b ; c ; d ; e ; x ; g ; h ; i l
-yIL;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'd'
-yiL;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' d '
-yaL;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; d '
-yAL;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; d ; '
 yIl;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'e'
 yil;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' e '
 yal;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; e '
@@ -2643,14 +2399,6 @@ yIn;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'g'
 yin;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' g '
 yan;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; g '
 yAn;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; g ; '
-yIN;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'h'
-yiN;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' h '
-yaN;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; h '
-yAN;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; h ; '
-y1IL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'd'
-y1iL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' d '
-y1aL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; d '
-y1AL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; d ; '
 y1Il;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'e'
 y1il;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' e '
 y1al;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; e '
@@ -2663,14 +2411,6 @@ y1In;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'g'
 y1in;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' g '
 y1an;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; g '
 y1An;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; g ; '
-y1IN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'h'
-y1iN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' h '
-y1aN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; h '
-y1AN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; h ; '
-y2IL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'b'
-y2iL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' b '
-y2aL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; b '
-y2AL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; b ; '
 y2Il;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'd'
 y2il;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' d '
 y2al;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; d '
@@ -2683,14 +2423,6 @@ y2In;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'h'
 y2in;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' h '
 y2an;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; h '
 y2An;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; h ; '
-y2IN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'k'
-y2iN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' k '
-y2aN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; k '
-y2AN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; k ; '
-vIL;            a ; b ; c ; _ ; e ; x ; g ; h ; i ; k ; l
-viL;            a ; b ; c ;___; e ; x ; g ; h ; i ; k ; l
-vaL;            a ; b ; c ____; e ; x ; g ; h ; i ; k ; l
-vAL;            a ; b ; c ______e ; x ; g ; h ; i ; k ; l
 vIl;            a ; b ; c ; d ; _ ; x ; g ; h ; i ; k ; l
 vil;            a ; b ; c ; d ;___; x ; g ; h ; i ; k ; l
 val;            a ; b ; c ; d ____; x ; g ; h ; i ; k ; l
@@ -2703,14 +2435,6 @@ vIn;            a ; b ; c ; d ; e ; x ; _ ; h ; i ; k ; l
 vin;            a ; b ; c ; d ; e ; x ;___; h ; i ; k ; l
 van;            a ; b ; c ; d ; e ; x ____; h ; i ; k ; l
 vAn;            a ; b ; c ; d ; e ; x ______h ; i ; k ; l
-vIN;            a ; b ; c ; d ; e ; x ; g ; _ ; i ; k ; l
-viN;            a ; b ; c ; d ; e ; x ; g ;___; i ; k ; l
-vaN;            a ; b ; c ; d ; e ; x ; g ____; i ; k ; l
-vAN;            a ; b ; c ; d ; e ; x ; g ______i ; k ; l
-v1IL;           a ; b ; c ; _ ; e ; x ; g ; h ; i ; k ; l
-v1iL;           a ; b ; c ;___; e ; x ; g ; h ; i ; k ; l
-v1aL;           a ; b ; c ____; e ; x ; g ; h ; i ; k ; l
-v1AL;           a ; b ; c ______e ; x ; g ; h ; i ; k ; l
 v1Il;           a ; b ; c ; d ; _ ; x ; g ; h ; i ; k ; l
 v1il;           a ; b ; c ; d ;___; x ; g ; h ; i ; k ; l
 v1al;           a ; b ; c ; d ____; x ; g ; h ; i ; k ; l
@@ -2723,14 +2447,6 @@ v1In;           a ; b ; c ; d ; e ; x ; _ ; h ; i ; k ; l
 v1in;           a ; b ; c ; d ; e ; x ;___; h ; i ; k ; l
 v1an;           a ; b ; c ; d ; e ; x ____; h ; i ; k ; l
 v1An;           a ; b ; c ; d ; e ; x ______h ; i ; k ; l
-v1IN;           a ; b ; c ; d ; e ; x ; g ; _ ; i ; k ; l
-v1iN;           a ; b ; c ; d ; e ; x ; g ;___; i ; k ; l
-v1aN;           a ; b ; c ; d ; e ; x ; g ____; i ; k ; l
-v1AN;           a ; b ; c ; d ; e ; x ; g ______i ; k ; l
-v2IL;           a ; _ ; c ; d ; e ; x ; g ; h ; i ; k ; l
-v2iL;           a ;___; c ; d ; e ; x ; g ; h ; i ; k ; l
-v2aL;           a ____; c ; d ; e ; x ; g ; h ; i ; k ; l
-v2AL;           a ______c ; d ; e ; x ; g ; h ; i ; k ; l
 v2Il;           a ; b ; c ; _ ; e ; x ; g ; h ; i ; k ; l
 v2il;           a ; b ; c ;___; e ; x ; g ; h ; i ; k ; l
 v2al;           a ; b ; c ____; e ; x ; g ; h ; i ; k ; l
@@ -2743,15 +2459,7 @@ v2In;           a ; b ; c ; d ; e ; x ; g ; _ ; i ; k ; l
 v2in;           a ; b ; c ; d ; e ; x ; g ;___; i ; k ; l
 v2an;           a ; b ; c ; d ; e ; x ; g ____; i ; k ; l
 v2An;           a ; b ; c ; d ; e ; x ; g ______i ; k ; l
-v2IN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; _ ; l
-v2iN;           a ; b ; c ; d ; e ; x ; g ; h ; i ;___; l
-v2aN;           a ; b ; c ; d ; e ; x ; g ; h ; i ____; l
-v2AN;           a ; b ; c ; d ; e ; x ; g ; h ; i ______l
 a : b : c : d : e : x : g : h : i : k : l
-cIL:            a : b : c : _ : e : x : g : h : i : k : l
-ciL:            a : b : c :_: e : x : g : h : i : k : l
-caL:            a : b : c _: e : x : g : h : i : k : l
-cAL:            a : b : c _e : x : g : h : i : k : l
 cIl:            a : b : c : d : _ : x : g : h : i : k : l
 cil:            a : b : c : d :_: x : g : h : i : k : l
 cal:            a : b : c : d _: x : g : h : i : k : l
@@ -2764,14 +2472,6 @@ cIn:            a : b : c : d : e : x : _ : h : i : k : l
 cin:            a : b : c : d : e : x :_: h : i : k : l
 can:            a : b : c : d : e : x _: h : i : k : l
 cAn:            a : b : c : d : e : x _h : i : k : l
-cIN:            a : b : c : d : e : x : g : _ : i : k : l
-ciN:            a : b : c : d : e : x : g :_: i : k : l
-caN:            a : b : c : d : e : x : g _: i : k : l
-cAN:            a : b : c : d : e : x : g _i : k : l
-c1IL:           a : b : c : _ : e : x : g : h : i : k : l
-c1iL:           a : b : c :_: e : x : g : h : i : k : l
-c1aL:           a : b : c _: e : x : g : h : i : k : l
-c1AL:           a : b : c _e : x : g : h : i : k : l
 c1Il:           a : b : c : d : _ : x : g : h : i : k : l
 c1il:           a : b : c : d :_: x : g : h : i : k : l
 c1al:           a : b : c : d _: x : g : h : i : k : l
@@ -2784,14 +2484,6 @@ c1In:           a : b : c : d : e : x : _ : h : i : k : l
 c1in:           a : b : c : d : e : x :_: h : i : k : l
 c1an:           a : b : c : d : e : x _: h : i : k : l
 c1An:           a : b : c : d : e : x _h : i : k : l
-c1IN:           a : b : c : d : e : x : g : _ : i : k : l
-c1iN:           a : b : c : d : e : x : g :_: i : k : l
-c1aN:           a : b : c : d : e : x : g _: i : k : l
-c1AN:           a : b : c : d : e : x : g _i : k : l
-c2IL:           a : _ : c : d : e : x : g : h : i : k : l
-c2iL:           a :_: c : d : e : x : g : h : i : k : l
-c2aL:           a _: c : d : e : x : g : h : i : k : l
-c2AL:           a _c : d : e : x : g : h : i : k : l
 c2Il:           a : b : c : _ : e : x : g : h : i : k : l
 c2il:           a : b : c :_: e : x : g : h : i : k : l
 c2al:           a : b : c _: e : x : g : h : i : k : l
@@ -2804,14 +2496,6 @@ c2In:           a : b : c : d : e : x : g : _ : i : k : l
 c2in:           a : b : c : d : e : x : g :_: i : k : l
 c2an:           a : b : c : d : e : x : g _: i : k : l
 c2An:           a : b : c : d : e : x : g _i : k : l
-c2IN:           a : b : c : d : e : x : g : h : i : _ : l
-c2iN:           a : b : c : d : e : x : g : h : i :_: l
-c2aN:           a : b : c : d : e : x : g : h : i _: l
-c2AN:           a : b : c : d : e : x : g : h : i _l
-dIL:            a : b : c :  : e : x : g : h : i : k : l
-diL:            a : b : c :: e : x : g : h : i : k : l
-daL:            a : b : c : e : x : g : h : i : k : l
-dAL:            a : b : c e : x : g : h : i : k : l
 dIl:            a : b : c : d :  : x : g : h : i : k : l
 dil:            a : b : c : d :: x : g : h : i : k : l
 dal:            a : b : c : d : x : g : h : i : k : l
@@ -2824,14 +2508,6 @@ dIn:            a : b : c : d : e : x :  : h : i : k : l
 din:            a : b : c : d : e : x :: h : i : k : l
 dan:            a : b : c : d : e : x : h : i : k : l
 dAn:            a : b : c : d : e : x h : i : k : l
-dIN:            a : b : c : d : e : x : g :  : i : k : l
-diN:            a : b : c : d : e : x : g :: i : k : l
-daN:            a : b : c : d : e : x : g : i : k : l
-dAN:            a : b : c : d : e : x : g i : k : l
-d1IL:           a : b : c :  : e : x : g : h : i : k : l
-d1iL:           a : b : c :: e : x : g : h : i : k : l
-d1aL:           a : b : c : e : x : g : h : i : k : l
-d1AL:           a : b : c e : x : g : h : i : k : l
 d1Il:           a : b : c : d :  : x : g : h : i : k : l
 d1il:           a : b : c : d :: x : g : h : i : k : l
 d1al:           a : b : c : d : x : g : h : i : k : l
@@ -2844,14 +2520,6 @@ d1In:           a : b : c : d : e : x :  : h : i : k : l
 d1in:           a : b : c : d : e : x :: h : i : k : l
 d1an:           a : b : c : d : e : x : h : i : k : l
 d1An:           a : b : c : d : e : x h : i : k : l
-d1IN:           a : b : c : d : e : x : g :  : i : k : l
-d1iN:           a : b : c : d : e : x : g :: i : k : l
-d1aN:           a : b : c : d : e : x : g : i : k : l
-d1AN:           a : b : c : d : e : x : g i : k : l
-d2IL:           a :  : c : d : e : x : g : h : i : k : l
-d2iL:           a :: c : d : e : x : g : h : i : k : l
-d2aL:           a : c : d : e : x : g : h : i : k : l
-d2AL:           a c : d : e : x : g : h : i : k : l
 d2Il:           a : b : c :  : e : x : g : h : i : k : l
 d2il:           a : b : c :: e : x : g : h : i : k : l
 d2al:           a : b : c : e : x : g : h : i : k : l
@@ -2864,14 +2532,6 @@ d2In:           a : b : c : d : e : x : g :  : i : k : l
 d2in:           a : b : c : d : e : x : g :: i : k : l
 d2an:           a : b : c : d : e : x : g : i : k : l
 d2An:           a : b : c : d : e : x : g i : k : l
-d2IN:           a : b : c : d : e : x : g : h : i :  : l
-d2iN:           a : b : c : d : e : x : g : h : i :: l
-d2aN:           a : b : c : d : e : x : g : h : i : l
-d2AN:           a : b : c : d : e : x : g : h : i l
-yIL:            a : b : c : d : e : x : g : h : i : k : l       'd'
-yiL:            a : b : c : d : e : x : g : h : i : k : l       ' d '
-yaL:            a : b : c : d : e : x : g : h : i : k : l       ': d '
-yAL:            a : b : c : d : e : x : g : h : i : k : l       ': d : '
 yIl:            a : b : c : d : e : x : g : h : i : k : l       'e'
 yil:            a : b : c : d : e : x : g : h : i : k : l       ' e '
 yal:            a : b : c : d : e : x : g : h : i : k : l       ': e '
@@ -2884,14 +2544,6 @@ yIn:            a : b : c : d : e : x : g : h : i : k : l       'g'
 yin:            a : b : c : d : e : x : g : h : i : k : l       ' g '
 yan:            a : b : c : d : e : x : g : h : i : k : l       ': g '
 yAn:            a : b : c : d : e : x : g : h : i : k : l       ': g : '
-yIN:            a : b : c : d : e : x : g : h : i : k : l       'h'
-yiN:            a : b : c : d : e : x : g : h : i : k : l       ' h '
-yaN:            a : b : c : d : e : x : g : h : i : k : l       ': h '
-yAN:            a : b : c : d : e : x : g : h : i : k : l       ': h : '
-y1IL:           a : b : c : d : e : x : g : h : i : k : l       'd'
-y1iL:           a : b : c : d : e : x : g : h : i : k : l       ' d '
-y1aL:           a : b : c : d : e : x : g : h : i : k : l       ': d '
-y1AL:           a : b : c : d : e : x : g : h : i : k : l       ': d : '
 y1Il:           a : b : c : d : e : x : g : h : i : k : l       'e'
 y1il:           a : b : c : d : e : x : g : h : i : k : l       ' e '
 y1al:           a : b : c : d : e : x : g : h : i : k : l       ': e '
@@ -2904,14 +2556,6 @@ y1In:           a : b : c : d : e : x : g : h : i : k : l       'g'
 y1in:           a : b : c : d : e : x : g : h : i : k : l       ' g '
 y1an:           a : b : c : d : e : x : g : h : i : k : l       ': g '
 y1An:           a : b : c : d : e : x : g : h : i : k : l       ': g : '
-y1IN:           a : b : c : d : e : x : g : h : i : k : l       'h'
-y1iN:           a : b : c : d : e : x : g : h : i : k : l       ' h '
-y1aN:           a : b : c : d : e : x : g : h : i : k : l       ': h '
-y1AN:           a : b : c : d : e : x : g : h : i : k : l       ': h : '
-y2IL:           a : b : c : d : e : x : g : h : i : k : l       'b'
-y2iL:           a : b : c : d : e : x : g : h : i : k : l       ' b '
-y2aL:           a : b : c : d : e : x : g : h : i : k : l       ': b '
-y2AL:           a : b : c : d : e : x : g : h : i : k : l       ': b : '
 y2Il:           a : b : c : d : e : x : g : h : i : k : l       'd'
 y2il:           a : b : c : d : e : x : g : h : i : k : l       ' d '
 y2al:           a : b : c : d : e : x : g : h : i : k : l       ': d '
@@ -2924,14 +2568,6 @@ y2In:           a : b : c : d : e : x : g : h : i : k : l       'h'
 y2in:           a : b : c : d : e : x : g : h : i : k : l       ' h '
 y2an:           a : b : c : d : e : x : g : h : i : k : l       ': h '
 y2An:           a : b : c : d : e : x : g : h : i : k : l       ': h : '
-y2IN:           a : b : c : d : e : x : g : h : i : k : l       'k'
-y2iN:           a : b : c : d : e : x : g : h : i : k : l       ' k '
-y2aN:           a : b : c : d : e : x : g : h : i : k : l       ': k '
-y2AN:           a : b : c : d : e : x : g : h : i : k : l       ': k : '
-vIL:            a : b : c : _ : e : x : g : h : i : k : l
-viL:            a : b : c :___: e : x : g : h : i : k : l
-vaL:            a : b : c ____: e : x : g : h : i : k : l
-vAL:            a : b : c ______e : x : g : h : i : k : l
 vIl:            a : b : c : d : _ : x : g : h : i : k : l
 vil:            a : b : c : d :___: x : g : h : i : k : l
 val:            a : b : c : d ____: x : g : h : i : k : l
@@ -2944,14 +2580,6 @@ vIn:            a : b : c : d : e : x : _ : h : i : k : l
 vin:            a : b : c : d : e : x :___: h : i : k : l
 van:            a : b : c : d : e : x ____: h : i : k : l
 vAn:            a : b : c : d : e : x ______h : i : k : l
-vIN:            a : b : c : d : e : x : g : _ : i : k : l
-viN:            a : b : c : d : e : x : g :___: i : k : l
-vaN:            a : b : c : d : e : x : g ____: i : k : l
-vAN:            a : b : c : d : e : x : g ______i : k : l
-v1IL:           a : b : c : _ : e : x : g : h : i : k : l
-v1iL:           a : b : c :___: e : x : g : h : i : k : l
-v1aL:           a : b : c ____: e : x : g : h : i : k : l
-v1AL:           a : b : c ______e : x : g : h : i : k : l
 v1Il:           a : b : c : d : _ : x : g : h : i : k : l
 v1il:           a : b : c : d :___: x : g : h : i : k : l
 v1al:           a : b : c : d ____: x : g : h : i : k : l
@@ -2964,14 +2592,6 @@ v1In:           a : b : c : d : e : x : _ : h : i : k : l
 v1in:           a : b : c : d : e : x :___: h : i : k : l
 v1an:           a : b : c : d : e : x ____: h : i : k : l
 v1An:           a : b : c : d : e : x ______h : i : k : l
-v1IN:           a : b : c : d : e : x : g : _ : i : k : l
-v1iN:           a : b : c : d : e : x : g :___: i : k : l
-v1aN:           a : b : c : d : e : x : g ____: i : k : l
-v1AN:           a : b : c : d : e : x : g ______i : k : l
-v2IL:           a : _ : c : d : e : x : g : h : i : k : l
-v2iL:           a :___: c : d : e : x : g : h : i : k : l
-v2aL:           a ____: c : d : e : x : g : h : i : k : l
-v2AL:           a ______c : d : e : x : g : h : i : k : l
 v2Il:           a : b : c : _ : e : x : g : h : i : k : l
 v2il:           a : b : c :___: e : x : g : h : i : k : l
 v2al:           a : b : c ____: e : x : g : h : i : k : l
@@ -2984,15 +2604,7 @@ v2In:           a : b : c : d : e : x : g : _ : i : k : l
 v2in:           a : b : c : d : e : x : g :___: i : k : l
 v2an:           a : b : c : d : e : x : g ____: i : k : l
 v2An:           a : b : c : d : e : x : g ______i : k : l
-v2IN:           a : b : c : d : e : x : g : h : i : _ : l
-v2iN:           a : b : c : d : e : x : g : h : i :___: l
-v2aN:           a : b : c : d : e : x : g : h : i ____: l
-v2AN:           a : b : c : d : e : x : g : h : i ______l
 a + b + c + d + e + x + g + h + i + k + l
-cIL+            a + b + c + _ + e + x + g + h + i + k + l
-ciL+            a + b + c +_+ e + x + g + h + i + k + l
-caL+            a + b + c _+ e + x + g + h + i + k + l
-cAL+            a + b + c _e + x + g + h + i + k + l
 cIl+            a + b + c + d + _ + x + g + h + i + k + l
 cil+            a + b + c + d +_+ x + g + h + i + k + l
 cal+            a + b + c + d _+ x + g + h + i + k + l
@@ -3005,14 +2617,6 @@ cIn+            a + b + c + d + e + x + _ + h + i + k + l
 cin+            a + b + c + d + e + x +_+ h + i + k + l
 can+            a + b + c + d + e + x _+ h + i + k + l
 cAn+            a + b + c + d + e + x _h + i + k + l
-cIN+            a + b + c + d + e + x + g + _ + i + k + l
-ciN+            a + b + c + d + e + x + g +_+ i + k + l
-caN+            a + b + c + d + e + x + g _+ i + k + l
-cAN+            a + b + c + d + e + x + g _i + k + l
-c1IL+           a + b + c + _ + e + x + g + h + i + k + l
-c1iL+           a + b + c +_+ e + x + g + h + i + k + l
-c1aL+           a + b + c _+ e + x + g + h + i + k + l
-c1AL+           a + b + c _e + x + g + h + i + k + l
 c1Il+           a + b + c + d + _ + x + g + h + i + k + l
 c1il+           a + b + c + d +_+ x + g + h + i + k + l
 c1al+           a + b + c + d _+ x + g + h + i + k + l
@@ -3025,14 +2629,6 @@ c1In+           a + b + c + d + e + x + _ + h + i + k + l
 c1in+           a + b + c + d + e + x +_+ h + i + k + l
 c1an+           a + b + c + d + e + x _+ h + i + k + l
 c1An+           a + b + c + d + e + x _h + i + k + l
-c1IN+           a + b + c + d + e + x + g + _ + i + k + l
-c1iN+           a + b + c + d + e + x + g +_+ i + k + l
-c1aN+           a + b + c + d + e + x + g _+ i + k + l
-c1AN+           a + b + c + d + e + x + g _i + k + l
-c2IL+           a + _ + c + d + e + x + g + h + i + k + l
-c2iL+           a +_+ c + d + e + x + g + h + i + k + l
-c2aL+           a _+ c + d + e + x + g + h + i + k + l
-c2AL+           a _c + d + e + x + g + h + i + k + l
 c2Il+           a + b + c + _ + e + x + g + h + i + k + l
 c2il+           a + b + c +_+ e + x + g + h + i + k + l
 c2al+           a + b + c _+ e + x + g + h + i + k + l
@@ -3045,14 +2641,6 @@ c2In+           a + b + c + d + e + x + g + _ + i + k + l
 c2in+           a + b + c + d + e + x + g +_+ i + k + l
 c2an+           a + b + c + d + e + x + g _+ i + k + l
 c2An+           a + b + c + d + e + x + g _i + k + l
-c2IN+           a + b + c + d + e + x + g + h + i + _ + l
-c2iN+           a + b + c + d + e + x + g + h + i +_+ l
-c2aN+           a + b + c + d + e + x + g + h + i _+ l
-c2AN+           a + b + c + d + e + x + g + h + i _l
-dIL+            a + b + c +  + e + x + g + h + i + k + l
-diL+            a + b + c ++ e + x + g + h + i + k + l
-daL+            a + b + c + e + x + g + h + i + k + l
-dAL+            a + b + c e + x + g + h + i + k + l
 dIl+            a + b + c + d +  + x + g + h + i + k + l
 dil+            a + b + c + d ++ x + g + h + i + k + l
 dal+            a + b + c + d + x + g + h + i + k + l
@@ -3065,14 +2653,6 @@ dIn+            a + b + c + d + e + x +  + h + i + k + l
 din+            a + b + c + d + e + x ++ h + i + k + l
 dan+            a + b + c + d + e + x + h + i + k + l
 dAn+            a + b + c + d + e + x h + i + k + l
-dIN+            a + b + c + d + e + x + g +  + i + k + l
-diN+            a + b + c + d + e + x + g ++ i + k + l
-daN+            a + b + c + d + e + x + g + i + k + l
-dAN+            a + b + c + d + e + x + g i + k + l
-d1IL+           a + b + c +  + e + x + g + h + i + k + l
-d1iL+           a + b + c ++ e + x + g + h + i + k + l
-d1aL+           a + b + c + e + x + g + h + i + k + l
-d1AL+           a + b + c e + x + g + h + i + k + l
 d1Il+           a + b + c + d +  + x + g + h + i + k + l
 d1il+           a + b + c + d ++ x + g + h + i + k + l
 d1al+           a + b + c + d + x + g + h + i + k + l
@@ -3085,14 +2665,6 @@ d1In+           a + b + c + d + e + x +  + h + i + k + l
 d1in+           a + b + c + d + e + x ++ h + i + k + l
 d1an+           a + b + c + d + e + x + h + i + k + l
 d1An+           a + b + c + d + e + x h + i + k + l
-d1IN+           a + b + c + d + e + x + g +  + i + k + l
-d1iN+           a + b + c + d + e + x + g ++ i + k + l
-d1aN+           a + b + c + d + e + x + g + i + k + l
-d1AN+           a + b + c + d + e + x + g i + k + l
-d2IL+           a +  + c + d + e + x + g + h + i + k + l
-d2iL+           a ++ c + d + e + x + g + h + i + k + l
-d2aL+           a + c + d + e + x + g + h + i + k + l
-d2AL+           a c + d + e + x + g + h + i + k + l
 d2Il+           a + b + c +  + e + x + g + h + i + k + l
 d2il+           a + b + c ++ e + x + g + h + i + k + l
 d2al+           a + b + c + e + x + g + h + i + k + l
@@ -3105,14 +2677,6 @@ d2In+           a + b + c + d + e + x + g +  + i + k + l
 d2in+           a + b + c + d + e + x + g ++ i + k + l
 d2an+           a + b + c + d + e + x + g + i + k + l
 d2An+           a + b + c + d + e + x + g i + k + l
-d2IN+           a + b + c + d + e + x + g + h + i +  + l
-d2iN+           a + b + c + d + e + x + g + h + i ++ l
-d2aN+           a + b + c + d + e + x + g + h + i + l
-d2AN+           a + b + c + d + e + x + g + h + i l
-yIL+            a + b + c + d + e + x + g + h + i + k + l       'd'
-yiL+            a + b + c + d + e + x + g + h + i + k + l       ' d '
-yaL+            a + b + c + d + e + x + g + h + i + k + l       '+ d '
-yAL+            a + b + c + d + e + x + g + h + i + k + l       '+ d + '
 yIl+            a + b + c + d + e + x + g + h + i + k + l       'e'
 yil+            a + b + c + d + e + x + g + h + i + k + l       ' e '
 yal+            a + b + c + d + e + x + g + h + i + k + l       '+ e '
@@ -3125,14 +2689,6 @@ yIn+            a + b + c + d + e + x + g + h + i + k + l       'g'
 yin+            a + b + c + d + e + x + g + h + i + k + l       ' g '
 yan+            a + b + c + d + e + x + g + h + i + k + l       '+ g '
 yAn+            a + b + c + d + e + x + g + h + i + k + l       '+ g + '
-yIN+            a + b + c + d + e + x + g + h + i + k + l       'h'
-yiN+            a + b + c + d + e + x + g + h + i + k + l       ' h '
-yaN+            a + b + c + d + e + x + g + h + i + k + l       '+ h '
-yAN+            a + b + c + d + e + x + g + h + i + k + l       '+ h + '
-y1IL+           a + b + c + d + e + x + g + h + i + k + l       'd'
-y1iL+           a + b + c + d + e + x + g + h + i + k + l       ' d '
-y1aL+           a + b + c + d + e + x + g + h + i + k + l       '+ d '
-y1AL+           a + b + c + d + e + x + g + h + i + k + l       '+ d + '
 y1Il+           a + b + c + d + e + x + g + h + i + k + l       'e'
 y1il+           a + b + c + d + e + x + g + h + i + k + l       ' e '
 y1al+           a + b + c + d + e + x + g + h + i + k + l       '+ e '
@@ -3145,14 +2701,6 @@ y1In+           a + b + c + d + e + x + g + h + i + k + l       'g'
 y1in+           a + b + c + d + e + x + g + h + i + k + l       ' g '
 y1an+           a + b + c + d + e + x + g + h + i + k + l       '+ g '
 y1An+           a + b + c + d + e + x + g + h + i + k + l       '+ g + '
-y1IN+           a + b + c + d + e + x + g + h + i + k + l       'h'
-y1iN+           a + b + c + d + e + x + g + h + i + k + l       ' h '
-y1aN+           a + b + c + d + e + x + g + h + i + k + l       '+ h '
-y1AN+           a + b + c + d + e + x + g + h + i + k + l       '+ h + '
-y2IL+           a + b + c + d + e + x + g + h + i + k + l       'b'
-y2iL+           a + b + c + d + e + x + g + h + i + k + l       ' b '
-y2aL+           a + b + c + d + e + x + g + h + i + k + l       '+ b '
-y2AL+           a + b + c + d + e + x + g + h + i + k + l       '+ b + '
 y2Il+           a + b + c + d + e + x + g + h + i + k + l       'd'
 y2il+           a + b + c + d + e + x + g + h + i + k + l       ' d '
 y2al+           a + b + c + d + e + x + g + h + i + k + l       '+ d '
@@ -3165,14 +2713,6 @@ y2In+           a + b + c + d + e + x + g + h + i + k + l       'h'
 y2in+           a + b + c + d + e + x + g + h + i + k + l       ' h '
 y2an+           a + b + c + d + e + x + g + h + i + k + l       '+ h '
 y2An+           a + b + c + d + e + x + g + h + i + k + l       '+ h + '
-y2IN+           a + b + c + d + e + x + g + h + i + k + l       'k'
-y2iN+           a + b + c + d + e + x + g + h + i + k + l       ' k '
-y2aN+           a + b + c + d + e + x + g + h + i + k + l       '+ k '
-y2AN+           a + b + c + d + e + x + g + h + i + k + l       '+ k + '
-vIL+            a + b + c + _ + e + x + g + h + i + k + l
-viL+            a + b + c +___+ e + x + g + h + i + k + l
-vaL+            a + b + c ____+ e + x + g + h + i + k + l
-vAL+            a + b + c ______e + x + g + h + i + k + l
 vIl+            a + b + c + d + _ + x + g + h + i + k + l
 vil+            a + b + c + d +___+ x + g + h + i + k + l
 val+            a + b + c + d ____+ x + g + h + i + k + l
@@ -3185,14 +2725,6 @@ vIn+            a + b + c + d + e + x + _ + h + i + k + l
 vin+            a + b + c + d + e + x +___+ h + i + k + l
 van+            a + b + c + d + e + x ____+ h + i + k + l
 vAn+            a + b + c + d + e + x ______h + i + k + l
-vIN+            a + b + c + d + e + x + g + _ + i + k + l
-viN+            a + b + c + d + e + x + g +___+ i + k + l
-vaN+            a + b + c + d + e + x + g ____+ i + k + l
-vAN+            a + b + c + d + e + x + g ______i + k + l
-v1IL+           a + b + c + _ + e + x + g + h + i + k + l
-v1iL+           a + b + c +___+ e + x + g + h + i + k + l
-v1aL+           a + b + c ____+ e + x + g + h + i + k + l
-v1AL+           a + b + c ______e + x + g + h + i + k + l
 v1Il+           a + b + c + d + _ + x + g + h + i + k + l
 v1il+           a + b + c + d +___+ x + g + h + i + k + l
 v1al+           a + b + c + d ____+ x + g + h + i + k + l
@@ -3205,14 +2737,6 @@ v1In+           a + b + c + d + e + x + _ + h + i + k + l
 v1in+           a + b + c + d + e + x +___+ h + i + k + l
 v1an+           a + b + c + d + e + x ____+ h + i + k + l
 v1An+           a + b + c + d + e + x ______h + i + k + l
-v1IN+           a + b + c + d + e + x + g + _ + i + k + l
-v1iN+           a + b + c + d + e + x + g +___+ i + k + l
-v1aN+           a + b + c + d + e + x + g ____+ i + k + l
-v1AN+           a + b + c + d + e + x + g ______i + k + l
-v2IL+           a + _ + c + d + e + x + g + h + i + k + l
-v2iL+           a +___+ c + d + e + x + g + h + i + k + l
-v2aL+           a ____+ c + d + e + x + g + h + i + k + l
-v2AL+           a ______c + d + e + x + g + h + i + k + l
 v2Il+           a + b + c + _ + e + x + g + h + i + k + l
 v2il+           a + b + c +___+ e + x + g + h + i + k + l
 v2al+           a + b + c ____+ e + x + g + h + i + k + l
@@ -3225,15 +2749,7 @@ v2In+           a + b + c + d + e + x + g + _ + i + k + l
 v2in+           a + b + c + d + e + x + g +___+ i + k + l
 v2an+           a + b + c + d + e + x + g ____+ i + k + l
 v2An+           a + b + c + d + e + x + g ______i + k + l
-v2IN+           a + b + c + d + e + x + g + h + i + _ + l
-v2iN+           a + b + c + d + e + x + g + h + i +___+ l
-v2aN+           a + b + c + d + e + x + g + h + i ____+ l
-v2AN+           a + b + c + d + e + x + g + h + i ______l
 a - b - c - d - e - x - g - h - i - k - l
-cIL-            a - b - c - _ - e - x - g - h - i - k - l
-ciL-            a - b - c -_- e - x - g - h - i - k - l
-caL-            a - b - c _- e - x - g - h - i - k - l
-cAL-            a - b - c _e - x - g - h - i - k - l
 cIl-            a - b - c - d - _ - x - g - h - i - k - l
 cil-            a - b - c - d -_- x - g - h - i - k - l
 cal-            a - b - c - d _- x - g - h - i - k - l
@@ -3246,14 +2762,6 @@ cIn-            a - b - c - d - e - x - _ - h - i - k - l
 cin-            a - b - c - d - e - x -_- h - i - k - l
 can-            a - b - c - d - e - x _- h - i - k - l
 cAn-            a - b - c - d - e - x _h - i - k - l
-cIN-            a - b - c - d - e - x - g - _ - i - k - l
-ciN-            a - b - c - d - e - x - g -_- i - k - l
-caN-            a - b - c - d - e - x - g _- i - k - l
-cAN-            a - b - c - d - e - x - g _i - k - l
-c1IL-           a - b - c - _ - e - x - g - h - i - k - l
-c1iL-           a - b - c -_- e - x - g - h - i - k - l
-c1aL-           a - b - c _- e - x - g - h - i - k - l
-c1AL-           a - b - c _e - x - g - h - i - k - l
 c1Il-           a - b - c - d - _ - x - g - h - i - k - l
 c1il-           a - b - c - d -_- x - g - h - i - k - l
 c1al-           a - b - c - d _- x - g - h - i - k - l
@@ -3266,14 +2774,6 @@ c1In-           a - b - c - d - e - x - _ - h - i - k - l
 c1in-           a - b - c - d - e - x -_- h - i - k - l
 c1an-           a - b - c - d - e - x _- h - i - k - l
 c1An-           a - b - c - d - e - x _h - i - k - l
-c1IN-           a - b - c - d - e - x - g - _ - i - k - l
-c1iN-           a - b - c - d - e - x - g -_- i - k - l
-c1aN-           a - b - c - d - e - x - g _- i - k - l
-c1AN-           a - b - c - d - e - x - g _i - k - l
-c2IL-           a - _ - c - d - e - x - g - h - i - k - l
-c2iL-           a -_- c - d - e - x - g - h - i - k - l
-c2aL-           a _- c - d - e - x - g - h - i - k - l
-c2AL-           a _c - d - e - x - g - h - i - k - l
 c2Il-           a - b - c - _ - e - x - g - h - i - k - l
 c2il-           a - b - c -_- e - x - g - h - i - k - l
 c2al-           a - b - c _- e - x - g - h - i - k - l
@@ -3286,14 +2786,6 @@ c2In-           a - b - c - d - e - x - g - _ - i - k - l
 c2in-           a - b - c - d - e - x - g -_- i - k - l
 c2an-           a - b - c - d - e - x - g _- i - k - l
 c2An-           a - b - c - d - e - x - g _i - k - l
-c2IN-           a - b - c - d - e - x - g - h - i - _ - l
-c2iN-           a - b - c - d - e - x - g - h - i -_- l
-c2aN-           a - b - c - d - e - x - g - h - i _- l
-c2AN-           a - b - c - d - e - x - g - h - i _l
-dIL-            a - b - c -  - e - x - g - h - i - k - l
-diL-            a - b - c -- e - x - g - h - i - k - l
-daL-            a - b - c - e - x - g - h - i - k - l
-dAL-            a - b - c e - x - g - h - i - k - l
 dIl-            a - b - c - d -  - x - g - h - i - k - l
 dil-            a - b - c - d -- x - g - h - i - k - l
 dal-            a - b - c - d - x - g - h - i - k - l
@@ -3306,14 +2798,6 @@ dIn-            a - b - c - d - e - x -  - h - i - k - l
 din-            a - b - c - d - e - x -- h - i - k - l
 dan-            a - b - c - d - e - x - h - i - k - l
 dAn-            a - b - c - d - e - x h - i - k - l
-dIN-            a - b - c - d - e - x - g -  - i - k - l
-diN-            a - b - c - d - e - x - g -- i - k - l
-daN-            a - b - c - d - e - x - g - i - k - l
-dAN-            a - b - c - d - e - x - g i - k - l
-d1IL-           a - b - c -  - e - x - g - h - i - k - l
-d1iL-           a - b - c -- e - x - g - h - i - k - l
-d1aL-           a - b - c - e - x - g - h - i - k - l
-d1AL-           a - b - c e - x - g - h - i - k - l
 d1Il-           a - b - c - d -  - x - g - h - i - k - l
 d1il-           a - b - c - d -- x - g - h - i - k - l
 d1al-           a - b - c - d - x - g - h - i - k - l
@@ -3326,14 +2810,6 @@ d1In-           a - b - c - d - e - x -  - h - i - k - l
 d1in-           a - b - c - d - e - x -- h - i - k - l
 d1an-           a - b - c - d - e - x - h - i - k - l
 d1An-           a - b - c - d - e - x h - i - k - l
-d1IN-           a - b - c - d - e - x - g -  - i - k - l
-d1iN-           a - b - c - d - e - x - g -- i - k - l
-d1aN-           a - b - c - d - e - x - g - i - k - l
-d1AN-           a - b - c - d - e - x - g i - k - l
-d2IL-           a -  - c - d - e - x - g - h - i - k - l
-d2iL-           a -- c - d - e - x - g - h - i - k - l
-d2aL-           a - c - d - e - x - g - h - i - k - l
-d2AL-           a c - d - e - x - g - h - i - k - l
 d2Il-           a - b - c -  - e - x - g - h - i - k - l
 d2il-           a - b - c -- e - x - g - h - i - k - l
 d2al-           a - b - c - e - x - g - h - i - k - l
@@ -3346,14 +2822,6 @@ d2In-           a - b - c - d - e - x - g -  - i - k - l
 d2in-           a - b - c - d - e - x - g -- i - k - l
 d2an-           a - b - c - d - e - x - g - i - k - l
 d2An-           a - b - c - d - e - x - g i - k - l
-d2IN-           a - b - c - d - e - x - g - h - i -  - l
-d2iN-           a - b - c - d - e - x - g - h - i -- l
-d2aN-           a - b - c - d - e - x - g - h - i - l
-d2AN-           a - b - c - d - e - x - g - h - i l
-yIL-            a - b - c - d - e - x - g - h - i - k - l       'd'
-yiL-            a - b - c - d - e - x - g - h - i - k - l       ' d '
-yaL-            a - b - c - d - e - x - g - h - i - k - l       '- d '
-yAL-            a - b - c - d - e - x - g - h - i - k - l       '- d - '
 yIl-            a - b - c - d - e - x - g - h - i - k - l       'e'
 yil-            a - b - c - d - e - x - g - h - i - k - l       ' e '
 yal-            a - b - c - d - e - x - g - h - i - k - l       '- e '
@@ -3366,14 +2834,6 @@ yIn-            a - b - c - d - e - x - g - h - i - k - l       'g'
 yin-            a - b - c - d - e - x - g - h - i - k - l       ' g '
 yan-            a - b - c - d - e - x - g - h - i - k - l       '- g '
 yAn-            a - b - c - d - e - x - g - h - i - k - l       '- g - '
-yIN-            a - b - c - d - e - x - g - h - i - k - l       'h'
-yiN-            a - b - c - d - e - x - g - h - i - k - l       ' h '
-yaN-            a - b - c - d - e - x - g - h - i - k - l       '- h '
-yAN-            a - b - c - d - e - x - g - h - i - k - l       '- h - '
-y1IL-           a - b - c - d - e - x - g - h - i - k - l       'd'
-y1iL-           a - b - c - d - e - x - g - h - i - k - l       ' d '
-y1aL-           a - b - c - d - e - x - g - h - i - k - l       '- d '
-y1AL-           a - b - c - d - e - x - g - h - i - k - l       '- d - '
 y1Il-           a - b - c - d - e - x - g - h - i - k - l       'e'
 y1il-           a - b - c - d - e - x - g - h - i - k - l       ' e '
 y1al-           a - b - c - d - e - x - g - h - i - k - l       '- e '
@@ -3386,14 +2846,6 @@ y1In-           a - b - c - d - e - x - g - h - i - k - l       'g'
 y1in-           a - b - c - d - e - x - g - h - i - k - l       ' g '
 y1an-           a - b - c - d - e - x - g - h - i - k - l       '- g '
 y1An-           a - b - c - d - e - x - g - h - i - k - l       '- g - '
-y1IN-           a - b - c - d - e - x - g - h - i - k - l       'h'
-y1iN-           a - b - c - d - e - x - g - h - i - k - l       ' h '
-y1aN-           a - b - c - d - e - x - g - h - i - k - l       '- h '
-y1AN-           a - b - c - d - e - x - g - h - i - k - l       '- h - '
-y2IL-           a - b - c - d - e - x - g - h - i - k - l       'b'
-y2iL-           a - b - c - d - e - x - g - h - i - k - l       ' b '
-y2aL-           a - b - c - d - e - x - g - h - i - k - l       '- b '
-y2AL-           a - b - c - d - e - x - g - h - i - k - l       '- b - '
 y2Il-           a - b - c - d - e - x - g - h - i - k - l       'd'
 y2il-           a - b - c - d - e - x - g - h - i - k - l       ' d '
 y2al-           a - b - c - d - e - x - g - h - i - k - l       '- d '
@@ -3406,14 +2858,6 @@ y2In-           a - b - c - d - e - x - g - h - i - k - l       'h'
 y2in-           a - b - c - d - e - x - g - h - i - k - l       ' h '
 y2an-           a - b - c - d - e - x - g - h - i - k - l       '- h '
 y2An-           a - b - c - d - e - x - g - h - i - k - l       '- h - '
-y2IN-           a - b - c - d - e - x - g - h - i - k - l       'k'
-y2iN-           a - b - c - d - e - x - g - h - i - k - l       ' k '
-y2aN-           a - b - c - d - e - x - g - h - i - k - l       '- k '
-y2AN-           a - b - c - d - e - x - g - h - i - k - l       '- k - '
-vIL-            a - b - c - _ - e - x - g - h - i - k - l
-viL-            a - b - c -___- e - x - g - h - i - k - l
-vaL-            a - b - c ____- e - x - g - h - i - k - l
-vAL-            a - b - c ______e - x - g - h - i - k - l
 vIl-            a - b - c - d - _ - x - g - h - i - k - l
 vil-            a - b - c - d -___- x - g - h - i - k - l
 val-            a - b - c - d ____- x - g - h - i - k - l
@@ -3426,14 +2870,6 @@ vIn-            a - b - c - d - e - x - _ - h - i - k - l
 vin-            a - b - c - d - e - x -___- h - i - k - l
 van-            a - b - c - d - e - x ____- h - i - k - l
 vAn-            a - b - c - d - e - x ______h - i - k - l
-vIN-            a - b - c - d - e - x - g - _ - i - k - l
-viN-            a - b - c - d - e - x - g -___- i - k - l
-vaN-            a - b - c - d - e - x - g ____- i - k - l
-vAN-            a - b - c - d - e - x - g ______i - k - l
-v1IL-           a - b - c - _ - e - x - g - h - i - k - l
-v1iL-           a - b - c -___- e - x - g - h - i - k - l
-v1aL-           a - b - c ____- e - x - g - h - i - k - l
-v1AL-           a - b - c ______e - x - g - h - i - k - l
 v1Il-           a - b - c - d - _ - x - g - h - i - k - l
 v1il-           a - b - c - d -___- x - g - h - i - k - l
 v1al-           a - b - c - d ____- x - g - h - i - k - l
@@ -3446,14 +2882,6 @@ v1In-           a - b - c - d - e - x - _ - h - i - k - l
 v1in-           a - b - c - d - e - x -___- h - i - k - l
 v1an-           a - b - c - d - e - x ____- h - i - k - l
 v1An-           a - b - c - d - e - x ______h - i - k - l
-v1IN-           a - b - c - d - e - x - g - _ - i - k - l
-v1iN-           a - b - c - d - e - x - g -___- i - k - l
-v1aN-           a - b - c - d - e - x - g ____- i - k - l
-v1AN-           a - b - c - d - e - x - g ______i - k - l
-v2IL-           a - _ - c - d - e - x - g - h - i - k - l
-v2iL-           a -___- c - d - e - x - g - h - i - k - l
-v2aL-           a ____- c - d - e - x - g - h - i - k - l
-v2AL-           a ______c - d - e - x - g - h - i - k - l
 v2Il-           a - b - c - _ - e - x - g - h - i - k - l
 v2il-           a - b - c -___- e - x - g - h - i - k - l
 v2al-           a - b - c ____- e - x - g - h - i - k - l
@@ -3466,15 +2894,7 @@ v2In-           a - b - c - d - e - x - g - _ - i - k - l
 v2in-           a - b - c - d - e - x - g -___- i - k - l
 v2an-           a - b - c - d - e - x - g ____- i - k - l
 v2An-           a - b - c - d - e - x - g ______i - k - l
-v2IN-           a - b - c - d - e - x - g - h - i - _ - l
-v2iN-           a - b - c - d - e - x - g - h - i -___- l
-v2aN-           a - b - c - d - e - x - g - h - i ____- l
-v2AN-           a - b - c - d - e - x - g - h - i ______l
 a = b = c = d = e = x = g = h = i = k = l
-cIL=            a = b = c = _ = e = x = g = h = i = k = l
-ciL=            a = b = c =_= e = x = g = h = i = k = l
-caL=            a = b = c _= e = x = g = h = i = k = l
-cAL=            a = b = c _e = x = g = h = i = k = l
 cIl=            a = b = c = d = _ = x = g = h = i = k = l
 cil=            a = b = c = d =_= x = g = h = i = k = l
 cal=            a = b = c = d _= x = g = h = i = k = l
@@ -3487,14 +2907,6 @@ cIn=            a = b = c = d = e = x = _ = h = i = k = l
 cin=            a = b = c = d = e = x =_= h = i = k = l
 can=            a = b = c = d = e = x _= h = i = k = l
 cAn=            a = b = c = d = e = x _h = i = k = l
-cIN=            a = b = c = d = e = x = g = _ = i = k = l
-ciN=            a = b = c = d = e = x = g =_= i = k = l
-caN=            a = b = c = d = e = x = g _= i = k = l
-cAN=            a = b = c = d = e = x = g _i = k = l
-c1IL=           a = b = c = _ = e = x = g = h = i = k = l
-c1iL=           a = b = c =_= e = x = g = h = i = k = l
-c1aL=           a = b = c _= e = x = g = h = i = k = l
-c1AL=           a = b = c _e = x = g = h = i = k = l
 c1Il=           a = b = c = d = _ = x = g = h = i = k = l
 c1il=           a = b = c = d =_= x = g = h = i = k = l
 c1al=           a = b = c = d _= x = g = h = i = k = l
@@ -3507,14 +2919,6 @@ c1In=           a = b = c = d = e = x = _ = h = i = k = l
 c1in=           a = b = c = d = e = x =_= h = i = k = l
 c1an=           a = b = c = d = e = x _= h = i = k = l
 c1An=           a = b = c = d = e = x _h = i = k = l
-c1IN=           a = b = c = d = e = x = g = _ = i = k = l
-c1iN=           a = b = c = d = e = x = g =_= i = k = l
-c1aN=           a = b = c = d = e = x = g _= i = k = l
-c1AN=           a = b = c = d = e = x = g _i = k = l
-c2IL=           a = _ = c = d = e = x = g = h = i = k = l
-c2iL=           a =_= c = d = e = x = g = h = i = k = l
-c2aL=           a _= c = d = e = x = g = h = i = k = l
-c2AL=           a _c = d = e = x = g = h = i = k = l
 c2Il=           a = b = c = _ = e = x = g = h = i = k = l
 c2il=           a = b = c =_= e = x = g = h = i = k = l
 c2al=           a = b = c _= e = x = g = h = i = k = l
@@ -3527,14 +2931,6 @@ c2In=           a = b = c = d = e = x = g = _ = i = k = l
 c2in=           a = b = c = d = e = x = g =_= i = k = l
 c2an=           a = b = c = d = e = x = g _= i = k = l
 c2An=           a = b = c = d = e = x = g _i = k = l
-c2IN=           a = b = c = d = e = x = g = h = i = _ = l
-c2iN=           a = b = c = d = e = x = g = h = i =_= l
-c2aN=           a = b = c = d = e = x = g = h = i _= l
-c2AN=           a = b = c = d = e = x = g = h = i _l
-dIL=            a = b = c =  = e = x = g = h = i = k = l
-diL=            a = b = c == e = x = g = h = i = k = l
-daL=            a = b = c = e = x = g = h = i = k = l
-dAL=            a = b = c e = x = g = h = i = k = l
 dIl=            a = b = c = d =  = x = g = h = i = k = l
 dil=            a = b = c = d == x = g = h = i = k = l
 dal=            a = b = c = d = x = g = h = i = k = l
@@ -3547,14 +2943,6 @@ dIn=            a = b = c = d = e = x =  = h = i = k = l
 din=            a = b = c = d = e = x == h = i = k = l
 dan=            a = b = c = d = e = x = h = i = k = l
 dAn=            a = b = c = d = e = x h = i = k = l
-dIN=            a = b = c = d = e = x = g =  = i = k = l
-diN=            a = b = c = d = e = x = g == i = k = l
-daN=            a = b = c = d = e = x = g = i = k = l
-dAN=            a = b = c = d = e = x = g i = k = l
-d1IL=           a = b = c =  = e = x = g = h = i = k = l
-d1iL=           a = b = c == e = x = g = h = i = k = l
-d1aL=           a = b = c = e = x = g = h = i = k = l
-d1AL=           a = b = c e = x = g = h = i = k = l
 d1Il=           a = b = c = d =  = x = g = h = i = k = l
 d1il=           a = b = c = d == x = g = h = i = k = l
 d1al=           a = b = c = d = x = g = h = i = k = l
@@ -3567,14 +2955,6 @@ d1In=           a = b = c = d = e = x =  = h = i = k = l
 d1in=           a = b = c = d = e = x == h = i = k = l
 d1an=           a = b = c = d = e = x = h = i = k = l
 d1An=           a = b = c = d = e = x h = i = k = l
-d1IN=           a = b = c = d = e = x = g =  = i = k = l
-d1iN=           a = b = c = d = e = x = g == i = k = l
-d1aN=           a = b = c = d = e = x = g = i = k = l
-d1AN=           a = b = c = d = e = x = g i = k = l
-d2IL=           a =  = c = d = e = x = g = h = i = k = l
-d2iL=           a == c = d = e = x = g = h = i = k = l
-d2aL=           a = c = d = e = x = g = h = i = k = l
-d2AL=           a c = d = e = x = g = h = i = k = l
 d2Il=           a = b = c =  = e = x = g = h = i = k = l
 d2il=           a = b = c == e = x = g = h = i = k = l
 d2al=           a = b = c = e = x = g = h = i = k = l
@@ -3587,14 +2967,6 @@ d2In=           a = b = c = d = e = x = g =  = i = k = l
 d2in=           a = b = c = d = e = x = g == i = k = l
 d2an=           a = b = c = d = e = x = g = i = k = l
 d2An=           a = b = c = d = e = x = g i = k = l
-d2IN=           a = b = c = d = e = x = g = h = i =  = l
-d2iN=           a = b = c = d = e = x = g = h = i == l
-d2aN=           a = b = c = d = e = x = g = h = i = l
-d2AN=           a = b = c = d = e = x = g = h = i l
-yIL=            a = b = c = d = e = x = g = h = i = k = l       'd'
-yiL=            a = b = c = d = e = x = g = h = i = k = l       ' d '
-yaL=            a = b = c = d = e = x = g = h = i = k = l       '= d '
-yAL=            a = b = c = d = e = x = g = h = i = k = l       '= d = '
 yIl=            a = b = c = d = e = x = g = h = i = k = l       'e'
 yil=            a = b = c = d = e = x = g = h = i = k = l       ' e '
 yal=            a = b = c = d = e = x = g = h = i = k = l       '= e '
@@ -3607,14 +2979,6 @@ yIn=            a = b = c = d = e = x = g = h = i = k = l       'g'
 yin=            a = b = c = d = e = x = g = h = i = k = l       ' g '
 yan=            a = b = c = d = e = x = g = h = i = k = l       '= g '
 yAn=            a = b = c = d = e = x = g = h = i = k = l       '= g = '
-yIN=            a = b = c = d = e = x = g = h = i = k = l       'h'
-yiN=            a = b = c = d = e = x = g = h = i = k = l       ' h '
-yaN=            a = b = c = d = e = x = g = h = i = k = l       '= h '
-yAN=            a = b = c = d = e = x = g = h = i = k = l       '= h = '
-y1IL=           a = b = c = d = e = x = g = h = i = k = l       'd'
-y1iL=           a = b = c = d = e = x = g = h = i = k = l       ' d '
-y1aL=           a = b = c = d = e = x = g = h = i = k = l       '= d '
-y1AL=           a = b = c = d = e = x = g = h = i = k = l       '= d = '
 y1Il=           a = b = c = d = e = x = g = h = i = k = l       'e'
 y1il=           a = b = c = d = e = x = g = h = i = k = l       ' e '
 y1al=           a = b = c = d = e = x = g = h = i = k = l       '= e '
@@ -3627,14 +2991,6 @@ y1In=           a = b = c = d = e = x = g = h = i = k = l       'g'
 y1in=           a = b = c = d = e = x = g = h = i = k = l       ' g '
 y1an=           a = b = c = d = e = x = g = h = i = k = l       '= g '
 y1An=           a = b = c = d = e = x = g = h = i = k = l       '= g = '
-y1IN=           a = b = c = d = e = x = g = h = i = k = l       'h'
-y1iN=           a = b = c = d = e = x = g = h = i = k = l       ' h '
-y1aN=           a = b = c = d = e = x = g = h = i = k = l       '= h '
-y1AN=           a = b = c = d = e = x = g = h = i = k = l       '= h = '
-y2IL=           a = b = c = d = e = x = g = h = i = k = l       'b'
-y2iL=           a = b = c = d = e = x = g = h = i = k = l       ' b '
-y2aL=           a = b = c = d = e = x = g = h = i = k = l       '= b '
-y2AL=           a = b = c = d = e = x = g = h = i = k = l       '= b = '
 y2Il=           a = b = c = d = e = x = g = h = i = k = l       'd'
 y2il=           a = b = c = d = e = x = g = h = i = k = l       ' d '
 y2al=           a = b = c = d = e = x = g = h = i = k = l       '= d '
@@ -3647,14 +3003,6 @@ y2In=           a = b = c = d = e = x = g = h = i = k = l       'h'
 y2in=           a = b = c = d = e = x = g = h = i = k = l       ' h '
 y2an=           a = b = c = d = e = x = g = h = i = k = l       '= h '
 y2An=           a = b = c = d = e = x = g = h = i = k = l       '= h = '
-y2IN=           a = b = c = d = e = x = g = h = i = k = l       'k'
-y2iN=           a = b = c = d = e = x = g = h = i = k = l       ' k '
-y2aN=           a = b = c = d = e = x = g = h = i = k = l       '= k '
-y2AN=           a = b = c = d = e = x = g = h = i = k = l       '= k = '
-vIL=            a = b = c = _ = e = x = g = h = i = k = l
-viL=            a = b = c =___= e = x = g = h = i = k = l
-vaL=            a = b = c ____= e = x = g = h = i = k = l
-vAL=            a = b = c ______e = x = g = h = i = k = l
 vIl=            a = b = c = d = _ = x = g = h = i = k = l
 vil=            a = b = c = d =___= x = g = h = i = k = l
 val=            a = b = c = d ____= x = g = h = i = k = l
@@ -3667,14 +3015,6 @@ vIn=            a = b = c = d = e = x = _ = h = i = k = l
 vin=            a = b = c = d = e = x =___= h = i = k = l
 van=            a = b = c = d = e = x ____= h = i = k = l
 vAn=            a = b = c = d = e = x ______h = i = k = l
-vIN=            a = b = c = d = e = x = g = _ = i = k = l
-viN=            a = b = c = d = e = x = g =___= i = k = l
-vaN=            a = b = c = d = e = x = g ____= i = k = l
-vAN=            a = b = c = d = e = x = g ______i = k = l
-v1IL=           a = b = c = _ = e = x = g = h = i = k = l
-v1iL=           a = b = c =___= e = x = g = h = i = k = l
-v1aL=           a = b = c ____= e = x = g = h = i = k = l
-v1AL=           a = b = c ______e = x = g = h = i = k = l
 v1Il=           a = b = c = d = _ = x = g = h = i = k = l
 v1il=           a = b = c = d =___= x = g = h = i = k = l
 v1al=           a = b = c = d ____= x = g = h = i = k = l
@@ -3687,14 +3027,6 @@ v1In=           a = b = c = d = e = x = _ = h = i = k = l
 v1in=           a = b = c = d = e = x =___= h = i = k = l
 v1an=           a = b = c = d = e = x ____= h = i = k = l
 v1An=           a = b = c = d = e = x ______h = i = k = l
-v1IN=           a = b = c = d = e = x = g = _ = i = k = l
-v1iN=           a = b = c = d = e = x = g =___= i = k = l
-v1aN=           a = b = c = d = e = x = g ____= i = k = l
-v1AN=           a = b = c = d = e = x = g ______i = k = l
-v2IL=           a = _ = c = d = e = x = g = h = i = k = l
-v2iL=           a =___= c = d = e = x = g = h = i = k = l
-v2aL=           a ____= c = d = e = x = g = h = i = k = l
-v2AL=           a ______c = d = e = x = g = h = i = k = l
 v2Il=           a = b = c = _ = e = x = g = h = i = k = l
 v2il=           a = b = c =___= e = x = g = h = i = k = l
 v2al=           a = b = c ____= e = x = g = h = i = k = l
@@ -3707,15 +3039,7 @@ v2In=           a = b = c = d = e = x = g = _ = i = k = l
 v2in=           a = b = c = d = e = x = g =___= i = k = l
 v2an=           a = b = c = d = e = x = g ____= i = k = l
 v2An=           a = b = c = d = e = x = g ______i = k = l
-v2IN=           a = b = c = d = e = x = g = h = i = _ = l
-v2iN=           a = b = c = d = e = x = g = h = i =___= l
-v2aN=           a = b = c = d = e = x = g = h = i ____= l
-v2AN=           a = b = c = d = e = x = g = h = i ______l
 a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-cIL~            a ~ b ~ c ~ _ ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-ciL~            a ~ b ~ c ~_~ e ~ x ~ g ~ h ~ i ~ k ~ l
-caL~            a ~ b ~ c _~ e ~ x ~ g ~ h ~ i ~ k ~ l
-cAL~            a ~ b ~ c _e ~ x ~ g ~ h ~ i ~ k ~ l
 cIl~            a ~ b ~ c ~ d ~ _ ~ x ~ g ~ h ~ i ~ k ~ l
 cil~            a ~ b ~ c ~ d ~_~ x ~ g ~ h ~ i ~ k ~ l
 cal~            a ~ b ~ c ~ d _~ x ~ g ~ h ~ i ~ k ~ l
@@ -3728,14 +3052,6 @@ cIn~            a ~ b ~ c ~ d ~ e ~ x ~ _ ~ h ~ i ~ k ~ l
 cin~            a ~ b ~ c ~ d ~ e ~ x ~_~ h ~ i ~ k ~ l
 can~            a ~ b ~ c ~ d ~ e ~ x _~ h ~ i ~ k ~ l
 cAn~            a ~ b ~ c ~ d ~ e ~ x _h ~ i ~ k ~ l
-cIN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ _ ~ i ~ k ~ l
-ciN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~_~ i ~ k ~ l
-caN~            a ~ b ~ c ~ d ~ e ~ x ~ g _~ i ~ k ~ l
-cAN~            a ~ b ~ c ~ d ~ e ~ x ~ g _i ~ k ~ l
-c1IL~           a ~ b ~ c ~ _ ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-c1iL~           a ~ b ~ c ~_~ e ~ x ~ g ~ h ~ i ~ k ~ l
-c1aL~           a ~ b ~ c _~ e ~ x ~ g ~ h ~ i ~ k ~ l
-c1AL~           a ~ b ~ c _e ~ x ~ g ~ h ~ i ~ k ~ l
 c1Il~           a ~ b ~ c ~ d ~ _ ~ x ~ g ~ h ~ i ~ k ~ l
 c1il~           a ~ b ~ c ~ d ~_~ x ~ g ~ h ~ i ~ k ~ l
 c1al~           a ~ b ~ c ~ d _~ x ~ g ~ h ~ i ~ k ~ l
@@ -3748,14 +3064,6 @@ c1In~           a ~ b ~ c ~ d ~ e ~ x ~ _ ~ h ~ i ~ k ~ l
 c1in~           a ~ b ~ c ~ d ~ e ~ x ~_~ h ~ i ~ k ~ l
 c1an~           a ~ b ~ c ~ d ~ e ~ x _~ h ~ i ~ k ~ l
 c1An~           a ~ b ~ c ~ d ~ e ~ x _h ~ i ~ k ~ l
-c1IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ _ ~ i ~ k ~ l
-c1iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~_~ i ~ k ~ l
-c1aN~           a ~ b ~ c ~ d ~ e ~ x ~ g _~ i ~ k ~ l
-c1AN~           a ~ b ~ c ~ d ~ e ~ x ~ g _i ~ k ~ l
-c2IL~           a ~ _ ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-c2iL~           a ~_~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-c2aL~           a _~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-c2AL~           a _c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
 c2Il~           a ~ b ~ c ~ _ ~ e ~ x ~ g ~ h ~ i ~ k ~ l
 c2il~           a ~ b ~ c ~_~ e ~ x ~ g ~ h ~ i ~ k ~ l
 c2al~           a ~ b ~ c _~ e ~ x ~ g ~ h ~ i ~ k ~ l
@@ -3768,14 +3076,6 @@ c2In~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ _ ~ i ~ k ~ l
 c2in~           a ~ b ~ c ~ d ~ e ~ x ~ g ~_~ i ~ k ~ l
 c2an~           a ~ b ~ c ~ d ~ e ~ x ~ g _~ i ~ k ~ l
 c2An~           a ~ b ~ c ~ d ~ e ~ x ~ g _i ~ k ~ l
-c2IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ _ ~ l
-c2iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~_~ l
-c2aN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i _~ l
-c2AN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i _l
-dIL~            a ~ b ~ c ~  ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-diL~            a ~ b ~ c ~~ e ~ x ~ g ~ h ~ i ~ k ~ l
-daL~            a ~ b ~ c ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-dAL~            a ~ b ~ c e ~ x ~ g ~ h ~ i ~ k ~ l
 dIl~            a ~ b ~ c ~ d ~  ~ x ~ g ~ h ~ i ~ k ~ l
 dil~            a ~ b ~ c ~ d ~~ x ~ g ~ h ~ i ~ k ~ l
 dal~            a ~ b ~ c ~ d ~ x ~ g ~ h ~ i ~ k ~ l
@@ -3788,14 +3088,6 @@ dIn~            a ~ b ~ c ~ d ~ e ~ x ~  ~ h ~ i ~ k ~ l
 din~            a ~ b ~ c ~ d ~ e ~ x ~~ h ~ i ~ k ~ l
 dan~            a ~ b ~ c ~ d ~ e ~ x ~ h ~ i ~ k ~ l
 dAn~            a ~ b ~ c ~ d ~ e ~ x h ~ i ~ k ~ l
-dIN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~  ~ i ~ k ~ l
-diN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~~ i ~ k ~ l
-daN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ i ~ k ~ l
-dAN~            a ~ b ~ c ~ d ~ e ~ x ~ g i ~ k ~ l
-d1IL~           a ~ b ~ c ~  ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-d1iL~           a ~ b ~ c ~~ e ~ x ~ g ~ h ~ i ~ k ~ l
-d1aL~           a ~ b ~ c ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-d1AL~           a ~ b ~ c e ~ x ~ g ~ h ~ i ~ k ~ l
 d1Il~           a ~ b ~ c ~ d ~  ~ x ~ g ~ h ~ i ~ k ~ l
 d1il~           a ~ b ~ c ~ d ~~ x ~ g ~ h ~ i ~ k ~ l
 d1al~           a ~ b ~ c ~ d ~ x ~ g ~ h ~ i ~ k ~ l
@@ -3808,14 +3100,6 @@ d1In~           a ~ b ~ c ~ d ~ e ~ x ~  ~ h ~ i ~ k ~ l
 d1in~           a ~ b ~ c ~ d ~ e ~ x ~~ h ~ i ~ k ~ l
 d1an~           a ~ b ~ c ~ d ~ e ~ x ~ h ~ i ~ k ~ l
 d1An~           a ~ b ~ c ~ d ~ e ~ x h ~ i ~ k ~ l
-d1IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~  ~ i ~ k ~ l
-d1iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~~ i ~ k ~ l
-d1aN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ i ~ k ~ l
-d1AN~           a ~ b ~ c ~ d ~ e ~ x ~ g i ~ k ~ l
-d2IL~           a ~  ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-d2iL~           a ~~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-d2aL~           a ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-d2AL~           a c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
 d2Il~           a ~ b ~ c ~  ~ e ~ x ~ g ~ h ~ i ~ k ~ l
 d2il~           a ~ b ~ c ~~ e ~ x ~ g ~ h ~ i ~ k ~ l
 d2al~           a ~ b ~ c ~ e ~ x ~ g ~ h ~ i ~ k ~ l
@@ -3828,14 +3112,6 @@ d2In~           a ~ b ~ c ~ d ~ e ~ x ~ g ~  ~ i ~ k ~ l
 d2in~           a ~ b ~ c ~ d ~ e ~ x ~ g ~~ i ~ k ~ l
 d2an~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ i ~ k ~ l
 d2An~           a ~ b ~ c ~ d ~ e ~ x ~ g i ~ k ~ l
-d2IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~  ~ l
-d2iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~~ l
-d2aN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ l
-d2AN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i l
-yIL~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'd'
-yiL~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' d '
-yaL~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ d '
-yAL~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ d ~ '
 yIl~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'e'
 yil~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' e '
 yal~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ e '
@@ -3848,14 +3124,6 @@ yIn~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'g'
 yin~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' g '
 yan~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ g '
 yAn~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ g ~ '
-yIN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'h'
-yiN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' h '
-yaN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ h '
-yAN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ h ~ '
-y1IL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'd'
-y1iL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' d '
-y1aL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ d '
-y1AL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ d ~ '
 y1Il~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'e'
 y1il~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' e '
 y1al~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ e '
@@ -3868,14 +3136,6 @@ y1In~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'g'
 y1in~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' g '
 y1an~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ g '
 y1An~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ g ~ '
-y1IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'h'
-y1iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' h '
-y1aN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ h '
-y1AN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ h ~ '
-y2IL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'b'
-y2iL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' b '
-y2aL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ b '
-y2AL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ b ~ '
 y2Il~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'd'
 y2il~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' d '
 y2al~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ d '
@@ -3888,14 +3148,6 @@ y2In~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'h'
 y2in~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' h '
 y2an~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ h '
 y2An~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ h ~ '
-y2IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'k'
-y2iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' k '
-y2aN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ k '
-y2AN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ k ~ '
-vIL~            a ~ b ~ c ~ _ ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-viL~            a ~ b ~ c ~___~ e ~ x ~ g ~ h ~ i ~ k ~ l
-vaL~            a ~ b ~ c ____~ e ~ x ~ g ~ h ~ i ~ k ~ l
-vAL~            a ~ b ~ c ______e ~ x ~ g ~ h ~ i ~ k ~ l
 vIl~            a ~ b ~ c ~ d ~ _ ~ x ~ g ~ h ~ i ~ k ~ l
 vil~            a ~ b ~ c ~ d ~___~ x ~ g ~ h ~ i ~ k ~ l
 val~            a ~ b ~ c ~ d ____~ x ~ g ~ h ~ i ~ k ~ l
@@ -3908,14 +3160,6 @@ vIn~            a ~ b ~ c ~ d ~ e ~ x ~ _ ~ h ~ i ~ k ~ l
 vin~            a ~ b ~ c ~ d ~ e ~ x ~___~ h ~ i ~ k ~ l
 van~            a ~ b ~ c ~ d ~ e ~ x ____~ h ~ i ~ k ~ l
 vAn~            a ~ b ~ c ~ d ~ e ~ x ______h ~ i ~ k ~ l
-vIN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ _ ~ i ~ k ~ l
-viN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~___~ i ~ k ~ l
-vaN~            a ~ b ~ c ~ d ~ e ~ x ~ g ____~ i ~ k ~ l
-vAN~            a ~ b ~ c ~ d ~ e ~ x ~ g ______i ~ k ~ l
-v1IL~           a ~ b ~ c ~ _ ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-v1iL~           a ~ b ~ c ~___~ e ~ x ~ g ~ h ~ i ~ k ~ l
-v1aL~           a ~ b ~ c ____~ e ~ x ~ g ~ h ~ i ~ k ~ l
-v1AL~           a ~ b ~ c ______e ~ x ~ g ~ h ~ i ~ k ~ l
 v1Il~           a ~ b ~ c ~ d ~ _ ~ x ~ g ~ h ~ i ~ k ~ l
 v1il~           a ~ b ~ c ~ d ~___~ x ~ g ~ h ~ i ~ k ~ l
 v1al~           a ~ b ~ c ~ d ____~ x ~ g ~ h ~ i ~ k ~ l
@@ -3928,14 +3172,6 @@ v1In~           a ~ b ~ c ~ d ~ e ~ x ~ _ ~ h ~ i ~ k ~ l
 v1in~           a ~ b ~ c ~ d ~ e ~ x ~___~ h ~ i ~ k ~ l
 v1an~           a ~ b ~ c ~ d ~ e ~ x ____~ h ~ i ~ k ~ l
 v1An~           a ~ b ~ c ~ d ~ e ~ x ______h ~ i ~ k ~ l
-v1IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ _ ~ i ~ k ~ l
-v1iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~___~ i ~ k ~ l
-v1aN~           a ~ b ~ c ~ d ~ e ~ x ~ g ____~ i ~ k ~ l
-v1AN~           a ~ b ~ c ~ d ~ e ~ x ~ g ______i ~ k ~ l
-v2IL~           a ~ _ ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-v2iL~           a ~___~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-v2aL~           a ____~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-v2AL~           a ______c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
 v2Il~           a ~ b ~ c ~ _ ~ e ~ x ~ g ~ h ~ i ~ k ~ l
 v2il~           a ~ b ~ c ~___~ e ~ x ~ g ~ h ~ i ~ k ~ l
 v2al~           a ~ b ~ c ____~ e ~ x ~ g ~ h ~ i ~ k ~ l
@@ -3948,15 +3184,7 @@ v2In~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ _ ~ i ~ k ~ l
 v2in~           a ~ b ~ c ~ d ~ e ~ x ~ g ~___~ i ~ k ~ l
 v2an~           a ~ b ~ c ~ d ~ e ~ x ~ g ____~ i ~ k ~ l
 v2An~           a ~ b ~ c ~ d ~ e ~ x ~ g ______i ~ k ~ l
-v2IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ _ ~ l
-v2iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~___~ l
-v2aN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ____~ l
-v2AN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ______l
 a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l
-cIL_            a _ b _ c _ _ _ e _ x _ g _ h _ i _ k _ l
-ciL_            a _ b _ c ___ e _ x _ g _ h _ i _ k _ l
-caL_            a _ b _ c __ e _ x _ g _ h _ i _ k _ l
-cAL_            a _ b _ c _e _ x _ g _ h _ i _ k _ l
 cIl_            a _ b _ c _ d _ _ _ x _ g _ h _ i _ k _ l
 cil_            a _ b _ c _ d ___ x _ g _ h _ i _ k _ l
 cal_            a _ b _ c _ d __ x _ g _ h _ i _ k _ l
@@ -3969,14 +3197,6 @@ cIn_            a _ b _ c _ d _ e _ x _ _ _ h _ i _ k _ l
 cin_            a _ b _ c _ d _ e _ x ___ h _ i _ k _ l
 can_            a _ b _ c _ d _ e _ x __ h _ i _ k _ l
 cAn_            a _ b _ c _ d _ e _ x _h _ i _ k _ l
-cIN_            a _ b _ c _ d _ e _ x _ g _ _ _ i _ k _ l
-ciN_            a _ b _ c _ d _ e _ x _ g ___ i _ k _ l
-caN_            a _ b _ c _ d _ e _ x _ g __ i _ k _ l
-cAN_            a _ b _ c _ d _ e _ x _ g _i _ k _ l
-c1IL_           a _ b _ c _ _ _ e _ x _ g _ h _ i _ k _ l
-c1iL_           a _ b _ c ___ e _ x _ g _ h _ i _ k _ l
-c1aL_           a _ b _ c __ e _ x _ g _ h _ i _ k _ l
-c1AL_           a _ b _ c _e _ x _ g _ h _ i _ k _ l
 c1Il_           a _ b _ c _ d _ _ _ x _ g _ h _ i _ k _ l
 c1il_           a _ b _ c _ d ___ x _ g _ h _ i _ k _ l
 c1al_           a _ b _ c _ d __ x _ g _ h _ i _ k _ l
@@ -3989,14 +3209,6 @@ c1In_           a _ b _ c _ d _ e _ x _ _ _ h _ i _ k _ l
 c1in_           a _ b _ c _ d _ e _ x ___ h _ i _ k _ l
 c1an_           a _ b _ c _ d _ e _ x __ h _ i _ k _ l
 c1An_           a _ b _ c _ d _ e _ x _h _ i _ k _ l
-c1IN_           a _ b _ c _ d _ e _ x _ g _ _ _ i _ k _ l
-c1iN_           a _ b _ c _ d _ e _ x _ g ___ i _ k _ l
-c1aN_           a _ b _ c _ d _ e _ x _ g __ i _ k _ l
-c1AN_           a _ b _ c _ d _ e _ x _ g _i _ k _ l
-c2IL_           a _ _ _ c _ d _ e _ x _ g _ h _ i _ k _ l
-c2iL_           a ___ c _ d _ e _ x _ g _ h _ i _ k _ l
-c2aL_           a __ c _ d _ e _ x _ g _ h _ i _ k _ l
-c2AL_           a _c _ d _ e _ x _ g _ h _ i _ k _ l
 c2Il_           a _ b _ c _ _ _ e _ x _ g _ h _ i _ k _ l
 c2il_           a _ b _ c ___ e _ x _ g _ h _ i _ k _ l
 c2al_           a _ b _ c __ e _ x _ g _ h _ i _ k _ l
@@ -4009,14 +3221,6 @@ c2In_           a _ b _ c _ d _ e _ x _ g _ _ _ i _ k _ l
 c2in_           a _ b _ c _ d _ e _ x _ g ___ i _ k _ l
 c2an_           a _ b _ c _ d _ e _ x _ g __ i _ k _ l
 c2An_           a _ b _ c _ d _ e _ x _ g _i _ k _ l
-c2IN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ _ _ l
-c2iN_           a _ b _ c _ d _ e _ x _ g _ h _ i ___ l
-c2aN_           a _ b _ c _ d _ e _ x _ g _ h _ i __ l
-c2AN_           a _ b _ c _ d _ e _ x _ g _ h _ i _l
-dIL_            a _ b _ c _  _ e _ x _ g _ h _ i _ k _ l
-diL_            a _ b _ c __ e _ x _ g _ h _ i _ k _ l
-daL_            a _ b _ c _ e _ x _ g _ h _ i _ k _ l
-dAL_            a _ b _ c e _ x _ g _ h _ i _ k _ l
 dIl_            a _ b _ c _ d _  _ x _ g _ h _ i _ k _ l
 dil_            a _ b _ c _ d __ x _ g _ h _ i _ k _ l
 dal_            a _ b _ c _ d _ x _ g _ h _ i _ k _ l
@@ -4029,14 +3233,6 @@ dIn_            a _ b _ c _ d _ e _ x _  _ h _ i _ k _ l
 din_            a _ b _ c _ d _ e _ x __ h _ i _ k _ l
 dan_            a _ b _ c _ d _ e _ x _ h _ i _ k _ l
 dAn_            a _ b _ c _ d _ e _ x h _ i _ k _ l
-dIN_            a _ b _ c _ d _ e _ x _ g _  _ i _ k _ l
-diN_            a _ b _ c _ d _ e _ x _ g __ i _ k _ l
-daN_            a _ b _ c _ d _ e _ x _ g _ i _ k _ l
-dAN_            a _ b _ c _ d _ e _ x _ g i _ k _ l
-d1IL_           a _ b _ c _  _ e _ x _ g _ h _ i _ k _ l
-d1iL_           a _ b _ c __ e _ x _ g _ h _ i _ k _ l
-d1aL_           a _ b _ c _ e _ x _ g _ h _ i _ k _ l
-d1AL_           a _ b _ c e _ x _ g _ h _ i _ k _ l
 d1Il_           a _ b _ c _ d _  _ x _ g _ h _ i _ k _ l
 d1il_           a _ b _ c _ d __ x _ g _ h _ i _ k _ l
 d1al_           a _ b _ c _ d _ x _ g _ h _ i _ k _ l
@@ -4049,14 +3245,6 @@ d1In_           a _ b _ c _ d _ e _ x _  _ h _ i _ k _ l
 d1in_           a _ b _ c _ d _ e _ x __ h _ i _ k _ l
 d1an_           a _ b _ c _ d _ e _ x _ h _ i _ k _ l
 d1An_           a _ b _ c _ d _ e _ x h _ i _ k _ l
-d1IN_           a _ b _ c _ d _ e _ x _ g _  _ i _ k _ l
-d1iN_           a _ b _ c _ d _ e _ x _ g __ i _ k _ l
-d1aN_           a _ b _ c _ d _ e _ x _ g _ i _ k _ l
-d1AN_           a _ b _ c _ d _ e _ x _ g i _ k _ l
-d2IL_           a _  _ c _ d _ e _ x _ g _ h _ i _ k _ l
-d2iL_           a __ c _ d _ e _ x _ g _ h _ i _ k _ l
-d2aL_           a _ c _ d _ e _ x _ g _ h _ i _ k _ l
-d2AL_           a c _ d _ e _ x _ g _ h _ i _ k _ l
 d2Il_           a _ b _ c _  _ e _ x _ g _ h _ i _ k _ l
 d2il_           a _ b _ c __ e _ x _ g _ h _ i _ k _ l
 d2al_           a _ b _ c _ e _ x _ g _ h _ i _ k _ l
@@ -4069,14 +3257,6 @@ d2In_           a _ b _ c _ d _ e _ x _ g _  _ i _ k _ l
 d2in_           a _ b _ c _ d _ e _ x _ g __ i _ k _ l
 d2an_           a _ b _ c _ d _ e _ x _ g _ i _ k _ l
 d2An_           a _ b _ c _ d _ e _ x _ g i _ k _ l
-d2IN_           a _ b _ c _ d _ e _ x _ g _ h _ i _  _ l
-d2iN_           a _ b _ c _ d _ e _ x _ g _ h _ i __ l
-d2aN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ l
-d2AN_           a _ b _ c _ d _ e _ x _ g _ h _ i l
-yIL_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'd'
-yiL_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' d '
-yaL_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ d '
-yAL_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ d _ '
 yIl_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'e'
 yil_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' e '
 yal_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ e '
@@ -4089,14 +3269,6 @@ yIn_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'g'
 yin_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' g '
 yan_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ g '
 yAn_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ g _ '
-yIN_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'h'
-yiN_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' h '
-yaN_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ h '
-yAN_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ h _ '
-y1IL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'd'
-y1iL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' d '
-y1aL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ d '
-y1AL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ d _ '
 y1Il_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'e'
 y1il_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' e '
 y1al_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ e '
@@ -4109,14 +3281,6 @@ y1In_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'g'
 y1in_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' g '
 y1an_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ g '
 y1An_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ g _ '
-y1IN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'h'
-y1iN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' h '
-y1aN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ h '
-y1AN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ h _ '
-y2IL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'b'
-y2iL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' b '
-y2aL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ b '
-y2AL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ b _ '
 y2Il_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'd'
 y2il_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' d '
 y2al_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ d '
@@ -4129,14 +3293,6 @@ y2In_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'h'
 y2in_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' h '
 y2an_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ h '
 y2An_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ h _ '
-y2IN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'k'
-y2iN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' k '
-y2aN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ k '
-y2AN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ k _ '
-vIL_            a _ b _ c _ _ _ e _ x _ g _ h _ i _ k _ l
-viL_            a _ b _ c _____ e _ x _ g _ h _ i _ k _ l
-vaL_            a _ b _ c _____ e _ x _ g _ h _ i _ k _ l
-vAL_            a _ b _ c ______e _ x _ g _ h _ i _ k _ l
 vIl_            a _ b _ c _ d _ _ _ x _ g _ h _ i _ k _ l
 vil_            a _ b _ c _ d _____ x _ g _ h _ i _ k _ l
 val_            a _ b _ c _ d _____ x _ g _ h _ i _ k _ l
@@ -4149,14 +3305,6 @@ vIn_            a _ b _ c _ d _ e _ x _ _ _ h _ i _ k _ l
 vin_            a _ b _ c _ d _ e _ x _____ h _ i _ k _ l
 van_            a _ b _ c _ d _ e _ x _____ h _ i _ k _ l
 vAn_            a _ b _ c _ d _ e _ x ______h _ i _ k _ l
-vIN_            a _ b _ c _ d _ e _ x _ g _ _ _ i _ k _ l
-viN_            a _ b _ c _ d _ e _ x _ g _____ i _ k _ l
-vaN_            a _ b _ c _ d _ e _ x _ g _____ i _ k _ l
-vAN_            a _ b _ c _ d _ e _ x _ g ______i _ k _ l
-v1IL_           a _ b _ c _ _ _ e _ x _ g _ h _ i _ k _ l
-v1iL_           a _ b _ c _____ e _ x _ g _ h _ i _ k _ l
-v1aL_           a _ b _ c _____ e _ x _ g _ h _ i _ k _ l
-v1AL_           a _ b _ c ______e _ x _ g _ h _ i _ k _ l
 v1Il_           a _ b _ c _ d _ _ _ x _ g _ h _ i _ k _ l
 v1il_           a _ b _ c _ d _____ x _ g _ h _ i _ k _ l
 v1al_           a _ b _ c _ d _____ x _ g _ h _ i _ k _ l
@@ -4169,14 +3317,6 @@ v1In_           a _ b _ c _ d _ e _ x _ _ _ h _ i _ k _ l
 v1in_           a _ b _ c _ d _ e _ x _____ h _ i _ k _ l
 v1an_           a _ b _ c _ d _ e _ x _____ h _ i _ k _ l
 v1An_           a _ b _ c _ d _ e _ x ______h _ i _ k _ l
-v1IN_           a _ b _ c _ d _ e _ x _ g _ _ _ i _ k _ l
-v1iN_           a _ b _ c _ d _ e _ x _ g _____ i _ k _ l
-v1aN_           a _ b _ c _ d _ e _ x _ g _____ i _ k _ l
-v1AN_           a _ b _ c _ d _ e _ x _ g ______i _ k _ l
-v2IL_           a _ _ _ c _ d _ e _ x _ g _ h _ i _ k _ l
-v2iL_           a _____ c _ d _ e _ x _ g _ h _ i _ k _ l
-v2aL_           a _____ c _ d _ e _ x _ g _ h _ i _ k _ l
-v2AL_           a ______c _ d _ e _ x _ g _ h _ i _ k _ l
 v2Il_           a _ b _ c _ _ _ e _ x _ g _ h _ i _ k _ l
 v2il_           a _ b _ c _____ e _ x _ g _ h _ i _ k _ l
 v2al_           a _ b _ c _____ e _ x _ g _ h _ i _ k _ l
@@ -4189,15 +3329,7 @@ v2In_           a _ b _ c _ d _ e _ x _ g _ _ _ i _ k _ l
 v2in_           a _ b _ c _ d _ e _ x _ g _____ i _ k _ l
 v2an_           a _ b _ c _ d _ e _ x _ g _____ i _ k _ l
 v2An_           a _ b _ c _ d _ e _ x _ g ______i _ k _ l
-v2IN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ _ _ l
-v2iN_           a _ b _ c _ d _ e _ x _ g _ h _ i _____ l
-v2aN_           a _ b _ c _ d _ e _ x _ g _ h _ i _____ l
-v2AN_           a _ b _ c _ d _ e _ x _ g _ h _ i ______l
 a * b * c * d * e * x * g * h * i * k * l
-cIL*            a * b * c * _ * e * x * g * h * i * k * l
-ciL*            a * b * c *_* e * x * g * h * i * k * l
-caL*            a * b * c _* e * x * g * h * i * k * l
-cAL*            a * b * c _e * x * g * h * i * k * l
 cIl*            a * b * c * d * _ * x * g * h * i * k * l
 cil*            a * b * c * d *_* x * g * h * i * k * l
 cal*            a * b * c * d _* x * g * h * i * k * l
@@ -4210,14 +3342,6 @@ cIn*            a * b * c * d * e * x * _ * h * i * k * l
 cin*            a * b * c * d * e * x *_* h * i * k * l
 can*            a * b * c * d * e * x _* h * i * k * l
 cAn*            a * b * c * d * e * x _h * i * k * l
-cIN*            a * b * c * d * e * x * g * _ * i * k * l
-ciN*            a * b * c * d * e * x * g *_* i * k * l
-caN*            a * b * c * d * e * x * g _* i * k * l
-cAN*            a * b * c * d * e * x * g _i * k * l
-c1IL*           a * b * c * _ * e * x * g * h * i * k * l
-c1iL*           a * b * c *_* e * x * g * h * i * k * l
-c1aL*           a * b * c _* e * x * g * h * i * k * l
-c1AL*           a * b * c _e * x * g * h * i * k * l
 c1Il*           a * b * c * d * _ * x * g * h * i * k * l
 c1il*           a * b * c * d *_* x * g * h * i * k * l
 c1al*           a * b * c * d _* x * g * h * i * k * l
@@ -4230,14 +3354,6 @@ c1In*           a * b * c * d * e * x * _ * h * i * k * l
 c1in*           a * b * c * d * e * x *_* h * i * k * l
 c1an*           a * b * c * d * e * x _* h * i * k * l
 c1An*           a * b * c * d * e * x _h * i * k * l
-c1IN*           a * b * c * d * e * x * g * _ * i * k * l
-c1iN*           a * b * c * d * e * x * g *_* i * k * l
-c1aN*           a * b * c * d * e * x * g _* i * k * l
-c1AN*           a * b * c * d * e * x * g _i * k * l
-c2IL*           a * _ * c * d * e * x * g * h * i * k * l
-c2iL*           a *_* c * d * e * x * g * h * i * k * l
-c2aL*           a _* c * d * e * x * g * h * i * k * l
-c2AL*           a _c * d * e * x * g * h * i * k * l
 c2Il*           a * b * c * _ * e * x * g * h * i * k * l
 c2il*           a * b * c *_* e * x * g * h * i * k * l
 c2al*           a * b * c _* e * x * g * h * i * k * l
@@ -4250,14 +3366,6 @@ c2In*           a * b * c * d * e * x * g * _ * i * k * l
 c2in*           a * b * c * d * e * x * g *_* i * k * l
 c2an*           a * b * c * d * e * x * g _* i * k * l
 c2An*           a * b * c * d * e * x * g _i * k * l
-c2IN*           a * b * c * d * e * x * g * h * i * _ * l
-c2iN*           a * b * c * d * e * x * g * h * i *_* l
-c2aN*           a * b * c * d * e * x * g * h * i _* l
-c2AN*           a * b * c * d * e * x * g * h * i _l
-dIL*            a * b * c *  * e * x * g * h * i * k * l
-diL*            a * b * c ** e * x * g * h * i * k * l
-daL*            a * b * c * e * x * g * h * i * k * l
-dAL*            a * b * c e * x * g * h * i * k * l
 dIl*            a * b * c * d *  * x * g * h * i * k * l
 dil*            a * b * c * d ** x * g * h * i * k * l
 dal*            a * b * c * d * x * g * h * i * k * l
@@ -4270,14 +3378,6 @@ dIn*            a * b * c * d * e * x *  * h * i * k * l
 din*            a * b * c * d * e * x ** h * i * k * l
 dan*            a * b * c * d * e * x * h * i * k * l
 dAn*            a * b * c * d * e * x h * i * k * l
-dIN*            a * b * c * d * e * x * g *  * i * k * l
-diN*            a * b * c * d * e * x * g ** i * k * l
-daN*            a * b * c * d * e * x * g * i * k * l
-dAN*            a * b * c * d * e * x * g i * k * l
-d1IL*           a * b * c *  * e * x * g * h * i * k * l
-d1iL*           a * b * c ** e * x * g * h * i * k * l
-d1aL*           a * b * c * e * x * g * h * i * k * l
-d1AL*           a * b * c e * x * g * h * i * k * l
 d1Il*           a * b * c * d *  * x * g * h * i * k * l
 d1il*           a * b * c * d ** x * g * h * i * k * l
 d1al*           a * b * c * d * x * g * h * i * k * l
@@ -4290,14 +3390,6 @@ d1In*           a * b * c * d * e * x *  * h * i * k * l
 d1in*           a * b * c * d * e * x ** h * i * k * l
 d1an*           a * b * c * d * e * x * h * i * k * l
 d1An*           a * b * c * d * e * x h * i * k * l
-d1IN*           a * b * c * d * e * x * g *  * i * k * l
-d1iN*           a * b * c * d * e * x * g ** i * k * l
-d1aN*           a * b * c * d * e * x * g * i * k * l
-d1AN*           a * b * c * d * e * x * g i * k * l
-d2IL*           a *  * c * d * e * x * g * h * i * k * l
-d2iL*           a ** c * d * e * x * g * h * i * k * l
-d2aL*           a * c * d * e * x * g * h * i * k * l
-d2AL*           a c * d * e * x * g * h * i * k * l
 d2Il*           a * b * c *  * e * x * g * h * i * k * l
 d2il*           a * b * c ** e * x * g * h * i * k * l
 d2al*           a * b * c * e * x * g * h * i * k * l
@@ -4310,14 +3402,6 @@ d2In*           a * b * c * d * e * x * g *  * i * k * l
 d2in*           a * b * c * d * e * x * g ** i * k * l
 d2an*           a * b * c * d * e * x * g * i * k * l
 d2An*           a * b * c * d * e * x * g i * k * l
-d2IN*           a * b * c * d * e * x * g * h * i *  * l
-d2iN*           a * b * c * d * e * x * g * h * i ** l
-d2aN*           a * b * c * d * e * x * g * h * i * l
-d2AN*           a * b * c * d * e * x * g * h * i l
-yIL*            a * b * c * d * e * x * g * h * i * k * l       'd'
-yiL*            a * b * c * d * e * x * g * h * i * k * l       ' d '
-yaL*            a * b * c * d * e * x * g * h * i * k * l       '* d '
-yAL*            a * b * c * d * e * x * g * h * i * k * l       '* d * '
 yIl*            a * b * c * d * e * x * g * h * i * k * l       'e'
 yil*            a * b * c * d * e * x * g * h * i * k * l       ' e '
 yal*            a * b * c * d * e * x * g * h * i * k * l       '* e '
@@ -4330,14 +3414,6 @@ yIn*            a * b * c * d * e * x * g * h * i * k * l       'g'
 yin*            a * b * c * d * e * x * g * h * i * k * l       ' g '
 yan*            a * b * c * d * e * x * g * h * i * k * l       '* g '
 yAn*            a * b * c * d * e * x * g * h * i * k * l       '* g * '
-yIN*            a * b * c * d * e * x * g * h * i * k * l       'h'
-yiN*            a * b * c * d * e * x * g * h * i * k * l       ' h '
-yaN*            a * b * c * d * e * x * g * h * i * k * l       '* h '
-yAN*            a * b * c * d * e * x * g * h * i * k * l       '* h * '
-y1IL*           a * b * c * d * e * x * g * h * i * k * l       'd'
-y1iL*           a * b * c * d * e * x * g * h * i * k * l       ' d '
-y1aL*           a * b * c * d * e * x * g * h * i * k * l       '* d '
-y1AL*           a * b * c * d * e * x * g * h * i * k * l       '* d * '
 y1Il*           a * b * c * d * e * x * g * h * i * k * l       'e'
 y1il*           a * b * c * d * e * x * g * h * i * k * l       ' e '
 y1al*           a * b * c * d * e * x * g * h * i * k * l       '* e '
@@ -4350,14 +3426,6 @@ y1In*           a * b * c * d * e * x * g * h * i * k * l       'g'
 y1in*           a * b * c * d * e * x * g * h * i * k * l       ' g '
 y1an*           a * b * c * d * e * x * g * h * i * k * l       '* g '
 y1An*           a * b * c * d * e * x * g * h * i * k * l       '* g * '
-y1IN*           a * b * c * d * e * x * g * h * i * k * l       'h'
-y1iN*           a * b * c * d * e * x * g * h * i * k * l       ' h '
-y1aN*           a * b * c * d * e * x * g * h * i * k * l       '* h '
-y1AN*           a * b * c * d * e * x * g * h * i * k * l       '* h * '
-y2IL*           a * b * c * d * e * x * g * h * i * k * l       'b'
-y2iL*           a * b * c * d * e * x * g * h * i * k * l       ' b '
-y2aL*           a * b * c * d * e * x * g * h * i * k * l       '* b '
-y2AL*           a * b * c * d * e * x * g * h * i * k * l       '* b * '
 y2Il*           a * b * c * d * e * x * g * h * i * k * l       'd'
 y2il*           a * b * c * d * e * x * g * h * i * k * l       ' d '
 y2al*           a * b * c * d * e * x * g * h * i * k * l       '* d '
@@ -4370,14 +3438,6 @@ y2In*           a * b * c * d * e * x * g * h * i * k * l       'h'
 y2in*           a * b * c * d * e * x * g * h * i * k * l       ' h '
 y2an*           a * b * c * d * e * x * g * h * i * k * l       '* h '
 y2An*           a * b * c * d * e * x * g * h * i * k * l       '* h * '
-y2IN*           a * b * c * d * e * x * g * h * i * k * l       'k'
-y2iN*           a * b * c * d * e * x * g * h * i * k * l       ' k '
-y2aN*           a * b * c * d * e * x * g * h * i * k * l       '* k '
-y2AN*           a * b * c * d * e * x * g * h * i * k * l       '* k * '
-vIL*            a * b * c * _ * e * x * g * h * i * k * l
-viL*            a * b * c *___* e * x * g * h * i * k * l
-vaL*            a * b * c ____* e * x * g * h * i * k * l
-vAL*            a * b * c ______e * x * g * h * i * k * l
 vIl*            a * b * c * d * _ * x * g * h * i * k * l
 vil*            a * b * c * d *___* x * g * h * i * k * l
 val*            a * b * c * d ____* x * g * h * i * k * l
@@ -4390,14 +3450,6 @@ vIn*            a * b * c * d * e * x * _ * h * i * k * l
 vin*            a * b * c * d * e * x *___* h * i * k * l
 van*            a * b * c * d * e * x ____* h * i * k * l
 vAn*            a * b * c * d * e * x ______h * i * k * l
-vIN*            a * b * c * d * e * x * g * _ * i * k * l
-viN*            a * b * c * d * e * x * g *___* i * k * l
-vaN*            a * b * c * d * e * x * g ____* i * k * l
-vAN*            a * b * c * d * e * x * g ______i * k * l
-v1IL*           a * b * c * _ * e * x * g * h * i * k * l
-v1iL*           a * b * c *___* e * x * g * h * i * k * l
-v1aL*           a * b * c ____* e * x * g * h * i * k * l
-v1AL*           a * b * c ______e * x * g * h * i * k * l
 v1Il*           a * b * c * d * _ * x * g * h * i * k * l
 v1il*           a * b * c * d *___* x * g * h * i * k * l
 v1al*           a * b * c * d ____* x * g * h * i * k * l
@@ -4410,14 +3462,6 @@ v1In*           a * b * c * d * e * x * _ * h * i * k * l
 v1in*           a * b * c * d * e * x *___* h * i * k * l
 v1an*           a * b * c * d * e * x ____* h * i * k * l
 v1An*           a * b * c * d * e * x ______h * i * k * l
-v1IN*           a * b * c * d * e * x * g * _ * i * k * l
-v1iN*           a * b * c * d * e * x * g *___* i * k * l
-v1aN*           a * b * c * d * e * x * g ____* i * k * l
-v1AN*           a * b * c * d * e * x * g ______i * k * l
-v2IL*           a * _ * c * d * e * x * g * h * i * k * l
-v2iL*           a *___* c * d * e * x * g * h * i * k * l
-v2aL*           a ____* c * d * e * x * g * h * i * k * l
-v2AL*           a ______c * d * e * x * g * h * i * k * l
 v2Il*           a * b * c * _ * e * x * g * h * i * k * l
 v2il*           a * b * c *___* e * x * g * h * i * k * l
 v2al*           a * b * c ____* e * x * g * h * i * k * l
@@ -4430,15 +3474,7 @@ v2In*           a * b * c * d * e * x * g * _ * i * k * l
 v2in*           a * b * c * d * e * x * g *___* i * k * l
 v2an*           a * b * c * d * e * x * g ____* i * k * l
 v2An*           a * b * c * d * e * x * g ______i * k * l
-v2IN*           a * b * c * d * e * x * g * h * i * _ * l
-v2iN*           a * b * c * d * e * x * g * h * i *___* l
-v2aN*           a * b * c * d * e * x * g * h * i ____* l
-v2AN*           a * b * c * d * e * x * g * h * i ______l
 a # b # c # d # e # x # g # h # i # k # l
-cIL#            a # b # c # _ # e # x # g # h # i # k # l
-ciL#            a # b # c #_# e # x # g # h # i # k # l
-caL#            a # b # c _# e # x # g # h # i # k # l
-cAL#            a # b # c _e # x # g # h # i # k # l
 cIl#            a # b # c # d # _ # x # g # h # i # k # l
 cil#            a # b # c # d #_# x # g # h # i # k # l
 cal#            a # b # c # d _# x # g # h # i # k # l
@@ -4451,14 +3487,6 @@ cIn#            a # b # c # d # e # x # _ # h # i # k # l
 cin#            a # b # c # d # e # x #_# h # i # k # l
 can#            a # b # c # d # e # x _# h # i # k # l
 cAn#            a # b # c # d # e # x _h # i # k # l
-cIN#            a # b # c # d # e # x # g # _ # i # k # l
-ciN#            a # b # c # d # e # x # g #_# i # k # l
-caN#            a # b # c # d # e # x # g _# i # k # l
-cAN#            a # b # c # d # e # x # g _i # k # l
-c1IL#           a # b # c # _ # e # x # g # h # i # k # l
-c1iL#           a # b # c #_# e # x # g # h # i # k # l
-c1aL#           a # b # c _# e # x # g # h # i # k # l
-c1AL#           a # b # c _e # x # g # h # i # k # l
 c1Il#           a # b # c # d # _ # x # g # h # i # k # l
 c1il#           a # b # c # d #_# x # g # h # i # k # l
 c1al#           a # b # c # d _# x # g # h # i # k # l
@@ -4471,14 +3499,6 @@ c1In#           a # b # c # d # e # x # _ # h # i # k # l
 c1in#           a # b # c # d # e # x #_# h # i # k # l
 c1an#           a # b # c # d # e # x _# h # i # k # l
 c1An#           a # b # c # d # e # x _h # i # k # l
-c1IN#           a # b # c # d # e # x # g # _ # i # k # l
-c1iN#           a # b # c # d # e # x # g #_# i # k # l
-c1aN#           a # b # c # d # e # x # g _# i # k # l
-c1AN#           a # b # c # d # e # x # g _i # k # l
-c2IL#           a # _ # c # d # e # x # g # h # i # k # l
-c2iL#           a #_# c # d # e # x # g # h # i # k # l
-c2aL#           a _# c # d # e # x # g # h # i # k # l
-c2AL#           a _c # d # e # x # g # h # i # k # l
 c2Il#           a # b # c # _ # e # x # g # h # i # k # l
 c2il#           a # b # c #_# e # x # g # h # i # k # l
 c2al#           a # b # c _# e # x # g # h # i # k # l
@@ -4491,14 +3511,6 @@ c2In#           a # b # c # d # e # x # g # _ # i # k # l
 c2in#           a # b # c # d # e # x # g #_# i # k # l
 c2an#           a # b # c # d # e # x # g _# i # k # l
 c2An#           a # b # c # d # e # x # g _i # k # l
-c2IN#           a # b # c # d # e # x # g # h # i # _ # l
-c2iN#           a # b # c # d # e # x # g # h # i #_# l
-c2aN#           a # b # c # d # e # x # g # h # i _# l
-c2AN#           a # b # c # d # e # x # g # h # i _l
-dIL#            a # b # c #  # e # x # g # h # i # k # l
-diL#            a # b # c ## e # x # g # h # i # k # l
-daL#            a # b # c # e # x # g # h # i # k # l
-dAL#            a # b # c e # x # g # h # i # k # l
 dIl#            a # b # c # d #  # x # g # h # i # k # l
 dil#            a # b # c # d ## x # g # h # i # k # l
 dal#            a # b # c # d # x # g # h # i # k # l
@@ -4511,14 +3523,6 @@ dIn#            a # b # c # d # e # x #  # h # i # k # l
 din#            a # b # c # d # e # x ## h # i # k # l
 dan#            a # b # c # d # e # x # h # i # k # l
 dAn#            a # b # c # d # e # x h # i # k # l
-dIN#            a # b # c # d # e # x # g #  # i # k # l
-diN#            a # b # c # d # e # x # g ## i # k # l
-daN#            a # b # c # d # e # x # g # i # k # l
-dAN#            a # b # c # d # e # x # g i # k # l
-d1IL#           a # b # c #  # e # x # g # h # i # k # l
-d1iL#           a # b # c ## e # x # g # h # i # k # l
-d1aL#           a # b # c # e # x # g # h # i # k # l
-d1AL#           a # b # c e # x # g # h # i # k # l
 d1Il#           a # b # c # d #  # x # g # h # i # k # l
 d1il#           a # b # c # d ## x # g # h # i # k # l
 d1al#           a # b # c # d # x # g # h # i # k # l
@@ -4531,14 +3535,6 @@ d1In#           a # b # c # d # e # x #  # h # i # k # l
 d1in#           a # b # c # d # e # x ## h # i # k # l
 d1an#           a # b # c # d # e # x # h # i # k # l
 d1An#           a # b # c # d # e # x h # i # k # l
-d1IN#           a # b # c # d # e # x # g #  # i # k # l
-d1iN#           a # b # c # d # e # x # g ## i # k # l
-d1aN#           a # b # c # d # e # x # g # i # k # l
-d1AN#           a # b # c # d # e # x # g i # k # l
-d2IL#           a #  # c # d # e # x # g # h # i # k # l
-d2iL#           a ## c # d # e # x # g # h # i # k # l
-d2aL#           a # c # d # e # x # g # h # i # k # l
-d2AL#           a c # d # e # x # g # h # i # k # l
 d2Il#           a # b # c #  # e # x # g # h # i # k # l
 d2il#           a # b # c ## e # x # g # h # i # k # l
 d2al#           a # b # c # e # x # g # h # i # k # l
@@ -4551,14 +3547,6 @@ d2In#           a # b # c # d # e # x # g #  # i # k # l
 d2in#           a # b # c # d # e # x # g ## i # k # l
 d2an#           a # b # c # d # e # x # g # i # k # l
 d2An#           a # b # c # d # e # x # g i # k # l
-d2IN#           a # b # c # d # e # x # g # h # i #  # l
-d2iN#           a # b # c # d # e # x # g # h # i ## l
-d2aN#           a # b # c # d # e # x # g # h # i # l
-d2AN#           a # b # c # d # e # x # g # h # i l
-yIL#            a # b # c # d # e # x # g # h # i # k # l       'd'
-yiL#            a # b # c # d # e # x # g # h # i # k # l       ' d '
-yaL#            a # b # c # d # e # x # g # h # i # k # l       '# d '
-yAL#            a # b # c # d # e # x # g # h # i # k # l       '# d # '
 yIl#            a # b # c # d # e # x # g # h # i # k # l       'e'
 yil#            a # b # c # d # e # x # g # h # i # k # l       ' e '
 yal#            a # b # c # d # e # x # g # h # i # k # l       '# e '
@@ -4571,14 +3559,6 @@ yIn#            a # b # c # d # e # x # g # h # i # k # l       'g'
 yin#            a # b # c # d # e # x # g # h # i # k # l       ' g '
 yan#            a # b # c # d # e # x # g # h # i # k # l       '# g '
 yAn#            a # b # c # d # e # x # g # h # i # k # l       '# g # '
-yIN#            a # b # c # d # e # x # g # h # i # k # l       'h'
-yiN#            a # b # c # d # e # x # g # h # i # k # l       ' h '
-yaN#            a # b # c # d # e # x # g # h # i # k # l       '# h '
-yAN#            a # b # c # d # e # x # g # h # i # k # l       '# h # '
-y1IL#           a # b # c # d # e # x # g # h # i # k # l       'd'
-y1iL#           a # b # c # d # e # x # g # h # i # k # l       ' d '
-y1aL#           a # b # c # d # e # x # g # h # i # k # l       '# d '
-y1AL#           a # b # c # d # e # x # g # h # i # k # l       '# d # '
 y1Il#           a # b # c # d # e # x # g # h # i # k # l       'e'
 y1il#           a # b # c # d # e # x # g # h # i # k # l       ' e '
 y1al#           a # b # c # d # e # x # g # h # i # k # l       '# e '
@@ -4591,14 +3571,6 @@ y1In#           a # b # c # d # e # x # g # h # i # k # l       'g'
 y1in#           a # b # c # d # e # x # g # h # i # k # l       ' g '
 y1an#           a # b # c # d # e # x # g # h # i # k # l       '# g '
 y1An#           a # b # c # d # e # x # g # h # i # k # l       '# g # '
-y1IN#           a # b # c # d # e # x # g # h # i # k # l       'h'
-y1iN#           a # b # c # d # e # x # g # h # i # k # l       ' h '
-y1aN#           a # b # c # d # e # x # g # h # i # k # l       '# h '
-y1AN#           a # b # c # d # e # x # g # h # i # k # l       '# h # '
-y2IL#           a # b # c # d # e # x # g # h # i # k # l       'b'
-y2iL#           a # b # c # d # e # x # g # h # i # k # l       ' b '
-y2aL#           a # b # c # d # e # x # g # h # i # k # l       '# b '
-y2AL#           a # b # c # d # e # x # g # h # i # k # l       '# b # '
 y2Il#           a # b # c # d # e # x # g # h # i # k # l       'd'
 y2il#           a # b # c # d # e # x # g # h # i # k # l       ' d '
 y2al#           a # b # c # d # e # x # g # h # i # k # l       '# d '
@@ -4611,14 +3583,6 @@ y2In#           a # b # c # d # e # x # g # h # i # k # l       'h'
 y2in#           a # b # c # d # e # x # g # h # i # k # l       ' h '
 y2an#           a # b # c # d # e # x # g # h # i # k # l       '# h '
 y2An#           a # b # c # d # e # x # g # h # i # k # l       '# h # '
-y2IN#           a # b # c # d # e # x # g # h # i # k # l       'k'
-y2iN#           a # b # c # d # e # x # g # h # i # k # l       ' k '
-y2aN#           a # b # c # d # e # x # g # h # i # k # l       '# k '
-y2AN#           a # b # c # d # e # x # g # h # i # k # l       '# k # '
-vIL#            a # b # c # _ # e # x # g # h # i # k # l
-viL#            a # b # c #___# e # x # g # h # i # k # l
-vaL#            a # b # c ____# e # x # g # h # i # k # l
-vAL#            a # b # c ______e # x # g # h # i # k # l
 vIl#            a # b # c # d # _ # x # g # h # i # k # l
 vil#            a # b # c # d #___# x # g # h # i # k # l
 val#            a # b # c # d ____# x # g # h # i # k # l
@@ -4631,14 +3595,6 @@ vIn#            a # b # c # d # e # x # _ # h # i # k # l
 vin#            a # b # c # d # e # x #___# h # i # k # l
 van#            a # b # c # d # e # x ____# h # i # k # l
 vAn#            a # b # c # d # e # x ______h # i # k # l
-vIN#            a # b # c # d # e # x # g # _ # i # k # l
-viN#            a # b # c # d # e # x # g #___# i # k # l
-vaN#            a # b # c # d # e # x # g ____# i # k # l
-vAN#            a # b # c # d # e # x # g ______i # k # l
-v1IL#           a # b # c # _ # e # x # g # h # i # k # l
-v1iL#           a # b # c #___# e # x # g # h # i # k # l
-v1aL#           a # b # c ____# e # x # g # h # i # k # l
-v1AL#           a # b # c ______e # x # g # h # i # k # l
 v1Il#           a # b # c # d # _ # x # g # h # i # k # l
 v1il#           a # b # c # d #___# x # g # h # i # k # l
 v1al#           a # b # c # d ____# x # g # h # i # k # l
@@ -4651,14 +3607,6 @@ v1In#           a # b # c # d # e # x # _ # h # i # k # l
 v1in#           a # b # c # d # e # x #___# h # i # k # l
 v1an#           a # b # c # d # e # x ____# h # i # k # l
 v1An#           a # b # c # d # e # x ______h # i # k # l
-v1IN#           a # b # c # d # e # x # g # _ # i # k # l
-v1iN#           a # b # c # d # e # x # g #___# i # k # l
-v1aN#           a # b # c # d # e # x # g ____# i # k # l
-v1AN#           a # b # c # d # e # x # g ______i # k # l
-v2IL#           a # _ # c # d # e # x # g # h # i # k # l
-v2iL#           a #___# c # d # e # x # g # h # i # k # l
-v2aL#           a ____# c # d # e # x # g # h # i # k # l
-v2AL#           a ______c # d # e # x # g # h # i # k # l
 v2Il#           a # b # c # _ # e # x # g # h # i # k # l
 v2il#           a # b # c #___# e # x # g # h # i # k # l
 v2al#           a # b # c ____# e # x # g # h # i # k # l
@@ -4671,15 +3619,7 @@ v2In#           a # b # c # d # e # x # g # _ # i # k # l
 v2in#           a # b # c # d # e # x # g #___# i # k # l
 v2an#           a # b # c # d # e # x # g ____# i # k # l
 v2An#           a # b # c # d # e # x # g ______i # k # l
-v2IN#           a # b # c # d # e # x # g # h # i # _ # l
-v2iN#           a # b # c # d # e # x # g # h # i #___# l
-v2aN#           a # b # c # d # e # x # g # h # i ____# l
-v2AN#           a # b # c # d # e # x # g # h # i ______l
 a / b / c / d / e / x / g / h / i / k / l
-cIL/            a / b / c / _ / e / x / g / h / i / k / l
-ciL/            a / b / c /_/ e / x / g / h / i / k / l
-caL/            a / b / c _/ e / x / g / h / i / k / l
-cAL/            a / b / c _e / x / g / h / i / k / l
 cIl/            a / b / c / d / _ / x / g / h / i / k / l
 cil/            a / b / c / d /_/ x / g / h / i / k / l
 cal/            a / b / c / d _/ x / g / h / i / k / l
@@ -4692,14 +3632,6 @@ cIn/            a / b / c / d / e / x / _ / h / i / k / l
 cin/            a / b / c / d / e / x /_/ h / i / k / l
 can/            a / b / c / d / e / x _/ h / i / k / l
 cAn/            a / b / c / d / e / x _h / i / k / l
-cIN/            a / b / c / d / e / x / g / _ / i / k / l
-ciN/            a / b / c / d / e / x / g /_/ i / k / l
-caN/            a / b / c / d / e / x / g _/ i / k / l
-cAN/            a / b / c / d / e / x / g _i / k / l
-c1IL/           a / b / c / _ / e / x / g / h / i / k / l
-c1iL/           a / b / c /_/ e / x / g / h / i / k / l
-c1aL/           a / b / c _/ e / x / g / h / i / k / l
-c1AL/           a / b / c _e / x / g / h / i / k / l
 c1Il/           a / b / c / d / _ / x / g / h / i / k / l
 c1il/           a / b / c / d /_/ x / g / h / i / k / l
 c1al/           a / b / c / d _/ x / g / h / i / k / l
@@ -4712,14 +3644,6 @@ c1In/           a / b / c / d / e / x / _ / h / i / k / l
 c1in/           a / b / c / d / e / x /_/ h / i / k / l
 c1an/           a / b / c / d / e / x _/ h / i / k / l
 c1An/           a / b / c / d / e / x _h / i / k / l
-c1IN/           a / b / c / d / e / x / g / _ / i / k / l
-c1iN/           a / b / c / d / e / x / g /_/ i / k / l
-c1aN/           a / b / c / d / e / x / g _/ i / k / l
-c1AN/           a / b / c / d / e / x / g _i / k / l
-c2IL/           a / _ / c / d / e / x / g / h / i / k / l
-c2iL/           a /_/ c / d / e / x / g / h / i / k / l
-c2aL/           a _/ c / d / e / x / g / h / i / k / l
-c2AL/           a _c / d / e / x / g / h / i / k / l
 c2Il/           a / b / c / _ / e / x / g / h / i / k / l
 c2il/           a / b / c /_/ e / x / g / h / i / k / l
 c2al/           a / b / c _/ e / x / g / h / i / k / l
@@ -4732,14 +3656,6 @@ c2In/           a / b / c / d / e / x / g / _ / i / k / l
 c2in/           a / b / c / d / e / x / g /_/ i / k / l
 c2an/           a / b / c / d / e / x / g _/ i / k / l
 c2An/           a / b / c / d / e / x / g _i / k / l
-c2IN/           a / b / c / d / e / x / g / h / i / _ / l
-c2iN/           a / b / c / d / e / x / g / h / i /_/ l
-c2aN/           a / b / c / d / e / x / g / h / i _/ l
-c2AN/           a / b / c / d / e / x / g / h / i _l
-dIL/            a / b / c /  / e / x / g / h / i / k / l
-diL/            a / b / c // e / x / g / h / i / k / l
-daL/            a / b / c / e / x / g / h / i / k / l
-dAL/            a / b / c e / x / g / h / i / k / l
 dIl/            a / b / c / d /  / x / g / h / i / k / l
 dil/            a / b / c / d // x / g / h / i / k / l
 dal/            a / b / c / d / x / g / h / i / k / l
@@ -4752,14 +3668,6 @@ dIn/            a / b / c / d / e / x /  / h / i / k / l
 din/            a / b / c / d / e / x // h / i / k / l
 dan/            a / b / c / d / e / x / h / i / k / l
 dAn/            a / b / c / d / e / x h / i / k / l
-dIN/            a / b / c / d / e / x / g /  / i / k / l
-diN/            a / b / c / d / e / x / g // i / k / l
-daN/            a / b / c / d / e / x / g / i / k / l
-dAN/            a / b / c / d / e / x / g i / k / l
-d1IL/           a / b / c /  / e / x / g / h / i / k / l
-d1iL/           a / b / c // e / x / g / h / i / k / l
-d1aL/           a / b / c / e / x / g / h / i / k / l
-d1AL/           a / b / c e / x / g / h / i / k / l
 d1Il/           a / b / c / d /  / x / g / h / i / k / l
 d1il/           a / b / c / d // x / g / h / i / k / l
 d1al/           a / b / c / d / x / g / h / i / k / l
@@ -4772,14 +3680,6 @@ d1In/           a / b / c / d / e / x /  / h / i / k / l
 d1in/           a / b / c / d / e / x // h / i / k / l
 d1an/           a / b / c / d / e / x / h / i / k / l
 d1An/           a / b / c / d / e / x h / i / k / l
-d1IN/           a / b / c / d / e / x / g /  / i / k / l
-d1iN/           a / b / c / d / e / x / g // i / k / l
-d1aN/           a / b / c / d / e / x / g / i / k / l
-d1AN/           a / b / c / d / e / x / g i / k / l
-d2IL/           a /  / c / d / e / x / g / h / i / k / l
-d2iL/           a // c / d / e / x / g / h / i / k / l
-d2aL/           a / c / d / e / x / g / h / i / k / l
-d2AL/           a c / d / e / x / g / h / i / k / l
 d2Il/           a / b / c /  / e / x / g / h / i / k / l
 d2il/           a / b / c // e / x / g / h / i / k / l
 d2al/           a / b / c / e / x / g / h / i / k / l
@@ -4792,14 +3692,6 @@ d2In/           a / b / c / d / e / x / g /  / i / k / l
 d2in/           a / b / c / d / e / x / g // i / k / l
 d2an/           a / b / c / d / e / x / g / i / k / l
 d2An/           a / b / c / d / e / x / g i / k / l
-d2IN/           a / b / c / d / e / x / g / h / i /  / l
-d2iN/           a / b / c / d / e / x / g / h / i // l
-d2aN/           a / b / c / d / e / x / g / h / i / l
-d2AN/           a / b / c / d / e / x / g / h / i l
-yIL/            a / b / c / d / e / x / g / h / i / k / l       'd'
-yiL/            a / b / c / d / e / x / g / h / i / k / l       ' d '
-yaL/            a / b / c / d / e / x / g / h / i / k / l       '/ d '
-yAL/            a / b / c / d / e / x / g / h / i / k / l       '/ d / '
 yIl/            a / b / c / d / e / x / g / h / i / k / l       'e'
 yil/            a / b / c / d / e / x / g / h / i / k / l       ' e '
 yal/            a / b / c / d / e / x / g / h / i / k / l       '/ e '
@@ -4812,14 +3704,6 @@ yIn/            a / b / c / d / e / x / g / h / i / k / l       'g'
 yin/            a / b / c / d / e / x / g / h / i / k / l       ' g '
 yan/            a / b / c / d / e / x / g / h / i / k / l       '/ g '
 yAn/            a / b / c / d / e / x / g / h / i / k / l       '/ g / '
-yIN/            a / b / c / d / e / x / g / h / i / k / l       'h'
-yiN/            a / b / c / d / e / x / g / h / i / k / l       ' h '
-yaN/            a / b / c / d / e / x / g / h / i / k / l       '/ h '
-yAN/            a / b / c / d / e / x / g / h / i / k / l       '/ h / '
-y1IL/           a / b / c / d / e / x / g / h / i / k / l       'd'
-y1iL/           a / b / c / d / e / x / g / h / i / k / l       ' d '
-y1aL/           a / b / c / d / e / x / g / h / i / k / l       '/ d '
-y1AL/           a / b / c / d / e / x / g / h / i / k / l       '/ d / '
 y1Il/           a / b / c / d / e / x / g / h / i / k / l       'e'
 y1il/           a / b / c / d / e / x / g / h / i / k / l       ' e '
 y1al/           a / b / c / d / e / x / g / h / i / k / l       '/ e '
@@ -4832,14 +3716,6 @@ y1In/           a / b / c / d / e / x / g / h / i / k / l       'g'
 y1in/           a / b / c / d / e / x / g / h / i / k / l       ' g '
 y1an/           a / b / c / d / e / x / g / h / i / k / l       '/ g '
 y1An/           a / b / c / d / e / x / g / h / i / k / l       '/ g / '
-y1IN/           a / b / c / d / e / x / g / h / i / k / l       'h'
-y1iN/           a / b / c / d / e / x / g / h / i / k / l       ' h '
-y1aN/           a / b / c / d / e / x / g / h / i / k / l       '/ h '
-y1AN/           a / b / c / d / e / x / g / h / i / k / l       '/ h / '
-y2IL/           a / b / c / d / e / x / g / h / i / k / l       'b'
-y2iL/           a / b / c / d / e / x / g / h / i / k / l       ' b '
-y2aL/           a / b / c / d / e / x / g / h / i / k / l       '/ b '
-y2AL/           a / b / c / d / e / x / g / h / i / k / l       '/ b / '
 y2Il/           a / b / c / d / e / x / g / h / i / k / l       'd'
 y2il/           a / b / c / d / e / x / g / h / i / k / l       ' d '
 y2al/           a / b / c / d / e / x / g / h / i / k / l       '/ d '
@@ -4852,14 +3728,6 @@ y2In/           a / b / c / d / e / x / g / h / i / k / l       'h'
 y2in/           a / b / c / d / e / x / g / h / i / k / l       ' h '
 y2an/           a / b / c / d / e / x / g / h / i / k / l       '/ h '
 y2An/           a / b / c / d / e / x / g / h / i / k / l       '/ h / '
-y2IN/           a / b / c / d / e / x / g / h / i / k / l       'k'
-y2iN/           a / b / c / d / e / x / g / h / i / k / l       ' k '
-y2aN/           a / b / c / d / e / x / g / h / i / k / l       '/ k '
-y2AN/           a / b / c / d / e / x / g / h / i / k / l       '/ k / '
-vIL/            a / b / c / _ / e / x / g / h / i / k / l
-viL/            a / b / c /___/ e / x / g / h / i / k / l
-vaL/            a / b / c ____/ e / x / g / h / i / k / l
-vAL/            a / b / c ______e / x / g / h / i / k / l
 vIl/            a / b / c / d / _ / x / g / h / i / k / l
 vil/            a / b / c / d /___/ x / g / h / i / k / l
 val/            a / b / c / d ____/ x / g / h / i / k / l
@@ -4872,14 +3740,6 @@ vIn/            a / b / c / d / e / x / _ / h / i / k / l
 vin/            a / b / c / d / e / x /___/ h / i / k / l
 van/            a / b / c / d / e / x ____/ h / i / k / l
 vAn/            a / b / c / d / e / x ______h / i / k / l
-vIN/            a / b / c / d / e / x / g / _ / i / k / l
-viN/            a / b / c / d / e / x / g /___/ i / k / l
-vaN/            a / b / c / d / e / x / g ____/ i / k / l
-vAN/            a / b / c / d / e / x / g ______i / k / l
-v1IL/           a / b / c / _ / e / x / g / h / i / k / l
-v1iL/           a / b / c /___/ e / x / g / h / i / k / l
-v1aL/           a / b / c ____/ e / x / g / h / i / k / l
-v1AL/           a / b / c ______e / x / g / h / i / k / l
 v1Il/           a / b / c / d / _ / x / g / h / i / k / l
 v1il/           a / b / c / d /___/ x / g / h / i / k / l
 v1al/           a / b / c / d ____/ x / g / h / i / k / l
@@ -4892,14 +3752,6 @@ v1In/           a / b / c / d / e / x / _ / h / i / k / l
 v1in/           a / b / c / d / e / x /___/ h / i / k / l
 v1an/           a / b / c / d / e / x ____/ h / i / k / l
 v1An/           a / b / c / d / e / x ______h / i / k / l
-v1IN/           a / b / c / d / e / x / g / _ / i / k / l
-v1iN/           a / b / c / d / e / x / g /___/ i / k / l
-v1aN/           a / b / c / d / e / x / g ____/ i / k / l
-v1AN/           a / b / c / d / e / x / g ______i / k / l
-v2IL/           a / _ / c / d / e / x / g / h / i / k / l
-v2iL/           a /___/ c / d / e / x / g / h / i / k / l
-v2aL/           a ____/ c / d / e / x / g / h / i / k / l
-v2AL/           a ______c / d / e / x / g / h / i / k / l
 v2Il/           a / b / c / _ / e / x / g / h / i / k / l
 v2il/           a / b / c /___/ e / x / g / h / i / k / l
 v2al/           a / b / c ____/ e / x / g / h / i / k / l
@@ -4912,15 +3764,7 @@ v2In/           a / b / c / d / e / x / g / _ / i / k / l
 v2in/           a / b / c / d / e / x / g /___/ i / k / l
 v2an/           a / b / c / d / e / x / g ____/ i / k / l
 v2An/           a / b / c / d / e / x / g ______i / k / l
-v2IN/           a / b / c / d / e / x / g / h / i / _ / l
-v2iN/           a / b / c / d / e / x / g / h / i /___/ l
-v2aN/           a / b / c / d / e / x / g / h / i ____/ l
-v2AN/           a / b / c / d / e / x / g / h / i ______l
 a | b | c | d | e | x | g | h | i | k | l
-cIL|            a | b | c | _ | e | x | g | h | i | k | l
-ciL|            a | b | c |_| e | x | g | h | i | k | l
-caL|            a | b | c _| e | x | g | h | i | k | l
-cAL|            a | b | c _e | x | g | h | i | k | l
 cIl|            a | b | c | d | _ | x | g | h | i | k | l
 cil|            a | b | c | d |_| x | g | h | i | k | l
 cal|            a | b | c | d _| x | g | h | i | k | l
@@ -4933,14 +3777,6 @@ cIn|            a | b | c | d | e | x | _ | h | i | k | l
 cin|            a | b | c | d | e | x |_| h | i | k | l
 can|            a | b | c | d | e | x _| h | i | k | l
 cAn|            a | b | c | d | e | x _h | i | k | l
-cIN|            a | b | c | d | e | x | g | _ | i | k | l
-ciN|            a | b | c | d | e | x | g |_| i | k | l
-caN|            a | b | c | d | e | x | g _| i | k | l
-cAN|            a | b | c | d | e | x | g _i | k | l
-c1IL|           a | b | c | _ | e | x | g | h | i | k | l
-c1iL|           a | b | c |_| e | x | g | h | i | k | l
-c1aL|           a | b | c _| e | x | g | h | i | k | l
-c1AL|           a | b | c _e | x | g | h | i | k | l
 c1Il|           a | b | c | d | _ | x | g | h | i | k | l
 c1il|           a | b | c | d |_| x | g | h | i | k | l
 c1al|           a | b | c | d _| x | g | h | i | k | l
@@ -4953,14 +3789,6 @@ c1In|           a | b | c | d | e | x | _ | h | i | k | l
 c1in|           a | b | c | d | e | x |_| h | i | k | l
 c1an|           a | b | c | d | e | x _| h | i | k | l
 c1An|           a | b | c | d | e | x _h | i | k | l
-c1IN|           a | b | c | d | e | x | g | _ | i | k | l
-c1iN|           a | b | c | d | e | x | g |_| i | k | l
-c1aN|           a | b | c | d | e | x | g _| i | k | l
-c1AN|           a | b | c | d | e | x | g _i | k | l
-c2IL|           a | _ | c | d | e | x | g | h | i | k | l
-c2iL|           a |_| c | d | e | x | g | h | i | k | l
-c2aL|           a _| c | d | e | x | g | h | i | k | l
-c2AL|           a _c | d | e | x | g | h | i | k | l
 c2Il|           a | b | c | _ | e | x | g | h | i | k | l
 c2il|           a | b | c |_| e | x | g | h | i | k | l
 c2al|           a | b | c _| e | x | g | h | i | k | l
@@ -4973,14 +3801,6 @@ c2In|           a | b | c | d | e | x | g | _ | i | k | l
 c2in|           a | b | c | d | e | x | g |_| i | k | l
 c2an|           a | b | c | d | e | x | g _| i | k | l
 c2An|           a | b | c | d | e | x | g _i | k | l
-c2IN|           a | b | c | d | e | x | g | h | i | _ | l
-c2iN|           a | b | c | d | e | x | g | h | i |_| l
-c2aN|           a | b | c | d | e | x | g | h | i _| l
-c2AN|           a | b | c | d | e | x | g | h | i _l
-dIL|            a | b | c |  | e | x | g | h | i | k | l
-diL|            a | b | c || e | x | g | h | i | k | l
-daL|            a | b | c | e | x | g | h | i | k | l
-dAL|            a | b | c e | x | g | h | i | k | l
 dIl|            a | b | c | d |  | x | g | h | i | k | l
 dil|            a | b | c | d || x | g | h | i | k | l
 dal|            a | b | c | d | x | g | h | i | k | l
@@ -4993,14 +3813,6 @@ dIn|            a | b | c | d | e | x |  | h | i | k | l
 din|            a | b | c | d | e | x || h | i | k | l
 dan|            a | b | c | d | e | x | h | i | k | l
 dAn|            a | b | c | d | e | x h | i | k | l
-dIN|            a | b | c | d | e | x | g |  | i | k | l
-diN|            a | b | c | d | e | x | g || i | k | l
-daN|            a | b | c | d | e | x | g | i | k | l
-dAN|            a | b | c | d | e | x | g i | k | l
-d1IL|           a | b | c |  | e | x | g | h | i | k | l
-d1iL|           a | b | c || e | x | g | h | i | k | l
-d1aL|           a | b | c | e | x | g | h | i | k | l
-d1AL|           a | b | c e | x | g | h | i | k | l
 d1Il|           a | b | c | d |  | x | g | h | i | k | l
 d1il|           a | b | c | d || x | g | h | i | k | l
 d1al|           a | b | c | d | x | g | h | i | k | l
@@ -5013,14 +3825,6 @@ d1In|           a | b | c | d | e | x |  | h | i | k | l
 d1in|           a | b | c | d | e | x || h | i | k | l
 d1an|           a | b | c | d | e | x | h | i | k | l
 d1An|           a | b | c | d | e | x h | i | k | l
-d1IN|           a | b | c | d | e | x | g |  | i | k | l
-d1iN|           a | b | c | d | e | x | g || i | k | l
-d1aN|           a | b | c | d | e | x | g | i | k | l
-d1AN|           a | b | c | d | e | x | g i | k | l
-d2IL|           a |  | c | d | e | x | g | h | i | k | l
-d2iL|           a || c | d | e | x | g | h | i | k | l
-d2aL|           a | c | d | e | x | g | h | i | k | l
-d2AL|           a c | d | e | x | g | h | i | k | l
 d2Il|           a | b | c |  | e | x | g | h | i | k | l
 d2il|           a | b | c || e | x | g | h | i | k | l
 d2al|           a | b | c | e | x | g | h | i | k | l
@@ -5033,14 +3837,6 @@ d2In|           a | b | c | d | e | x | g |  | i | k | l
 d2in|           a | b | c | d | e | x | g || i | k | l
 d2an|           a | b | c | d | e | x | g | i | k | l
 d2An|           a | b | c | d | e | x | g i | k | l
-d2IN|           a | b | c | d | e | x | g | h | i |  | l
-d2iN|           a | b | c | d | e | x | g | h | i || l
-d2aN|           a | b | c | d | e | x | g | h | i | l
-d2AN|           a | b | c | d | e | x | g | h | i l
-yIL|            a | b | c | d | e | x | g | h | i | k | l       'd'
-yiL|            a | b | c | d | e | x | g | h | i | k | l       ' d '
-yaL|            a | b | c | d | e | x | g | h | i | k | l       '| d '
-yAL|            a | b | c | d | e | x | g | h | i | k | l       '| d | '
 yIl|            a | b | c | d | e | x | g | h | i | k | l       'e'
 yil|            a | b | c | d | e | x | g | h | i | k | l       ' e '
 yal|            a | b | c | d | e | x | g | h | i | k | l       '| e '
@@ -5053,14 +3849,6 @@ yIn|            a | b | c | d | e | x | g | h | i | k | l       'g'
 yin|            a | b | c | d | e | x | g | h | i | k | l       ' g '
 yan|            a | b | c | d | e | x | g | h | i | k | l       '| g '
 yAn|            a | b | c | d | e | x | g | h | i | k | l       '| g | '
-yIN|            a | b | c | d | e | x | g | h | i | k | l       'h'
-yiN|            a | b | c | d | e | x | g | h | i | k | l       ' h '
-yaN|            a | b | c | d | e | x | g | h | i | k | l       '| h '
-yAN|            a | b | c | d | e | x | g | h | i | k | l       '| h | '
-y1IL|           a | b | c | d | e | x | g | h | i | k | l       'd'
-y1iL|           a | b | c | d | e | x | g | h | i | k | l       ' d '
-y1aL|           a | b | c | d | e | x | g | h | i | k | l       '| d '
-y1AL|           a | b | c | d | e | x | g | h | i | k | l       '| d | '
 y1Il|           a | b | c | d | e | x | g | h | i | k | l       'e'
 y1il|           a | b | c | d | e | x | g | h | i | k | l       ' e '
 y1al|           a | b | c | d | e | x | g | h | i | k | l       '| e '
@@ -5073,14 +3861,6 @@ y1In|           a | b | c | d | e | x | g | h | i | k | l       'g'
 y1in|           a | b | c | d | e | x | g | h | i | k | l       ' g '
 y1an|           a | b | c | d | e | x | g | h | i | k | l       '| g '
 y1An|           a | b | c | d | e | x | g | h | i | k | l       '| g | '
-y1IN|           a | b | c | d | e | x | g | h | i | k | l       'h'
-y1iN|           a | b | c | d | e | x | g | h | i | k | l       ' h '
-y1aN|           a | b | c | d | e | x | g | h | i | k | l       '| h '
-y1AN|           a | b | c | d | e | x | g | h | i | k | l       '| h | '
-y2IL|           a | b | c | d | e | x | g | h | i | k | l       'b'
-y2iL|           a | b | c | d | e | x | g | h | i | k | l       ' b '
-y2aL|           a | b | c | d | e | x | g | h | i | k | l       '| b '
-y2AL|           a | b | c | d | e | x | g | h | i | k | l       '| b | '
 y2Il|           a | b | c | d | e | x | g | h | i | k | l       'd'
 y2il|           a | b | c | d | e | x | g | h | i | k | l       ' d '
 y2al|           a | b | c | d | e | x | g | h | i | k | l       '| d '
@@ -5093,14 +3873,6 @@ y2In|           a | b | c | d | e | x | g | h | i | k | l       'h'
 y2in|           a | b | c | d | e | x | g | h | i | k | l       ' h '
 y2an|           a | b | c | d | e | x | g | h | i | k | l       '| h '
 y2An|           a | b | c | d | e | x | g | h | i | k | l       '| h | '
-y2IN|           a | b | c | d | e | x | g | h | i | k | l       'k'
-y2iN|           a | b | c | d | e | x | g | h | i | k | l       ' k '
-y2aN|           a | b | c | d | e | x | g | h | i | k | l       '| k '
-y2AN|           a | b | c | d | e | x | g | h | i | k | l       '| k | '
-vIL|            a | b | c | _ | e | x | g | h | i | k | l
-viL|            a | b | c |___| e | x | g | h | i | k | l
-vaL|            a | b | c ____| e | x | g | h | i | k | l
-vAL|            a | b | c ______e | x | g | h | i | k | l
 vIl|            a | b | c | d | _ | x | g | h | i | k | l
 vil|            a | b | c | d |___| x | g | h | i | k | l
 val|            a | b | c | d ____| x | g | h | i | k | l
@@ -5113,14 +3885,6 @@ vIn|            a | b | c | d | e | x | _ | h | i | k | l
 vin|            a | b | c | d | e | x |___| h | i | k | l
 van|            a | b | c | d | e | x ____| h | i | k | l
 vAn|            a | b | c | d | e | x ______h | i | k | l
-vIN|            a | b | c | d | e | x | g | _ | i | k | l
-viN|            a | b | c | d | e | x | g |___| i | k | l
-vaN|            a | b | c | d | e | x | g ____| i | k | l
-vAN|            a | b | c | d | e | x | g ______i | k | l
-v1IL|           a | b | c | _ | e | x | g | h | i | k | l
-v1iL|           a | b | c |___| e | x | g | h | i | k | l
-v1aL|           a | b | c ____| e | x | g | h | i | k | l
-v1AL|           a | b | c ______e | x | g | h | i | k | l
 v1Il|           a | b | c | d | _ | x | g | h | i | k | l
 v1il|           a | b | c | d |___| x | g | h | i | k | l
 v1al|           a | b | c | d ____| x | g | h | i | k | l
@@ -5133,14 +3897,6 @@ v1In|           a | b | c | d | e | x | _ | h | i | k | l
 v1in|           a | b | c | d | e | x |___| h | i | k | l
 v1an|           a | b | c | d | e | x ____| h | i | k | l
 v1An|           a | b | c | d | e | x ______h | i | k | l
-v1IN|           a | b | c | d | e | x | g | _ | i | k | l
-v1iN|           a | b | c | d | e | x | g |___| i | k | l
-v1aN|           a | b | c | d | e | x | g ____| i | k | l
-v1AN|           a | b | c | d | e | x | g ______i | k | l
-v2IL|           a | _ | c | d | e | x | g | h | i | k | l
-v2iL|           a |___| c | d | e | x | g | h | i | k | l
-v2aL|           a ____| c | d | e | x | g | h | i | k | l
-v2AL|           a ______c | d | e | x | g | h | i | k | l
 v2Il|           a | b | c | _ | e | x | g | h | i | k | l
 v2il|           a | b | c |___| e | x | g | h | i | k | l
 v2al|           a | b | c ____| e | x | g | h | i | k | l
@@ -5153,15 +3909,7 @@ v2In|           a | b | c | d | e | x | g | _ | i | k | l
 v2in|           a | b | c | d | e | x | g |___| i | k | l
 v2an|           a | b | c | d | e | x | g ____| i | k | l
 v2An|           a | b | c | d | e | x | g ______i | k | l
-v2IN|           a | b | c | d | e | x | g | h | i | _ | l
-v2iN|           a | b | c | d | e | x | g | h | i |___| l
-v2aN|           a | b | c | d | e | x | g | h | i ____| l
-v2AN|           a | b | c | d | e | x | g | h | i ______l
 a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l
-cIL\            a \ b \ c \ _ \ e \ x \ g \ h \ i \ k \ l
-ciL\            a \ b \ c \_\ e \ x \ g \ h \ i \ k \ l
-caL\            a \ b \ c _\ e \ x \ g \ h \ i \ k \ l
-cAL\            a \ b \ c _e \ x \ g \ h \ i \ k \ l
 cIl\            a \ b \ c \ d \ _ \ x \ g \ h \ i \ k \ l
 cil\            a \ b \ c \ d \_\ x \ g \ h \ i \ k \ l
 cal\            a \ b \ c \ d _\ x \ g \ h \ i \ k \ l
@@ -5174,14 +3922,6 @@ cIn\            a \ b \ c \ d \ e \ x \ _ \ h \ i \ k \ l
 cin\            a \ b \ c \ d \ e \ x \_\ h \ i \ k \ l
 can\            a \ b \ c \ d \ e \ x _\ h \ i \ k \ l
 cAn\            a \ b \ c \ d \ e \ x _h \ i \ k \ l
-cIN\            a \ b \ c \ d \ e \ x \ g \ _ \ i \ k \ l
-ciN\            a \ b \ c \ d \ e \ x \ g \_\ i \ k \ l
-caN\            a \ b \ c \ d \ e \ x \ g _\ i \ k \ l
-cAN\            a \ b \ c \ d \ e \ x \ g _i \ k \ l
-c1IL\           a \ b \ c \ _ \ e \ x \ g \ h \ i \ k \ l
-c1iL\           a \ b \ c \_\ e \ x \ g \ h \ i \ k \ l
-c1aL\           a \ b \ c _\ e \ x \ g \ h \ i \ k \ l
-c1AL\           a \ b \ c _e \ x \ g \ h \ i \ k \ l
 c1Il\           a \ b \ c \ d \ _ \ x \ g \ h \ i \ k \ l
 c1il\           a \ b \ c \ d \_\ x \ g \ h \ i \ k \ l
 c1al\           a \ b \ c \ d _\ x \ g \ h \ i \ k \ l
@@ -5194,14 +3934,6 @@ c1In\           a \ b \ c \ d \ e \ x \ _ \ h \ i \ k \ l
 c1in\           a \ b \ c \ d \ e \ x \_\ h \ i \ k \ l
 c1an\           a \ b \ c \ d \ e \ x _\ h \ i \ k \ l
 c1An\           a \ b \ c \ d \ e \ x _h \ i \ k \ l
-c1IN\           a \ b \ c \ d \ e \ x \ g \ _ \ i \ k \ l
-c1iN\           a \ b \ c \ d \ e \ x \ g \_\ i \ k \ l
-c1aN\           a \ b \ c \ d \ e \ x \ g _\ i \ k \ l
-c1AN\           a \ b \ c \ d \ e \ x \ g _i \ k \ l
-c2IL\           a \ _ \ c \ d \ e \ x \ g \ h \ i \ k \ l
-c2iL\           a \_\ c \ d \ e \ x \ g \ h \ i \ k \ l
-c2aL\           a _\ c \ d \ e \ x \ g \ h \ i \ k \ l
-c2AL\           a _c \ d \ e \ x \ g \ h \ i \ k \ l
 c2Il\           a \ b \ c \ _ \ e \ x \ g \ h \ i \ k \ l
 c2il\           a \ b \ c \_\ e \ x \ g \ h \ i \ k \ l
 c2al\           a \ b \ c _\ e \ x \ g \ h \ i \ k \ l
@@ -5214,14 +3946,6 @@ c2In\           a \ b \ c \ d \ e \ x \ g \ _ \ i \ k \ l
 c2in\           a \ b \ c \ d \ e \ x \ g \_\ i \ k \ l
 c2an\           a \ b \ c \ d \ e \ x \ g _\ i \ k \ l
 c2An\           a \ b \ c \ d \ e \ x \ g _i \ k \ l
-c2IN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ _ \ l
-c2iN\           a \ b \ c \ d \ e \ x \ g \ h \ i \_\ l
-c2aN\           a \ b \ c \ d \ e \ x \ g \ h \ i _\ l
-c2AN\           a \ b \ c \ d \ e \ x \ g \ h \ i _l
-dIL\            a \ b \ c \  \ e \ x \ g \ h \ i \ k \ l
-diL\            a \ b \ c \\ e \ x \ g \ h \ i \ k \ l
-daL\            a \ b \ c \ e \ x \ g \ h \ i \ k \ l
-dAL\            a \ b \ c e \ x \ g \ h \ i \ k \ l
 dIl\            a \ b \ c \ d \  \ x \ g \ h \ i \ k \ l
 dil\            a \ b \ c \ d \\ x \ g \ h \ i \ k \ l
 dal\            a \ b \ c \ d \ x \ g \ h \ i \ k \ l
@@ -5234,14 +3958,6 @@ dIn\            a \ b \ c \ d \ e \ x \  \ h \ i \ k \ l
 din\            a \ b \ c \ d \ e \ x \\ h \ i \ k \ l
 dan\            a \ b \ c \ d \ e \ x \ h \ i \ k \ l
 dAn\            a \ b \ c \ d \ e \ x h \ i \ k \ l
-dIN\            a \ b \ c \ d \ e \ x \ g \  \ i \ k \ l
-diN\            a \ b \ c \ d \ e \ x \ g \\ i \ k \ l
-daN\            a \ b \ c \ d \ e \ x \ g \ i \ k \ l
-dAN\            a \ b \ c \ d \ e \ x \ g i \ k \ l
-d1IL\           a \ b \ c \  \ e \ x \ g \ h \ i \ k \ l
-d1iL\           a \ b \ c \\ e \ x \ g \ h \ i \ k \ l
-d1aL\           a \ b \ c \ e \ x \ g \ h \ i \ k \ l
-d1AL\           a \ b \ c e \ x \ g \ h \ i \ k \ l
 d1Il\           a \ b \ c \ d \  \ x \ g \ h \ i \ k \ l
 d1il\           a \ b \ c \ d \\ x \ g \ h \ i \ k \ l
 d1al\           a \ b \ c \ d \ x \ g \ h \ i \ k \ l
@@ -5254,14 +3970,6 @@ d1In\           a \ b \ c \ d \ e \ x \  \ h \ i \ k \ l
 d1in\           a \ b \ c \ d \ e \ x \\ h \ i \ k \ l
 d1an\           a \ b \ c \ d \ e \ x \ h \ i \ k \ l
 d1An\           a \ b \ c \ d \ e \ x h \ i \ k \ l
-d1IN\           a \ b \ c \ d \ e \ x \ g \  \ i \ k \ l
-d1iN\           a \ b \ c \ d \ e \ x \ g \\ i \ k \ l
-d1aN\           a \ b \ c \ d \ e \ x \ g \ i \ k \ l
-d1AN\           a \ b \ c \ d \ e \ x \ g i \ k \ l
-d2IL\           a \  \ c \ d \ e \ x \ g \ h \ i \ k \ l
-d2iL\           a \\ c \ d \ e \ x \ g \ h \ i \ k \ l
-d2aL\           a \ c \ d \ e \ x \ g \ h \ i \ k \ l
-d2AL\           a c \ d \ e \ x \ g \ h \ i \ k \ l
 d2Il\           a \ b \ c \  \ e \ x \ g \ h \ i \ k \ l
 d2il\           a \ b \ c \\ e \ x \ g \ h \ i \ k \ l
 d2al\           a \ b \ c \ e \ x \ g \ h \ i \ k \ l
@@ -5274,14 +3982,6 @@ d2In\           a \ b \ c \ d \ e \ x \ g \  \ i \ k \ l
 d2in\           a \ b \ c \ d \ e \ x \ g \\ i \ k \ l
 d2an\           a \ b \ c \ d \ e \ x \ g \ i \ k \ l
 d2An\           a \ b \ c \ d \ e \ x \ g i \ k \ l
-d2IN\           a \ b \ c \ d \ e \ x \ g \ h \ i \  \ l
-d2iN\           a \ b \ c \ d \ e \ x \ g \ h \ i \\ l
-d2aN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ l
-d2AN\           a \ b \ c \ d \ e \ x \ g \ h \ i l
-yIL\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'd'
-yiL\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' d '
-yaL\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ d '
-yAL\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ d \ '
 yIl\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'e'
 yil\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' e '
 yal\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ e '
@@ -5294,14 +3994,6 @@ yIn\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'g'
 yin\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' g '
 yan\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ g '
 yAn\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ g \ '
-yIN\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'h'
-yiN\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' h '
-yaN\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ h '
-yAN\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ h \ '
-y1IL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'd'
-y1iL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' d '
-y1aL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ d '
-y1AL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ d \ '
 y1Il\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'e'
 y1il\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' e '
 y1al\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ e '
@@ -5314,14 +4006,6 @@ y1In\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'g'
 y1in\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' g '
 y1an\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ g '
 y1An\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ g \ '
-y1IN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'h'
-y1iN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' h '
-y1aN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ h '
-y1AN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ h \ '
-y2IL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'b'
-y2iL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' b '
-y2aL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ b '
-y2AL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ b \ '
 y2Il\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'd'
 y2il\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' d '
 y2al\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ d '
@@ -5334,14 +4018,6 @@ y2In\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'h'
 y2in\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' h '
 y2an\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ h '
 y2An\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ h \ '
-y2IN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'k'
-y2iN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' k '
-y2aN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ k '
-y2AN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ k \ '
-vIL\            a \ b \ c \ _ \ e \ x \ g \ h \ i \ k \ l
-viL\            a \ b \ c \___\ e \ x \ g \ h \ i \ k \ l
-vaL\            a \ b \ c ____\ e \ x \ g \ h \ i \ k \ l
-vAL\            a \ b \ c ______e \ x \ g \ h \ i \ k \ l
 vIl\            a \ b \ c \ d \ _ \ x \ g \ h \ i \ k \ l
 vil\            a \ b \ c \ d \___\ x \ g \ h \ i \ k \ l
 val\            a \ b \ c \ d ____\ x \ g \ h \ i \ k \ l
@@ -5354,14 +4030,6 @@ vIn\            a \ b \ c \ d \ e \ x \ _ \ h \ i \ k \ l
 vin\            a \ b \ c \ d \ e \ x \___\ h \ i \ k \ l
 van\            a \ b \ c \ d \ e \ x ____\ h \ i \ k \ l
 vAn\            a \ b \ c \ d \ e \ x ______h \ i \ k \ l
-vIN\            a \ b \ c \ d \ e \ x \ g \ _ \ i \ k \ l
-viN\            a \ b \ c \ d \ e \ x \ g \___\ i \ k \ l
-vaN\            a \ b \ c \ d \ e \ x \ g ____\ i \ k \ l
-vAN\            a \ b \ c \ d \ e \ x \ g ______i \ k \ l
-v1IL\           a \ b \ c \ _ \ e \ x \ g \ h \ i \ k \ l
-v1iL\           a \ b \ c \___\ e \ x \ g \ h \ i \ k \ l
-v1aL\           a \ b \ c ____\ e \ x \ g \ h \ i \ k \ l
-v1AL\           a \ b \ c ______e \ x \ g \ h \ i \ k \ l
 v1Il\           a \ b \ c \ d \ _ \ x \ g \ h \ i \ k \ l
 v1il\           a \ b \ c \ d \___\ x \ g \ h \ i \ k \ l
 v1al\           a \ b \ c \ d ____\ x \ g \ h \ i \ k \ l
@@ -5374,14 +4042,6 @@ v1In\           a \ b \ c \ d \ e \ x \ _ \ h \ i \ k \ l
 v1in\           a \ b \ c \ d \ e \ x \___\ h \ i \ k \ l
 v1an\           a \ b \ c \ d \ e \ x ____\ h \ i \ k \ l
 v1An\           a \ b \ c \ d \ e \ x ______h \ i \ k \ l
-v1IN\           a \ b \ c \ d \ e \ x \ g \ _ \ i \ k \ l
-v1iN\           a \ b \ c \ d \ e \ x \ g \___\ i \ k \ l
-v1aN\           a \ b \ c \ d \ e \ x \ g ____\ i \ k \ l
-v1AN\           a \ b \ c \ d \ e \ x \ g ______i \ k \ l
-v2IL\           a \ _ \ c \ d \ e \ x \ g \ h \ i \ k \ l
-v2iL\           a \___\ c \ d \ e \ x \ g \ h \ i \ k \ l
-v2aL\           a ____\ c \ d \ e \ x \ g \ h \ i \ k \ l
-v2AL\           a ______c \ d \ e \ x \ g \ h \ i \ k \ l
 v2Il\           a \ b \ c \ _ \ e \ x \ g \ h \ i \ k \ l
 v2il\           a \ b \ c \___\ e \ x \ g \ h \ i \ k \ l
 v2al\           a \ b \ c ____\ e \ x \ g \ h \ i \ k \ l
@@ -5394,15 +4054,7 @@ v2In\           a \ b \ c \ d \ e \ x \ g \ _ \ i \ k \ l
 v2in\           a \ b \ c \ d \ e \ x \ g \___\ i \ k \ l
 v2an\           a \ b \ c \ d \ e \ x \ g ____\ i \ k \ l
 v2An\           a \ b \ c \ d \ e \ x \ g ______i \ k \ l
-v2IN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ _ \ l
-v2iN\           a \ b \ c \ d \ e \ x \ g \ h \ i \___\ l
-v2aN\           a \ b \ c \ d \ e \ x \ g \ h \ i ____\ l
-v2AN\           a \ b \ c \ d \ e \ x \ g \ h \ i ______l
 a & b & c & d & e & x & g & h & i & k & l
-cIL&            a & b & c & _ & e & x & g & h & i & k & l
-ciL&            a & b & c &_& e & x & g & h & i & k & l
-caL&            a & b & c _& e & x & g & h & i & k & l
-cAL&            a & b & c _e & x & g & h & i & k & l
 cIl&            a & b & c & d & _ & x & g & h & i & k & l
 cil&            a & b & c & d &_& x & g & h & i & k & l
 cal&            a & b & c & d _& x & g & h & i & k & l
@@ -5415,14 +4067,6 @@ cIn&            a & b & c & d & e & x & _ & h & i & k & l
 cin&            a & b & c & d & e & x &_& h & i & k & l
 can&            a & b & c & d & e & x _& h & i & k & l
 cAn&            a & b & c & d & e & x _h & i & k & l
-cIN&            a & b & c & d & e & x & g & _ & i & k & l
-ciN&            a & b & c & d & e & x & g &_& i & k & l
-caN&            a & b & c & d & e & x & g _& i & k & l
-cAN&            a & b & c & d & e & x & g _i & k & l
-c1IL&           a & b & c & _ & e & x & g & h & i & k & l
-c1iL&           a & b & c &_& e & x & g & h & i & k & l
-c1aL&           a & b & c _& e & x & g & h & i & k & l
-c1AL&           a & b & c _e & x & g & h & i & k & l
 c1Il&           a & b & c & d & _ & x & g & h & i & k & l
 c1il&           a & b & c & d &_& x & g & h & i & k & l
 c1al&           a & b & c & d _& x & g & h & i & k & l
@@ -5435,14 +4079,6 @@ c1In&           a & b & c & d & e & x & _ & h & i & k & l
 c1in&           a & b & c & d & e & x &_& h & i & k & l
 c1an&           a & b & c & d & e & x _& h & i & k & l
 c1An&           a & b & c & d & e & x _h & i & k & l
-c1IN&           a & b & c & d & e & x & g & _ & i & k & l
-c1iN&           a & b & c & d & e & x & g &_& i & k & l
-c1aN&           a & b & c & d & e & x & g _& i & k & l
-c1AN&           a & b & c & d & e & x & g _i & k & l
-c2IL&           a & _ & c & d & e & x & g & h & i & k & l
-c2iL&           a &_& c & d & e & x & g & h & i & k & l
-c2aL&           a _& c & d & e & x & g & h & i & k & l
-c2AL&           a _c & d & e & x & g & h & i & k & l
 c2Il&           a & b & c & _ & e & x & g & h & i & k & l
 c2il&           a & b & c &_& e & x & g & h & i & k & l
 c2al&           a & b & c _& e & x & g & h & i & k & l
@@ -5455,14 +4091,6 @@ c2In&           a & b & c & d & e & x & g & _ & i & k & l
 c2in&           a & b & c & d & e & x & g &_& i & k & l
 c2an&           a & b & c & d & e & x & g _& i & k & l
 c2An&           a & b & c & d & e & x & g _i & k & l
-c2IN&           a & b & c & d & e & x & g & h & i & _ & l
-c2iN&           a & b & c & d & e & x & g & h & i &_& l
-c2aN&           a & b & c & d & e & x & g & h & i _& l
-c2AN&           a & b & c & d & e & x & g & h & i _l
-dIL&            a & b & c &  & e & x & g & h & i & k & l
-diL&            a & b & c && e & x & g & h & i & k & l
-daL&            a & b & c & e & x & g & h & i & k & l
-dAL&            a & b & c e & x & g & h & i & k & l
 dIl&            a & b & c & d &  & x & g & h & i & k & l
 dil&            a & b & c & d && x & g & h & i & k & l
 dal&            a & b & c & d & x & g & h & i & k & l
@@ -5475,14 +4103,6 @@ dIn&            a & b & c & d & e & x &  & h & i & k & l
 din&            a & b & c & d & e & x && h & i & k & l
 dan&            a & b & c & d & e & x & h & i & k & l
 dAn&            a & b & c & d & e & x h & i & k & l
-dIN&            a & b & c & d & e & x & g &  & i & k & l
-diN&            a & b & c & d & e & x & g && i & k & l
-daN&            a & b & c & d & e & x & g & i & k & l
-dAN&            a & b & c & d & e & x & g i & k & l
-d1IL&           a & b & c &  & e & x & g & h & i & k & l
-d1iL&           a & b & c && e & x & g & h & i & k & l
-d1aL&           a & b & c & e & x & g & h & i & k & l
-d1AL&           a & b & c e & x & g & h & i & k & l
 d1Il&           a & b & c & d &  & x & g & h & i & k & l
 d1il&           a & b & c & d && x & g & h & i & k & l
 d1al&           a & b & c & d & x & g & h & i & k & l
@@ -5495,14 +4115,6 @@ d1In&           a & b & c & d & e & x &  & h & i & k & l
 d1in&           a & b & c & d & e & x && h & i & k & l
 d1an&           a & b & c & d & e & x & h & i & k & l
 d1An&           a & b & c & d & e & x h & i & k & l
-d1IN&           a & b & c & d & e & x & g &  & i & k & l
-d1iN&           a & b & c & d & e & x & g && i & k & l
-d1aN&           a & b & c & d & e & x & g & i & k & l
-d1AN&           a & b & c & d & e & x & g i & k & l
-d2IL&           a &  & c & d & e & x & g & h & i & k & l
-d2iL&           a && c & d & e & x & g & h & i & k & l
-d2aL&           a & c & d & e & x & g & h & i & k & l
-d2AL&           a c & d & e & x & g & h & i & k & l
 d2Il&           a & b & c &  & e & x & g & h & i & k & l
 d2il&           a & b & c && e & x & g & h & i & k & l
 d2al&           a & b & c & e & x & g & h & i & k & l
@@ -5515,14 +4127,6 @@ d2In&           a & b & c & d & e & x & g &  & i & k & l
 d2in&           a & b & c & d & e & x & g && i & k & l
 d2an&           a & b & c & d & e & x & g & i & k & l
 d2An&           a & b & c & d & e & x & g i & k & l
-d2IN&           a & b & c & d & e & x & g & h & i &  & l
-d2iN&           a & b & c & d & e & x & g & h & i && l
-d2aN&           a & b & c & d & e & x & g & h & i & l
-d2AN&           a & b & c & d & e & x & g & h & i l
-yIL&            a & b & c & d & e & x & g & h & i & k & l       'd'
-yiL&            a & b & c & d & e & x & g & h & i & k & l       ' d '
-yaL&            a & b & c & d & e & x & g & h & i & k & l       '& d '
-yAL&            a & b & c & d & e & x & g & h & i & k & l       '& d & '
 yIl&            a & b & c & d & e & x & g & h & i & k & l       'e'
 yil&            a & b & c & d & e & x & g & h & i & k & l       ' e '
 yal&            a & b & c & d & e & x & g & h & i & k & l       '& e '
@@ -5535,14 +4139,6 @@ yIn&            a & b & c & d & e & x & g & h & i & k & l       'g'
 yin&            a & b & c & d & e & x & g & h & i & k & l       ' g '
 yan&            a & b & c & d & e & x & g & h & i & k & l       '& g '
 yAn&            a & b & c & d & e & x & g & h & i & k & l       '& g & '
-yIN&            a & b & c & d & e & x & g & h & i & k & l       'h'
-yiN&            a & b & c & d & e & x & g & h & i & k & l       ' h '
-yaN&            a & b & c & d & e & x & g & h & i & k & l       '& h '
-yAN&            a & b & c & d & e & x & g & h & i & k & l       '& h & '
-y1IL&           a & b & c & d & e & x & g & h & i & k & l       'd'
-y1iL&           a & b & c & d & e & x & g & h & i & k & l       ' d '
-y1aL&           a & b & c & d & e & x & g & h & i & k & l       '& d '
-y1AL&           a & b & c & d & e & x & g & h & i & k & l       '& d & '
 y1Il&           a & b & c & d & e & x & g & h & i & k & l       'e'
 y1il&           a & b & c & d & e & x & g & h & i & k & l       ' e '
 y1al&           a & b & c & d & e & x & g & h & i & k & l       '& e '
@@ -5555,14 +4151,6 @@ y1In&           a & b & c & d & e & x & g & h & i & k & l       'g'
 y1in&           a & b & c & d & e & x & g & h & i & k & l       ' g '
 y1an&           a & b & c & d & e & x & g & h & i & k & l       '& g '
 y1An&           a & b & c & d & e & x & g & h & i & k & l       '& g & '
-y1IN&           a & b & c & d & e & x & g & h & i & k & l       'h'
-y1iN&           a & b & c & d & e & x & g & h & i & k & l       ' h '
-y1aN&           a & b & c & d & e & x & g & h & i & k & l       '& h '
-y1AN&           a & b & c & d & e & x & g & h & i & k & l       '& h & '
-y2IL&           a & b & c & d & e & x & g & h & i & k & l       'b'
-y2iL&           a & b & c & d & e & x & g & h & i & k & l       ' b '
-y2aL&           a & b & c & d & e & x & g & h & i & k & l       '& b '
-y2AL&           a & b & c & d & e & x & g & h & i & k & l       '& b & '
 y2Il&           a & b & c & d & e & x & g & h & i & k & l       'd'
 y2il&           a & b & c & d & e & x & g & h & i & k & l       ' d '
 y2al&           a & b & c & d & e & x & g & h & i & k & l       '& d '
@@ -5575,14 +4163,6 @@ y2In&           a & b & c & d & e & x & g & h & i & k & l       'h'
 y2in&           a & b & c & d & e & x & g & h & i & k & l       ' h '
 y2an&           a & b & c & d & e & x & g & h & i & k & l       '& h '
 y2An&           a & b & c & d & e & x & g & h & i & k & l       '& h & '
-y2IN&           a & b & c & d & e & x & g & h & i & k & l       'k'
-y2iN&           a & b & c & d & e & x & g & h & i & k & l       ' k '
-y2aN&           a & b & c & d & e & x & g & h & i & k & l       '& k '
-y2AN&           a & b & c & d & e & x & g & h & i & k & l       '& k & '
-vIL&            a & b & c & _ & e & x & g & h & i & k & l
-viL&            a & b & c &___& e & x & g & h & i & k & l
-vaL&            a & b & c ____& e & x & g & h & i & k & l
-vAL&            a & b & c ______e & x & g & h & i & k & l
 vIl&            a & b & c & d & _ & x & g & h & i & k & l
 vil&            a & b & c & d &___& x & g & h & i & k & l
 val&            a & b & c & d ____& x & g & h & i & k & l
@@ -5595,14 +4175,6 @@ vIn&            a & b & c & d & e & x & _ & h & i & k & l
 vin&            a & b & c & d & e & x &___& h & i & k & l
 van&            a & b & c & d & e & x ____& h & i & k & l
 vAn&            a & b & c & d & e & x ______h & i & k & l
-vIN&            a & b & c & d & e & x & g & _ & i & k & l
-viN&            a & b & c & d & e & x & g &___& i & k & l
-vaN&            a & b & c & d & e & x & g ____& i & k & l
-vAN&            a & b & c & d & e & x & g ______i & k & l
-v1IL&           a & b & c & _ & e & x & g & h & i & k & l
-v1iL&           a & b & c &___& e & x & g & h & i & k & l
-v1aL&           a & b & c ____& e & x & g & h & i & k & l
-v1AL&           a & b & c ______e & x & g & h & i & k & l
 v1Il&           a & b & c & d & _ & x & g & h & i & k & l
 v1il&           a & b & c & d &___& x & g & h & i & k & l
 v1al&           a & b & c & d ____& x & g & h & i & k & l
@@ -5615,14 +4187,6 @@ v1In&           a & b & c & d & e & x & _ & h & i & k & l
 v1in&           a & b & c & d & e & x &___& h & i & k & l
 v1an&           a & b & c & d & e & x ____& h & i & k & l
 v1An&           a & b & c & d & e & x ______h & i & k & l
-v1IN&           a & b & c & d & e & x & g & _ & i & k & l
-v1iN&           a & b & c & d & e & x & g &___& i & k & l
-v1aN&           a & b & c & d & e & x & g ____& i & k & l
-v1AN&           a & b & c & d & e & x & g ______i & k & l
-v2IL&           a & _ & c & d & e & x & g & h & i & k & l
-v2iL&           a &___& c & d & e & x & g & h & i & k & l
-v2aL&           a ____& c & d & e & x & g & h & i & k & l
-v2AL&           a ______c & d & e & x & g & h & i & k & l
 v2Il&           a & b & c & _ & e & x & g & h & i & k & l
 v2il&           a & b & c &___& e & x & g & h & i & k & l
 v2al&           a & b & c ____& e & x & g & h & i & k & l
@@ -5635,15 +4199,7 @@ v2In&           a & b & c & d & e & x & g & _ & i & k & l
 v2in&           a & b & c & d & e & x & g &___& i & k & l
 v2an&           a & b & c & d & e & x & g ____& i & k & l
 v2An&           a & b & c & d & e & x & g ______i & k & l
-v2IN&           a & b & c & d & e & x & g & h & i & _ & l
-v2iN&           a & b & c & d & e & x & g & h & i &___& l
-v2aN&           a & b & c & d & e & x & g & h & i ____& l
-v2AN&           a & b & c & d & e & x & g & h & i ______l
 a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l
-cIL$            a $ b $ c $ _ $ e $ x $ g $ h $ i $ k $ l
-ciL$            a $ b $ c $_$ e $ x $ g $ h $ i $ k $ l
-caL$            a $ b $ c _$ e $ x $ g $ h $ i $ k $ l
-cAL$            a $ b $ c _e $ x $ g $ h $ i $ k $ l
 cIl$            a $ b $ c $ d $ _ $ x $ g $ h $ i $ k $ l
 cil$            a $ b $ c $ d $_$ x $ g $ h $ i $ k $ l
 cal$            a $ b $ c $ d _$ x $ g $ h $ i $ k $ l
@@ -5656,14 +4212,6 @@ cIn$            a $ b $ c $ d $ e $ x $ _ $ h $ i $ k $ l
 cin$            a $ b $ c $ d $ e $ x $_$ h $ i $ k $ l
 can$            a $ b $ c $ d $ e $ x _$ h $ i $ k $ l
 cAn$            a $ b $ c $ d $ e $ x _h $ i $ k $ l
-cIN$            a $ b $ c $ d $ e $ x $ g $ _ $ i $ k $ l
-ciN$            a $ b $ c $ d $ e $ x $ g $_$ i $ k $ l
-caN$            a $ b $ c $ d $ e $ x $ g _$ i $ k $ l
-cAN$            a $ b $ c $ d $ e $ x $ g _i $ k $ l
-c1IL$           a $ b $ c $ _ $ e $ x $ g $ h $ i $ k $ l
-c1iL$           a $ b $ c $_$ e $ x $ g $ h $ i $ k $ l
-c1aL$           a $ b $ c _$ e $ x $ g $ h $ i $ k $ l
-c1AL$           a $ b $ c _e $ x $ g $ h $ i $ k $ l
 c1Il$           a $ b $ c $ d $ _ $ x $ g $ h $ i $ k $ l
 c1il$           a $ b $ c $ d $_$ x $ g $ h $ i $ k $ l
 c1al$           a $ b $ c $ d _$ x $ g $ h $ i $ k $ l
@@ -5676,14 +4224,6 @@ c1In$           a $ b $ c $ d $ e $ x $ _ $ h $ i $ k $ l
 c1in$           a $ b $ c $ d $ e $ x $_$ h $ i $ k $ l
 c1an$           a $ b $ c $ d $ e $ x _$ h $ i $ k $ l
 c1An$           a $ b $ c $ d $ e $ x _h $ i $ k $ l
-c1IN$           a $ b $ c $ d $ e $ x $ g $ _ $ i $ k $ l
-c1iN$           a $ b $ c $ d $ e $ x $ g $_$ i $ k $ l
-c1aN$           a $ b $ c $ d $ e $ x $ g _$ i $ k $ l
-c1AN$           a $ b $ c $ d $ e $ x $ g _i $ k $ l
-c2IL$           a $ _ $ c $ d $ e $ x $ g $ h $ i $ k $ l
-c2iL$           a $_$ c $ d $ e $ x $ g $ h $ i $ k $ l
-c2aL$           a _$ c $ d $ e $ x $ g $ h $ i $ k $ l
-c2AL$           a _c $ d $ e $ x $ g $ h $ i $ k $ l
 c2Il$           a $ b $ c $ _ $ e $ x $ g $ h $ i $ k $ l
 c2il$           a $ b $ c $_$ e $ x $ g $ h $ i $ k $ l
 c2al$           a $ b $ c _$ e $ x $ g $ h $ i $ k $ l
@@ -5696,14 +4236,6 @@ c2In$           a $ b $ c $ d $ e $ x $ g $ _ $ i $ k $ l
 c2in$           a $ b $ c $ d $ e $ x $ g $_$ i $ k $ l
 c2an$           a $ b $ c $ d $ e $ x $ g _$ i $ k $ l
 c2An$           a $ b $ c $ d $ e $ x $ g _i $ k $ l
-c2IN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ _ $ l
-c2iN$           a $ b $ c $ d $ e $ x $ g $ h $ i $_$ l
-c2aN$           a $ b $ c $ d $ e $ x $ g $ h $ i _$ l
-c2AN$           a $ b $ c $ d $ e $ x $ g $ h $ i _l
-dIL$            a $ b $ c $  $ e $ x $ g $ h $ i $ k $ l
-diL$            a $ b $ c $$ e $ x $ g $ h $ i $ k $ l
-daL$            a $ b $ c $ e $ x $ g $ h $ i $ k $ l
-dAL$            a $ b $ c e $ x $ g $ h $ i $ k $ l
 dIl$            a $ b $ c $ d $  $ x $ g $ h $ i $ k $ l
 dil$            a $ b $ c $ d $$ x $ g $ h $ i $ k $ l
 dal$            a $ b $ c $ d $ x $ g $ h $ i $ k $ l
@@ -5716,14 +4248,6 @@ dIn$            a $ b $ c $ d $ e $ x $  $ h $ i $ k $ l
 din$            a $ b $ c $ d $ e $ x $$ h $ i $ k $ l
 dan$            a $ b $ c $ d $ e $ x $ h $ i $ k $ l
 dAn$            a $ b $ c $ d $ e $ x h $ i $ k $ l
-dIN$            a $ b $ c $ d $ e $ x $ g $  $ i $ k $ l
-diN$            a $ b $ c $ d $ e $ x $ g $$ i $ k $ l
-daN$            a $ b $ c $ d $ e $ x $ g $ i $ k $ l
-dAN$            a $ b $ c $ d $ e $ x $ g i $ k $ l
-d1IL$           a $ b $ c $  $ e $ x $ g $ h $ i $ k $ l
-d1iL$           a $ b $ c $$ e $ x $ g $ h $ i $ k $ l
-d1aL$           a $ b $ c $ e $ x $ g $ h $ i $ k $ l
-d1AL$           a $ b $ c e $ x $ g $ h $ i $ k $ l
 d1Il$           a $ b $ c $ d $  $ x $ g $ h $ i $ k $ l
 d1il$           a $ b $ c $ d $$ x $ g $ h $ i $ k $ l
 d1al$           a $ b $ c $ d $ x $ g $ h $ i $ k $ l
@@ -5736,14 +4260,6 @@ d1In$           a $ b $ c $ d $ e $ x $  $ h $ i $ k $ l
 d1in$           a $ b $ c $ d $ e $ x $$ h $ i $ k $ l
 d1an$           a $ b $ c $ d $ e $ x $ h $ i $ k $ l
 d1An$           a $ b $ c $ d $ e $ x h $ i $ k $ l
-d1IN$           a $ b $ c $ d $ e $ x $ g $  $ i $ k $ l
-d1iN$           a $ b $ c $ d $ e $ x $ g $$ i $ k $ l
-d1aN$           a $ b $ c $ d $ e $ x $ g $ i $ k $ l
-d1AN$           a $ b $ c $ d $ e $ x $ g i $ k $ l
-d2IL$           a $  $ c $ d $ e $ x $ g $ h $ i $ k $ l
-d2iL$           a $$ c $ d $ e $ x $ g $ h $ i $ k $ l
-d2aL$           a $ c $ d $ e $ x $ g $ h $ i $ k $ l
-d2AL$           a c $ d $ e $ x $ g $ h $ i $ k $ l
 d2Il$           a $ b $ c $  $ e $ x $ g $ h $ i $ k $ l
 d2il$           a $ b $ c $$ e $ x $ g $ h $ i $ k $ l
 d2al$           a $ b $ c $ e $ x $ g $ h $ i $ k $ l
@@ -5756,14 +4272,6 @@ d2In$           a $ b $ c $ d $ e $ x $ g $  $ i $ k $ l
 d2in$           a $ b $ c $ d $ e $ x $ g $$ i $ k $ l
 d2an$           a $ b $ c $ d $ e $ x $ g $ i $ k $ l
 d2An$           a $ b $ c $ d $ e $ x $ g i $ k $ l
-d2IN$           a $ b $ c $ d $ e $ x $ g $ h $ i $  $ l
-d2iN$           a $ b $ c $ d $ e $ x $ g $ h $ i $$ l
-d2aN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ l
-d2AN$           a $ b $ c $ d $ e $ x $ g $ h $ i l
-yIL$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'd'
-yiL$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' d '
-yaL$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ d '
-yAL$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ d $ '
 yIl$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'e'
 yil$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' e '
 yal$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ e '
@@ -5776,14 +4284,6 @@ yIn$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'g'
 yin$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' g '
 yan$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ g '
 yAn$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ g $ '
-yIN$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'h'
-yiN$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' h '
-yaN$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ h '
-yAN$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ h $ '
-y1IL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'd'
-y1iL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' d '
-y1aL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ d '
-y1AL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ d $ '
 y1Il$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'e'
 y1il$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' e '
 y1al$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ e '
@@ -5796,14 +4296,6 @@ y1In$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'g'
 y1in$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' g '
 y1an$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ g '
 y1An$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ g $ '
-y1IN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'h'
-y1iN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' h '
-y1aN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ h '
-y1AN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ h $ '
-y2IL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'b'
-y2iL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' b '
-y2aL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ b '
-y2AL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ b $ '
 y2Il$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'd'
 y2il$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' d '
 y2al$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ d '
@@ -5816,14 +4308,6 @@ y2In$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'h'
 y2in$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' h '
 y2an$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ h '
 y2An$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ h $ '
-y2IN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'k'
-y2iN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' k '
-y2aN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ k '
-y2AN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ k $ '
-vIL$            a $ b $ c $ _ $ e $ x $ g $ h $ i $ k $ l
-viL$            a $ b $ c $___$ e $ x $ g $ h $ i $ k $ l
-vaL$            a $ b $ c ____$ e $ x $ g $ h $ i $ k $ l
-vAL$            a $ b $ c ______e $ x $ g $ h $ i $ k $ l
 vIl$            a $ b $ c $ d $ _ $ x $ g $ h $ i $ k $ l
 vil$            a $ b $ c $ d $___$ x $ g $ h $ i $ k $ l
 val$            a $ b $ c $ d ____$ x $ g $ h $ i $ k $ l
@@ -5836,14 +4320,6 @@ vIn$            a $ b $ c $ d $ e $ x $ _ $ h $ i $ k $ l
 vin$            a $ b $ c $ d $ e $ x $___$ h $ i $ k $ l
 van$            a $ b $ c $ d $ e $ x ____$ h $ i $ k $ l
 vAn$            a $ b $ c $ d $ e $ x ______h $ i $ k $ l
-vIN$            a $ b $ c $ d $ e $ x $ g $ _ $ i $ k $ l
-viN$            a $ b $ c $ d $ e $ x $ g $___$ i $ k $ l
-vaN$            a $ b $ c $ d $ e $ x $ g ____$ i $ k $ l
-vAN$            a $ b $ c $ d $ e $ x $ g ______i $ k $ l
-v1IL$           a $ b $ c $ _ $ e $ x $ g $ h $ i $ k $ l
-v1iL$           a $ b $ c $___$ e $ x $ g $ h $ i $ k $ l
-v1aL$           a $ b $ c ____$ e $ x $ g $ h $ i $ k $ l
-v1AL$           a $ b $ c ______e $ x $ g $ h $ i $ k $ l
 v1Il$           a $ b $ c $ d $ _ $ x $ g $ h $ i $ k $ l
 v1il$           a $ b $ c $ d $___$ x $ g $ h $ i $ k $ l
 v1al$           a $ b $ c $ d ____$ x $ g $ h $ i $ k $ l
@@ -5856,14 +4332,6 @@ v1In$           a $ b $ c $ d $ e $ x $ _ $ h $ i $ k $ l
 v1in$           a $ b $ c $ d $ e $ x $___$ h $ i $ k $ l
 v1an$           a $ b $ c $ d $ e $ x ____$ h $ i $ k $ l
 v1An$           a $ b $ c $ d $ e $ x ______h $ i $ k $ l
-v1IN$           a $ b $ c $ d $ e $ x $ g $ _ $ i $ k $ l
-v1iN$           a $ b $ c $ d $ e $ x $ g $___$ i $ k $ l
-v1aN$           a $ b $ c $ d $ e $ x $ g ____$ i $ k $ l
-v1AN$           a $ b $ c $ d $ e $ x $ g ______i $ k $ l
-v2IL$           a $ _ $ c $ d $ e $ x $ g $ h $ i $ k $ l
-v2iL$           a $___$ c $ d $ e $ x $ g $ h $ i $ k $ l
-v2aL$           a ____$ c $ d $ e $ x $ g $ h $ i $ k $ l
-v2AL$           a ______c $ d $ e $ x $ g $ h $ i $ k $ l
 v2Il$           a $ b $ c $ _ $ e $ x $ g $ h $ i $ k $ l
 v2il$           a $ b $ c $___$ e $ x $ g $ h $ i $ k $ l
 v2al$           a $ b $ c ____$ e $ x $ g $ h $ i $ k $ l
@@ -5876,10 +4344,6 @@ v2In$           a $ b $ c $ d $ e $ x $ g $ _ $ i $ k $ l
 v2in$           a $ b $ c $ d $ e $ x $ g $___$ i $ k $ l
 v2an$           a $ b $ c $ d $ e $ x $ g ____$ i $ k $ l
 v2An$           a $ b $ c $ d $ e $ x $ g ______i $ k $ l
-v2IN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ _ $ l
-v2iN$           a $ b $ c $ d $ e $ x $ g $ h $ i $___$ l
-v2aN$           a $ b $ c $ d $ e $ x $ g $ h $ i ____$ l
-v2AN$           a $ b $ c $ d $ e $ x $ g $ h $ i ______l
 
 a ( b , c ( d ) , d ( x , e ) , f ) g
 cIla            a ( b , _ , d ( x , e ) , f ) g

--- a/test/test1.out
+++ b/test/test1.out
@@ -2025,10 +2025,6 @@ v2an`           a ` b ` c ` d ` e ` x ` g ` h ` i _____ l
 v2An`           a ` b ` c ` d ` e ` x ` g ` h ` i ______l
 
 a , b , c , d , e , x , g , h , i , k , l
-cIL,            a , b , c , _ , e , x , g , h , i , k , l
-ciL,            a , b , c ,_, e , x , g , h , i , k , l
-caL,            a , b , c _, e , x , g , h , i , k , l
-cAL,            a , b , c _e , x , g , h , i , k , l
 cIl,            a , b , c , d , _ , x , g , h , i , k , l
 cil,            a , b , c , d ,_, x , g , h , i , k , l
 cal,            a , b , c , d _, x , g , h , i , k , l
@@ -2041,14 +2037,6 @@ cIn,            a , b , c , d , e , x , _ , h , i , k , l
 cin,            a , b , c , d , e , x ,_, h , i , k , l
 can,            a , b , c , d , e , x _, h , i , k , l
 cAn,            a , b , c , d , e , x _h , i , k , l
-cIN,            a , b , c , d , e , x , g , _ , i , k , l
-ciN,            a , b , c , d , e , x , g ,_, i , k , l
-caN,            a , b , c , d , e , x , g _, i , k , l
-cAN,            a , b , c , d , e , x , g _i , k , l
-c1IL,           a , b , c , _ , e , x , g , h , i , k , l
-c1iL,           a , b , c ,_, e , x , g , h , i , k , l
-c1aL,           a , b , c _, e , x , g , h , i , k , l
-c1AL,           a , b , c _e , x , g , h , i , k , l
 c1Il,           a , b , c , d , _ , x , g , h , i , k , l
 c1il,           a , b , c , d ,_, x , g , h , i , k , l
 c1al,           a , b , c , d _, x , g , h , i , k , l
@@ -2061,14 +2049,6 @@ c1In,           a , b , c , d , e , x , _ , h , i , k , l
 c1in,           a , b , c , d , e , x ,_, h , i , k , l
 c1an,           a , b , c , d , e , x _, h , i , k , l
 c1An,           a , b , c , d , e , x _h , i , k , l
-c1IN,           a , b , c , d , e , x , g , _ , i , k , l
-c1iN,           a , b , c , d , e , x , g ,_, i , k , l
-c1aN,           a , b , c , d , e , x , g _, i , k , l
-c1AN,           a , b , c , d , e , x , g _i , k , l
-c2IL,           a , _ , c , d , e , x , g , h , i , k , l
-c2iL,           a ,_, c , d , e , x , g , h , i , k , l
-c2aL,           a _, c , d , e , x , g , h , i , k , l
-c2AL,           a _c , d , e , x , g , h , i , k , l
 c2Il,           a , b , c , _ , e , x , g , h , i , k , l
 c2il,           a , b , c ,_, e , x , g , h , i , k , l
 c2al,           a , b , c _, e , x , g , h , i , k , l
@@ -2081,14 +2061,6 @@ c2In,           a , b , c , d , e , x , g , _ , i , k , l
 c2in,           a , b , c , d , e , x , g ,_, i , k , l
 c2an,           a , b , c , d , e , x , g _, i , k , l
 c2An,           a , b , c , d , e , x , g _i , k , l
-c2IN,           a , b , c , d , e , x , g , h , i , _ , l
-c2iN,           a , b , c , d , e , x , g , h , i ,_, l
-c2aN,           a , b , c , d , e , x , g , h , i _, l
-c2AN,           a , b , c , d , e , x , g , h , i _l
-dIL,            a , b , c ,  , e , x , g , h , i , k , l
-diL,            a , b , c ,, e , x , g , h , i , k , l
-daL,            a , b , c , e , x , g , h , i , k , l
-dAL,            a , b , c e , x , g , h , i , k , l
 dIl,            a , b , c , d ,  , x , g , h , i , k , l
 dil,            a , b , c , d ,, x , g , h , i , k , l
 dal,            a , b , c , d , x , g , h , i , k , l
@@ -2101,14 +2073,6 @@ dIn,            a , b , c , d , e , x ,  , h , i , k , l
 din,            a , b , c , d , e , x ,, h , i , k , l
 dan,            a , b , c , d , e , x , h , i , k , l
 dAn,            a , b , c , d , e , x h , i , k , l
-dIN,            a , b , c , d , e , x , g ,  , i , k , l
-diN,            a , b , c , d , e , x , g ,, i , k , l
-daN,            a , b , c , d , e , x , g , i , k , l
-dAN,            a , b , c , d , e , x , g i , k , l
-d1IL,           a , b , c ,  , e , x , g , h , i , k , l
-d1iL,           a , b , c ,, e , x , g , h , i , k , l
-d1aL,           a , b , c , e , x , g , h , i , k , l
-d1AL,           a , b , c e , x , g , h , i , k , l
 d1Il,           a , b , c , d ,  , x , g , h , i , k , l
 d1il,           a , b , c , d ,, x , g , h , i , k , l
 d1al,           a , b , c , d , x , g , h , i , k , l
@@ -2121,14 +2085,6 @@ d1In,           a , b , c , d , e , x ,  , h , i , k , l
 d1in,           a , b , c , d , e , x ,, h , i , k , l
 d1an,           a , b , c , d , e , x , h , i , k , l
 d1An,           a , b , c , d , e , x h , i , k , l
-d1IN,           a , b , c , d , e , x , g ,  , i , k , l
-d1iN,           a , b , c , d , e , x , g ,, i , k , l
-d1aN,           a , b , c , d , e , x , g , i , k , l
-d1AN,           a , b , c , d , e , x , g i , k , l
-d2IL,           a ,  , c , d , e , x , g , h , i , k , l
-d2iL,           a ,, c , d , e , x , g , h , i , k , l
-d2aL,           a , c , d , e , x , g , h , i , k , l
-d2AL,           a c , d , e , x , g , h , i , k , l
 d2Il,           a , b , c ,  , e , x , g , h , i , k , l
 d2il,           a , b , c ,, e , x , g , h , i , k , l
 d2al,           a , b , c , e , x , g , h , i , k , l
@@ -2141,14 +2097,6 @@ d2In,           a , b , c , d , e , x , g ,  , i , k , l
 d2in,           a , b , c , d , e , x , g ,, i , k , l
 d2an,           a , b , c , d , e , x , g , i , k , l
 d2An,           a , b , c , d , e , x , g i , k , l
-d2IN,           a , b , c , d , e , x , g , h , i ,  , l
-d2iN,           a , b , c , d , e , x , g , h , i ,, l
-d2aN,           a , b , c , d , e , x , g , h , i , l
-d2AN,           a , b , c , d , e , x , g , h , i l
-yIL,            a , b , c , d , e , x , g , h , i , k , l       'd'
-yiL,            a , b , c , d , e , x , g , h , i , k , l       ' d '
-yaL,            a , b , c , d , e , x , g , h , i , k , l       ', d '
-yAL,            a , b , c , d , e , x , g , h , i , k , l       ', d , '
 yIl,            a , b , c , d , e , x , g , h , i , k , l       'e'
 yil,            a , b , c , d , e , x , g , h , i , k , l       ' e '
 yal,            a , b , c , d , e , x , g , h , i , k , l       ', e '
@@ -2161,14 +2109,6 @@ yIn,            a , b , c , d , e , x , g , h , i , k , l       'g'
 yin,            a , b , c , d , e , x , g , h , i , k , l       ' g '
 yan,            a , b , c , d , e , x , g , h , i , k , l       ', g '
 yAn,            a , b , c , d , e , x , g , h , i , k , l       ', g , '
-yIN,            a , b , c , d , e , x , g , h , i , k , l       'h'
-yiN,            a , b , c , d , e , x , g , h , i , k , l       ' h '
-yaN,            a , b , c , d , e , x , g , h , i , k , l       ', h '
-yAN,            a , b , c , d , e , x , g , h , i , k , l       ', h , '
-y1IL,           a , b , c , d , e , x , g , h , i , k , l       'd'
-y1iL,           a , b , c , d , e , x , g , h , i , k , l       ' d '
-y1aL,           a , b , c , d , e , x , g , h , i , k , l       ', d '
-y1AL,           a , b , c , d , e , x , g , h , i , k , l       ', d , '
 y1Il,           a , b , c , d , e , x , g , h , i , k , l       'e'
 y1il,           a , b , c , d , e , x , g , h , i , k , l       ' e '
 y1al,           a , b , c , d , e , x , g , h , i , k , l       ', e '
@@ -2181,14 +2121,6 @@ y1In,           a , b , c , d , e , x , g , h , i , k , l       'g'
 y1in,           a , b , c , d , e , x , g , h , i , k , l       ' g '
 y1an,           a , b , c , d , e , x , g , h , i , k , l       ', g '
 y1An,           a , b , c , d , e , x , g , h , i , k , l       ', g , '
-y1IN,           a , b , c , d , e , x , g , h , i , k , l       'h'
-y1iN,           a , b , c , d , e , x , g , h , i , k , l       ' h '
-y1aN,           a , b , c , d , e , x , g , h , i , k , l       ', h '
-y1AN,           a , b , c , d , e , x , g , h , i , k , l       ', h , '
-y2IL,           a , b , c , d , e , x , g , h , i , k , l       'b'
-y2iL,           a , b , c , d , e , x , g , h , i , k , l       ' b '
-y2aL,           a , b , c , d , e , x , g , h , i , k , l       ', b '
-y2AL,           a , b , c , d , e , x , g , h , i , k , l       ', b , '
 y2Il,           a , b , c , d , e , x , g , h , i , k , l       'd'
 y2il,           a , b , c , d , e , x , g , h , i , k , l       ' d '
 y2al,           a , b , c , d , e , x , g , h , i , k , l       ', d '
@@ -2201,14 +2133,6 @@ y2In,           a , b , c , d , e , x , g , h , i , k , l       'h'
 y2in,           a , b , c , d , e , x , g , h , i , k , l       ' h '
 y2an,           a , b , c , d , e , x , g , h , i , k , l       ', h '
 y2An,           a , b , c , d , e , x , g , h , i , k , l       ', h , '
-y2IN,           a , b , c , d , e , x , g , h , i , k , l       'k'
-y2iN,           a , b , c , d , e , x , g , h , i , k , l       ' k '
-y2aN,           a , b , c , d , e , x , g , h , i , k , l       ', k '
-y2AN,           a , b , c , d , e , x , g , h , i , k , l       ', k , '
-vIL,            a , b , c , _ , e , x , g , h , i , k , l
-viL,            a , b , c ,___, e , x , g , h , i , k , l
-vaL,            a , b , c ____, e , x , g , h , i , k , l
-vAL,            a , b , c ______e , x , g , h , i , k , l
 vIl,            a , b , c , d , _ , x , g , h , i , k , l
 vil,            a , b , c , d ,___, x , g , h , i , k , l
 val,            a , b , c , d ____, x , g , h , i , k , l
@@ -2221,14 +2145,6 @@ vIn,            a , b , c , d , e , x , _ , h , i , k , l
 vin,            a , b , c , d , e , x ,___, h , i , k , l
 van,            a , b , c , d , e , x ____, h , i , k , l
 vAn,            a , b , c , d , e , x ______h , i , k , l
-vIN,            a , b , c , d , e , x , g , _ , i , k , l
-viN,            a , b , c , d , e , x , g ,___, i , k , l
-vaN,            a , b , c , d , e , x , g ____, i , k , l
-vAN,            a , b , c , d , e , x , g ______i , k , l
-v1IL,           a , b , c , _ , e , x , g , h , i , k , l
-v1iL,           a , b , c ,___, e , x , g , h , i , k , l
-v1aL,           a , b , c ____, e , x , g , h , i , k , l
-v1AL,           a , b , c ______e , x , g , h , i , k , l
 v1Il,           a , b , c , d , _ , x , g , h , i , k , l
 v1il,           a , b , c , d ,___, x , g , h , i , k , l
 v1al,           a , b , c , d ____, x , g , h , i , k , l
@@ -2241,14 +2157,6 @@ v1In,           a , b , c , d , e , x , _ , h , i , k , l
 v1in,           a , b , c , d , e , x ,___, h , i , k , l
 v1an,           a , b , c , d , e , x ____, h , i , k , l
 v1An,           a , b , c , d , e , x ______h , i , k , l
-v1IN,           a , b , c , d , e , x , g , _ , i , k , l
-v1iN,           a , b , c , d , e , x , g ,___, i , k , l
-v1aN,           a , b , c , d , e , x , g ____, i , k , l
-v1AN,           a , b , c , d , e , x , g ______i , k , l
-v2IL,           a , _ , c , d , e , x , g , h , i , k , l
-v2iL,           a ,___, c , d , e , x , g , h , i , k , l
-v2aL,           a ____, c , d , e , x , g , h , i , k , l
-v2AL,           a ______c , d , e , x , g , h , i , k , l
 v2Il,           a , b , c , _ , e , x , g , h , i , k , l
 v2il,           a , b , c ,___, e , x , g , h , i , k , l
 v2al,           a , b , c ____, e , x , g , h , i , k , l
@@ -2261,15 +2169,7 @@ v2In,           a , b , c , d , e , x , g , _ , i , k , l
 v2in,           a , b , c , d , e , x , g ,___, i , k , l
 v2an,           a , b , c , d , e , x , g ____, i , k , l
 v2An,           a , b , c , d , e , x , g ______i , k , l
-v2IN,           a , b , c , d , e , x , g , h , i , _ , l
-v2iN,           a , b , c , d , e , x , g , h , i ,___, l
-v2aN,           a , b , c , d , e , x , g , h , i ____, l
-v2AN,           a , b , c , d , e , x , g , h , i ______l
 a . b . c . d . e . x . g . h . i . k . l
-cIL.            a . b . c . _ . e . x . g . h . i . k . l
-ciL.            a . b . c ._. e . x . g . h . i . k . l
-caL.            a . b . c _. e . x . g . h . i . k . l
-cAL.            a . b . c _e . x . g . h . i . k . l
 cIl.            a . b . c . d . _ . x . g . h . i . k . l
 cil.            a . b . c . d ._. x . g . h . i . k . l
 cal.            a . b . c . d _. x . g . h . i . k . l
@@ -2282,14 +2182,6 @@ cIn.            a . b . c . d . e . x . _ . h . i . k . l
 cin.            a . b . c . d . e . x ._. h . i . k . l
 can.            a . b . c . d . e . x _. h . i . k . l
 cAn.            a . b . c . d . e . x _h . i . k . l
-cIN.            a . b . c . d . e . x . g . _ . i . k . l
-ciN.            a . b . c . d . e . x . g ._. i . k . l
-caN.            a . b . c . d . e . x . g _. i . k . l
-cAN.            a . b . c . d . e . x . g _i . k . l
-c1IL.           a . b . c . _ . e . x . g . h . i . k . l
-c1iL.           a . b . c ._. e . x . g . h . i . k . l
-c1aL.           a . b . c _. e . x . g . h . i . k . l
-c1AL.           a . b . c _e . x . g . h . i . k . l
 c1Il.           a . b . c . d . _ . x . g . h . i . k . l
 c1il.           a . b . c . d ._. x . g . h . i . k . l
 c1al.           a . b . c . d _. x . g . h . i . k . l
@@ -2302,14 +2194,6 @@ c1In.           a . b . c . d . e . x . _ . h . i . k . l
 c1in.           a . b . c . d . e . x ._. h . i . k . l
 c1an.           a . b . c . d . e . x _. h . i . k . l
 c1An.           a . b . c . d . e . x _h . i . k . l
-c1IN.           a . b . c . d . e . x . g . _ . i . k . l
-c1iN.           a . b . c . d . e . x . g ._. i . k . l
-c1aN.           a . b . c . d . e . x . g _. i . k . l
-c1AN.           a . b . c . d . e . x . g _i . k . l
-c2IL.           a . _ . c . d . e . x . g . h . i . k . l
-c2iL.           a ._. c . d . e . x . g . h . i . k . l
-c2aL.           a _. c . d . e . x . g . h . i . k . l
-c2AL.           a _c . d . e . x . g . h . i . k . l
 c2Il.           a . b . c . _ . e . x . g . h . i . k . l
 c2il.           a . b . c ._. e . x . g . h . i . k . l
 c2al.           a . b . c _. e . x . g . h . i . k . l
@@ -2322,14 +2206,6 @@ c2In.           a . b . c . d . e . x . g . _ . i . k . l
 c2in.           a . b . c . d . e . x . g ._. i . k . l
 c2an.           a . b . c . d . e . x . g _. i . k . l
 c2An.           a . b . c . d . e . x . g _i . k . l
-c2IN.           a . b . c . d . e . x . g . h . i . _ . l
-c2iN.           a . b . c . d . e . x . g . h . i ._. l
-c2aN.           a . b . c . d . e . x . g . h . i _. l
-c2AN.           a . b . c . d . e . x . g . h . i _l
-dIL.            a . b . c .  . e . x . g . h . i . k . l
-diL.            a . b . c .. e . x . g . h . i . k . l
-daL.            a . b . c . e . x . g . h . i . k . l
-dAL.            a . b . c e . x . g . h . i . k . l
 dIl.            a . b . c . d .  . x . g . h . i . k . l
 dil.            a . b . c . d .. x . g . h . i . k . l
 dal.            a . b . c . d . x . g . h . i . k . l
@@ -2342,14 +2218,6 @@ dIn.            a . b . c . d . e . x .  . h . i . k . l
 din.            a . b . c . d . e . x .. h . i . k . l
 dan.            a . b . c . d . e . x . h . i . k . l
 dAn.            a . b . c . d . e . x h . i . k . l
-dIN.            a . b . c . d . e . x . g .  . i . k . l
-diN.            a . b . c . d . e . x . g .. i . k . l
-daN.            a . b . c . d . e . x . g . i . k . l
-dAN.            a . b . c . d . e . x . g i . k . l
-d1IL.           a . b . c .  . e . x . g . h . i . k . l
-d1iL.           a . b . c .. e . x . g . h . i . k . l
-d1aL.           a . b . c . e . x . g . h . i . k . l
-d1AL.           a . b . c e . x . g . h . i . k . l
 d1Il.           a . b . c . d .  . x . g . h . i . k . l
 d1il.           a . b . c . d .. x . g . h . i . k . l
 d1al.           a . b . c . d . x . g . h . i . k . l
@@ -2362,14 +2230,6 @@ d1In.           a . b . c . d . e . x .  . h . i . k . l
 d1in.           a . b . c . d . e . x .. h . i . k . l
 d1an.           a . b . c . d . e . x . h . i . k . l
 d1An.           a . b . c . d . e . x h . i . k . l
-d1IN.           a . b . c . d . e . x . g .  . i . k . l
-d1iN.           a . b . c . d . e . x . g .. i . k . l
-d1aN.           a . b . c . d . e . x . g . i . k . l
-d1AN.           a . b . c . d . e . x . g i . k . l
-d2IL.           a .  . c . d . e . x . g . h . i . k . l
-d2iL.           a .. c . d . e . x . g . h . i . k . l
-d2aL.           a . c . d . e . x . g . h . i . k . l
-d2AL.           a c . d . e . x . g . h . i . k . l
 d2Il.           a . b . c .  . e . x . g . h . i . k . l
 d2il.           a . b . c .. e . x . g . h . i . k . l
 d2al.           a . b . c . e . x . g . h . i . k . l
@@ -2382,14 +2242,6 @@ d2In.           a . b . c . d . e . x . g .  . i . k . l
 d2in.           a . b . c . d . e . x . g .. i . k . l
 d2an.           a . b . c . d . e . x . g . i . k . l
 d2An.           a . b . c . d . e . x . g i . k . l
-d2IN.           a . b . c . d . e . x . g . h . i .  . l
-d2iN.           a . b . c . d . e . x . g . h . i .. l
-d2aN.           a . b . c . d . e . x . g . h . i . l
-d2AN.           a . b . c . d . e . x . g . h . i l
-yIL.            a . b . c . d . e . x . g . h . i . k . l       'd'
-yiL.            a . b . c . d . e . x . g . h . i . k . l       ' d '
-yaL.            a . b . c . d . e . x . g . h . i . k . l       '. d '
-yAL.            a . b . c . d . e . x . g . h . i . k . l       '. d . '
 yIl.            a . b . c . d . e . x . g . h . i . k . l       'e'
 yil.            a . b . c . d . e . x . g . h . i . k . l       ' e '
 yal.            a . b . c . d . e . x . g . h . i . k . l       '. e '
@@ -2402,14 +2254,6 @@ yIn.            a . b . c . d . e . x . g . h . i . k . l       'g'
 yin.            a . b . c . d . e . x . g . h . i . k . l       ' g '
 yan.            a . b . c . d . e . x . g . h . i . k . l       '. g '
 yAn.            a . b . c . d . e . x . g . h . i . k . l       '. g . '
-yIN.            a . b . c . d . e . x . g . h . i . k . l       'h'
-yiN.            a . b . c . d . e . x . g . h . i . k . l       ' h '
-yaN.            a . b . c . d . e . x . g . h . i . k . l       '. h '
-yAN.            a . b . c . d . e . x . g . h . i . k . l       '. h . '
-y1IL.           a . b . c . d . e . x . g . h . i . k . l       'd'
-y1iL.           a . b . c . d . e . x . g . h . i . k . l       ' d '
-y1aL.           a . b . c . d . e . x . g . h . i . k . l       '. d '
-y1AL.           a . b . c . d . e . x . g . h . i . k . l       '. d . '
 y1Il.           a . b . c . d . e . x . g . h . i . k . l       'e'
 y1il.           a . b . c . d . e . x . g . h . i . k . l       ' e '
 y1al.           a . b . c . d . e . x . g . h . i . k . l       '. e '
@@ -2422,14 +2266,6 @@ y1In.           a . b . c . d . e . x . g . h . i . k . l       'g'
 y1in.           a . b . c . d . e . x . g . h . i . k . l       ' g '
 y1an.           a . b . c . d . e . x . g . h . i . k . l       '. g '
 y1An.           a . b . c . d . e . x . g . h . i . k . l       '. g . '
-y1IN.           a . b . c . d . e . x . g . h . i . k . l       'h'
-y1iN.           a . b . c . d . e . x . g . h . i . k . l       ' h '
-y1aN.           a . b . c . d . e . x . g . h . i . k . l       '. h '
-y1AN.           a . b . c . d . e . x . g . h . i . k . l       '. h . '
-y2IL.           a . b . c . d . e . x . g . h . i . k . l       'b'
-y2iL.           a . b . c . d . e . x . g . h . i . k . l       ' b '
-y2aL.           a . b . c . d . e . x . g . h . i . k . l       '. b '
-y2AL.           a . b . c . d . e . x . g . h . i . k . l       '. b . '
 y2Il.           a . b . c . d . e . x . g . h . i . k . l       'd'
 y2il.           a . b . c . d . e . x . g . h . i . k . l       ' d '
 y2al.           a . b . c . d . e . x . g . h . i . k . l       '. d '
@@ -2442,14 +2278,6 @@ y2In.           a . b . c . d . e . x . g . h . i . k . l       'h'
 y2in.           a . b . c . d . e . x . g . h . i . k . l       ' h '
 y2an.           a . b . c . d . e . x . g . h . i . k . l       '. h '
 y2An.           a . b . c . d . e . x . g . h . i . k . l       '. h . '
-y2IN.           a . b . c . d . e . x . g . h . i . k . l       'k'
-y2iN.           a . b . c . d . e . x . g . h . i . k . l       ' k '
-y2aN.           a . b . c . d . e . x . g . h . i . k . l       '. k '
-y2AN.           a . b . c . d . e . x . g . h . i . k . l       '. k . '
-vIL.            a . b . c . _ . e . x . g . h . i . k . l
-viL.            a . b . c .___. e . x . g . h . i . k . l
-vaL.            a . b . c ____. e . x . g . h . i . k . l
-vAL.            a . b . c ______e . x . g . h . i . k . l
 vIl.            a . b . c . d . _ . x . g . h . i . k . l
 vil.            a . b . c . d .___. x . g . h . i . k . l
 val.            a . b . c . d ____. x . g . h . i . k . l
@@ -2462,14 +2290,6 @@ vIn.            a . b . c . d . e . x . _ . h . i . k . l
 vin.            a . b . c . d . e . x .___. h . i . k . l
 van.            a . b . c . d . e . x ____. h . i . k . l
 vAn.            a . b . c . d . e . x ______h . i . k . l
-vIN.            a . b . c . d . e . x . g . _ . i . k . l
-viN.            a . b . c . d . e . x . g .___. i . k . l
-vaN.            a . b . c . d . e . x . g ____. i . k . l
-vAN.            a . b . c . d . e . x . g ______i . k . l
-v1IL.           a . b . c . _ . e . x . g . h . i . k . l
-v1iL.           a . b . c .___. e . x . g . h . i . k . l
-v1aL.           a . b . c ____. e . x . g . h . i . k . l
-v1AL.           a . b . c ______e . x . g . h . i . k . l
 v1Il.           a . b . c . d . _ . x . g . h . i . k . l
 v1il.           a . b . c . d .___. x . g . h . i . k . l
 v1al.           a . b . c . d ____. x . g . h . i . k . l
@@ -2482,14 +2302,6 @@ v1In.           a . b . c . d . e . x . _ . h . i . k . l
 v1in.           a . b . c . d . e . x .___. h . i . k . l
 v1an.           a . b . c . d . e . x ____. h . i . k . l
 v1An.           a . b . c . d . e . x ______h . i . k . l
-v1IN.           a . b . c . d . e . x . g . _ . i . k . l
-v1iN.           a . b . c . d . e . x . g .___. i . k . l
-v1aN.           a . b . c . d . e . x . g ____. i . k . l
-v1AN.           a . b . c . d . e . x . g ______i . k . l
-v2IL.           a . _ . c . d . e . x . g . h . i . k . l
-v2iL.           a .___. c . d . e . x . g . h . i . k . l
-v2aL.           a ____. c . d . e . x . g . h . i . k . l
-v2AL.           a ______c . d . e . x . g . h . i . k . l
 v2Il.           a . b . c . _ . e . x . g . h . i . k . l
 v2il.           a . b . c .___. e . x . g . h . i . k . l
 v2al.           a . b . c ____. e . x . g . h . i . k . l
@@ -2502,15 +2314,7 @@ v2In.           a . b . c . d . e . x . g . _ . i . k . l
 v2in.           a . b . c . d . e . x . g .___. i . k . l
 v2an.           a . b . c . d . e . x . g ____. i . k . l
 v2An.           a . b . c . d . e . x . g ______i . k . l
-v2IN.           a . b . c . d . e . x . g . h . i . _ . l
-v2iN.           a . b . c . d . e . x . g . h . i .___. l
-v2aN.           a . b . c . d . e . x . g . h . i ____. l
-v2AN.           a . b . c . d . e . x . g . h . i ______l
 a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l
-cIL;            a ; b ; c ; _ ; e ; x ; g ; h ; i ; k ; l
-ciL;            a ; b ; c ;_; e ; x ; g ; h ; i ; k ; l
-caL;            a ; b ; c _; e ; x ; g ; h ; i ; k ; l
-cAL;            a ; b ; c _e ; x ; g ; h ; i ; k ; l
 cIl;            a ; b ; c ; d ; _ ; x ; g ; h ; i ; k ; l
 cil;            a ; b ; c ; d ;_; x ; g ; h ; i ; k ; l
 cal;            a ; b ; c ; d _; x ; g ; h ; i ; k ; l
@@ -2523,14 +2327,6 @@ cIn;            a ; b ; c ; d ; e ; x ; _ ; h ; i ; k ; l
 cin;            a ; b ; c ; d ; e ; x ;_; h ; i ; k ; l
 can;            a ; b ; c ; d ; e ; x _; h ; i ; k ; l
 cAn;            a ; b ; c ; d ; e ; x _h ; i ; k ; l
-cIN;            a ; b ; c ; d ; e ; x ; g ; _ ; i ; k ; l
-ciN;            a ; b ; c ; d ; e ; x ; g ;_; i ; k ; l
-caN;            a ; b ; c ; d ; e ; x ; g _; i ; k ; l
-cAN;            a ; b ; c ; d ; e ; x ; g _i ; k ; l
-c1IL;           a ; b ; c ; _ ; e ; x ; g ; h ; i ; k ; l
-c1iL;           a ; b ; c ;_; e ; x ; g ; h ; i ; k ; l
-c1aL;           a ; b ; c _; e ; x ; g ; h ; i ; k ; l
-c1AL;           a ; b ; c _e ; x ; g ; h ; i ; k ; l
 c1Il;           a ; b ; c ; d ; _ ; x ; g ; h ; i ; k ; l
 c1il;           a ; b ; c ; d ;_; x ; g ; h ; i ; k ; l
 c1al;           a ; b ; c ; d _; x ; g ; h ; i ; k ; l
@@ -2543,14 +2339,6 @@ c1In;           a ; b ; c ; d ; e ; x ; _ ; h ; i ; k ; l
 c1in;           a ; b ; c ; d ; e ; x ;_; h ; i ; k ; l
 c1an;           a ; b ; c ; d ; e ; x _; h ; i ; k ; l
 c1An;           a ; b ; c ; d ; e ; x _h ; i ; k ; l
-c1IN;           a ; b ; c ; d ; e ; x ; g ; _ ; i ; k ; l
-c1iN;           a ; b ; c ; d ; e ; x ; g ;_; i ; k ; l
-c1aN;           a ; b ; c ; d ; e ; x ; g _; i ; k ; l
-c1AN;           a ; b ; c ; d ; e ; x ; g _i ; k ; l
-c2IL;           a ; _ ; c ; d ; e ; x ; g ; h ; i ; k ; l
-c2iL;           a ;_; c ; d ; e ; x ; g ; h ; i ; k ; l
-c2aL;           a _; c ; d ; e ; x ; g ; h ; i ; k ; l
-c2AL;           a _c ; d ; e ; x ; g ; h ; i ; k ; l
 c2Il;           a ; b ; c ; _ ; e ; x ; g ; h ; i ; k ; l
 c2il;           a ; b ; c ;_; e ; x ; g ; h ; i ; k ; l
 c2al;           a ; b ; c _; e ; x ; g ; h ; i ; k ; l
@@ -2563,14 +2351,6 @@ c2In;           a ; b ; c ; d ; e ; x ; g ; _ ; i ; k ; l
 c2in;           a ; b ; c ; d ; e ; x ; g ;_; i ; k ; l
 c2an;           a ; b ; c ; d ; e ; x ; g _; i ; k ; l
 c2An;           a ; b ; c ; d ; e ; x ; g _i ; k ; l
-c2IN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; _ ; l
-c2iN;           a ; b ; c ; d ; e ; x ; g ; h ; i ;_; l
-c2aN;           a ; b ; c ; d ; e ; x ; g ; h ; i _; l
-c2AN;           a ; b ; c ; d ; e ; x ; g ; h ; i _l
-dIL;            a ; b ; c ;  ; e ; x ; g ; h ; i ; k ; l
-diL;            a ; b ; c ;; e ; x ; g ; h ; i ; k ; l
-daL;            a ; b ; c ; e ; x ; g ; h ; i ; k ; l
-dAL;            a ; b ; c e ; x ; g ; h ; i ; k ; l
 dIl;            a ; b ; c ; d ;  ; x ; g ; h ; i ; k ; l
 dil;            a ; b ; c ; d ;; x ; g ; h ; i ; k ; l
 dal;            a ; b ; c ; d ; x ; g ; h ; i ; k ; l
@@ -2583,14 +2363,6 @@ dIn;            a ; b ; c ; d ; e ; x ;  ; h ; i ; k ; l
 din;            a ; b ; c ; d ; e ; x ;; h ; i ; k ; l
 dan;            a ; b ; c ; d ; e ; x ; h ; i ; k ; l
 dAn;            a ; b ; c ; d ; e ; x h ; i ; k ; l
-dIN;            a ; b ; c ; d ; e ; x ; g ;  ; i ; k ; l
-diN;            a ; b ; c ; d ; e ; x ; g ;; i ; k ; l
-daN;            a ; b ; c ; d ; e ; x ; g ; i ; k ; l
-dAN;            a ; b ; c ; d ; e ; x ; g i ; k ; l
-d1IL;           a ; b ; c ;  ; e ; x ; g ; h ; i ; k ; l
-d1iL;           a ; b ; c ;; e ; x ; g ; h ; i ; k ; l
-d1aL;           a ; b ; c ; e ; x ; g ; h ; i ; k ; l
-d1AL;           a ; b ; c e ; x ; g ; h ; i ; k ; l
 d1Il;           a ; b ; c ; d ;  ; x ; g ; h ; i ; k ; l
 d1il;           a ; b ; c ; d ;; x ; g ; h ; i ; k ; l
 d1al;           a ; b ; c ; d ; x ; g ; h ; i ; k ; l
@@ -2603,14 +2375,6 @@ d1In;           a ; b ; c ; d ; e ; x ;  ; h ; i ; k ; l
 d1in;           a ; b ; c ; d ; e ; x ;; h ; i ; k ; l
 d1an;           a ; b ; c ; d ; e ; x ; h ; i ; k ; l
 d1An;           a ; b ; c ; d ; e ; x h ; i ; k ; l
-d1IN;           a ; b ; c ; d ; e ; x ; g ;  ; i ; k ; l
-d1iN;           a ; b ; c ; d ; e ; x ; g ;; i ; k ; l
-d1aN;           a ; b ; c ; d ; e ; x ; g ; i ; k ; l
-d1AN;           a ; b ; c ; d ; e ; x ; g i ; k ; l
-d2IL;           a ;  ; c ; d ; e ; x ; g ; h ; i ; k ; l
-d2iL;           a ;; c ; d ; e ; x ; g ; h ; i ; k ; l
-d2aL;           a ; c ; d ; e ; x ; g ; h ; i ; k ; l
-d2AL;           a c ; d ; e ; x ; g ; h ; i ; k ; l
 d2Il;           a ; b ; c ;  ; e ; x ; g ; h ; i ; k ; l
 d2il;           a ; b ; c ;; e ; x ; g ; h ; i ; k ; l
 d2al;           a ; b ; c ; e ; x ; g ; h ; i ; k ; l
@@ -2623,14 +2387,6 @@ d2In;           a ; b ; c ; d ; e ; x ; g ;  ; i ; k ; l
 d2in;           a ; b ; c ; d ; e ; x ; g ;; i ; k ; l
 d2an;           a ; b ; c ; d ; e ; x ; g ; i ; k ; l
 d2An;           a ; b ; c ; d ; e ; x ; g i ; k ; l
-d2IN;           a ; b ; c ; d ; e ; x ; g ; h ; i ;  ; l
-d2iN;           a ; b ; c ; d ; e ; x ; g ; h ; i ;; l
-d2aN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; l
-d2AN;           a ; b ; c ; d ; e ; x ; g ; h ; i l
-yIL;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'd'
-yiL;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' d '
-yaL;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; d '
-yAL;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; d ; '
 yIl;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'e'
 yil;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' e '
 yal;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; e '
@@ -2643,14 +2399,6 @@ yIn;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'g'
 yin;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' g '
 yan;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; g '
 yAn;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; g ; '
-yIN;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'h'
-yiN;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' h '
-yaN;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; h '
-yAN;            a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; h ; '
-y1IL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'd'
-y1iL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' d '
-y1aL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; d '
-y1AL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; d ; '
 y1Il;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'e'
 y1il;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' e '
 y1al;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; e '
@@ -2663,14 +2411,6 @@ y1In;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'g'
 y1in;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' g '
 y1an;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; g '
 y1An;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; g ; '
-y1IN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'h'
-y1iN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' h '
-y1aN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; h '
-y1AN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; h ; '
-y2IL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'b'
-y2iL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' b '
-y2aL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; b '
-y2AL;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; b ; '
 y2Il;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'd'
 y2il;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' d '
 y2al;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; d '
@@ -2683,14 +2423,6 @@ y2In;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'h'
 y2in;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' h '
 y2an;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; h '
 y2An;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; h ; '
-y2IN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       'k'
-y2iN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       ' k '
-y2aN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; k '
-y2AN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; k ; l       '; k ; '
-vIL;            a ; b ; c ; _ ; e ; x ; g ; h ; i ; k ; l
-viL;            a ; b ; c ;___; e ; x ; g ; h ; i ; k ; l
-vaL;            a ; b ; c ____; e ; x ; g ; h ; i ; k ; l
-vAL;            a ; b ; c ______e ; x ; g ; h ; i ; k ; l
 vIl;            a ; b ; c ; d ; _ ; x ; g ; h ; i ; k ; l
 vil;            a ; b ; c ; d ;___; x ; g ; h ; i ; k ; l
 val;            a ; b ; c ; d ____; x ; g ; h ; i ; k ; l
@@ -2703,14 +2435,6 @@ vIn;            a ; b ; c ; d ; e ; x ; _ ; h ; i ; k ; l
 vin;            a ; b ; c ; d ; e ; x ;___; h ; i ; k ; l
 van;            a ; b ; c ; d ; e ; x ____; h ; i ; k ; l
 vAn;            a ; b ; c ; d ; e ; x ______h ; i ; k ; l
-vIN;            a ; b ; c ; d ; e ; x ; g ; _ ; i ; k ; l
-viN;            a ; b ; c ; d ; e ; x ; g ;___; i ; k ; l
-vaN;            a ; b ; c ; d ; e ; x ; g ____; i ; k ; l
-vAN;            a ; b ; c ; d ; e ; x ; g ______i ; k ; l
-v1IL;           a ; b ; c ; _ ; e ; x ; g ; h ; i ; k ; l
-v1iL;           a ; b ; c ;___; e ; x ; g ; h ; i ; k ; l
-v1aL;           a ; b ; c ____; e ; x ; g ; h ; i ; k ; l
-v1AL;           a ; b ; c ______e ; x ; g ; h ; i ; k ; l
 v1Il;           a ; b ; c ; d ; _ ; x ; g ; h ; i ; k ; l
 v1il;           a ; b ; c ; d ;___; x ; g ; h ; i ; k ; l
 v1al;           a ; b ; c ; d ____; x ; g ; h ; i ; k ; l
@@ -2723,14 +2447,6 @@ v1In;           a ; b ; c ; d ; e ; x ; _ ; h ; i ; k ; l
 v1in;           a ; b ; c ; d ; e ; x ;___; h ; i ; k ; l
 v1an;           a ; b ; c ; d ; e ; x ____; h ; i ; k ; l
 v1An;           a ; b ; c ; d ; e ; x ______h ; i ; k ; l
-v1IN;           a ; b ; c ; d ; e ; x ; g ; _ ; i ; k ; l
-v1iN;           a ; b ; c ; d ; e ; x ; g ;___; i ; k ; l
-v1aN;           a ; b ; c ; d ; e ; x ; g ____; i ; k ; l
-v1AN;           a ; b ; c ; d ; e ; x ; g ______i ; k ; l
-v2IL;           a ; _ ; c ; d ; e ; x ; g ; h ; i ; k ; l
-v2iL;           a ;___; c ; d ; e ; x ; g ; h ; i ; k ; l
-v2aL;           a ____; c ; d ; e ; x ; g ; h ; i ; k ; l
-v2AL;           a ______c ; d ; e ; x ; g ; h ; i ; k ; l
 v2Il;           a ; b ; c ; _ ; e ; x ; g ; h ; i ; k ; l
 v2il;           a ; b ; c ;___; e ; x ; g ; h ; i ; k ; l
 v2al;           a ; b ; c ____; e ; x ; g ; h ; i ; k ; l
@@ -2743,15 +2459,7 @@ v2In;           a ; b ; c ; d ; e ; x ; g ; _ ; i ; k ; l
 v2in;           a ; b ; c ; d ; e ; x ; g ;___; i ; k ; l
 v2an;           a ; b ; c ; d ; e ; x ; g ____; i ; k ; l
 v2An;           a ; b ; c ; d ; e ; x ; g ______i ; k ; l
-v2IN;           a ; b ; c ; d ; e ; x ; g ; h ; i ; _ ; l
-v2iN;           a ; b ; c ; d ; e ; x ; g ; h ; i ;___; l
-v2aN;           a ; b ; c ; d ; e ; x ; g ; h ; i ____; l
-v2AN;           a ; b ; c ; d ; e ; x ; g ; h ; i ______l
 a : b : c : d : e : x : g : h : i : k : l
-cIL:            a : b : c : _ : e : x : g : h : i : k : l
-ciL:            a : b : c :_: e : x : g : h : i : k : l
-caL:            a : b : c _: e : x : g : h : i : k : l
-cAL:            a : b : c _e : x : g : h : i : k : l
 cIl:            a : b : c : d : _ : x : g : h : i : k : l
 cil:            a : b : c : d :_: x : g : h : i : k : l
 cal:            a : b : c : d _: x : g : h : i : k : l
@@ -2764,14 +2472,6 @@ cIn:            a : b : c : d : e : x : _ : h : i : k : l
 cin:            a : b : c : d : e : x :_: h : i : k : l
 can:            a : b : c : d : e : x _: h : i : k : l
 cAn:            a : b : c : d : e : x _h : i : k : l
-cIN:            a : b : c : d : e : x : g : _ : i : k : l
-ciN:            a : b : c : d : e : x : g :_: i : k : l
-caN:            a : b : c : d : e : x : g _: i : k : l
-cAN:            a : b : c : d : e : x : g _i : k : l
-c1IL:           a : b : c : _ : e : x : g : h : i : k : l
-c1iL:           a : b : c :_: e : x : g : h : i : k : l
-c1aL:           a : b : c _: e : x : g : h : i : k : l
-c1AL:           a : b : c _e : x : g : h : i : k : l
 c1Il:           a : b : c : d : _ : x : g : h : i : k : l
 c1il:           a : b : c : d :_: x : g : h : i : k : l
 c1al:           a : b : c : d _: x : g : h : i : k : l
@@ -2784,14 +2484,6 @@ c1In:           a : b : c : d : e : x : _ : h : i : k : l
 c1in:           a : b : c : d : e : x :_: h : i : k : l
 c1an:           a : b : c : d : e : x _: h : i : k : l
 c1An:           a : b : c : d : e : x _h : i : k : l
-c1IN:           a : b : c : d : e : x : g : _ : i : k : l
-c1iN:           a : b : c : d : e : x : g :_: i : k : l
-c1aN:           a : b : c : d : e : x : g _: i : k : l
-c1AN:           a : b : c : d : e : x : g _i : k : l
-c2IL:           a : _ : c : d : e : x : g : h : i : k : l
-c2iL:           a :_: c : d : e : x : g : h : i : k : l
-c2aL:           a _: c : d : e : x : g : h : i : k : l
-c2AL:           a _c : d : e : x : g : h : i : k : l
 c2Il:           a : b : c : _ : e : x : g : h : i : k : l
 c2il:           a : b : c :_: e : x : g : h : i : k : l
 c2al:           a : b : c _: e : x : g : h : i : k : l
@@ -2804,14 +2496,6 @@ c2In:           a : b : c : d : e : x : g : _ : i : k : l
 c2in:           a : b : c : d : e : x : g :_: i : k : l
 c2an:           a : b : c : d : e : x : g _: i : k : l
 c2An:           a : b : c : d : e : x : g _i : k : l
-c2IN:           a : b : c : d : e : x : g : h : i : _ : l
-c2iN:           a : b : c : d : e : x : g : h : i :_: l
-c2aN:           a : b : c : d : e : x : g : h : i _: l
-c2AN:           a : b : c : d : e : x : g : h : i _l
-dIL:            a : b : c :  : e : x : g : h : i : k : l
-diL:            a : b : c :: e : x : g : h : i : k : l
-daL:            a : b : c : e : x : g : h : i : k : l
-dAL:            a : b : c e : x : g : h : i : k : l
 dIl:            a : b : c : d :  : x : g : h : i : k : l
 dil:            a : b : c : d :: x : g : h : i : k : l
 dal:            a : b : c : d : x : g : h : i : k : l
@@ -2824,14 +2508,6 @@ dIn:            a : b : c : d : e : x :  : h : i : k : l
 din:            a : b : c : d : e : x :: h : i : k : l
 dan:            a : b : c : d : e : x : h : i : k : l
 dAn:            a : b : c : d : e : x h : i : k : l
-dIN:            a : b : c : d : e : x : g :  : i : k : l
-diN:            a : b : c : d : e : x : g :: i : k : l
-daN:            a : b : c : d : e : x : g : i : k : l
-dAN:            a : b : c : d : e : x : g i : k : l
-d1IL:           a : b : c :  : e : x : g : h : i : k : l
-d1iL:           a : b : c :: e : x : g : h : i : k : l
-d1aL:           a : b : c : e : x : g : h : i : k : l
-d1AL:           a : b : c e : x : g : h : i : k : l
 d1Il:           a : b : c : d :  : x : g : h : i : k : l
 d1il:           a : b : c : d :: x : g : h : i : k : l
 d1al:           a : b : c : d : x : g : h : i : k : l
@@ -2844,14 +2520,6 @@ d1In:           a : b : c : d : e : x :  : h : i : k : l
 d1in:           a : b : c : d : e : x :: h : i : k : l
 d1an:           a : b : c : d : e : x : h : i : k : l
 d1An:           a : b : c : d : e : x h : i : k : l
-d1IN:           a : b : c : d : e : x : g :  : i : k : l
-d1iN:           a : b : c : d : e : x : g :: i : k : l
-d1aN:           a : b : c : d : e : x : g : i : k : l
-d1AN:           a : b : c : d : e : x : g i : k : l
-d2IL:           a :  : c : d : e : x : g : h : i : k : l
-d2iL:           a :: c : d : e : x : g : h : i : k : l
-d2aL:           a : c : d : e : x : g : h : i : k : l
-d2AL:           a c : d : e : x : g : h : i : k : l
 d2Il:           a : b : c :  : e : x : g : h : i : k : l
 d2il:           a : b : c :: e : x : g : h : i : k : l
 d2al:           a : b : c : e : x : g : h : i : k : l
@@ -2864,14 +2532,6 @@ d2In:           a : b : c : d : e : x : g :  : i : k : l
 d2in:           a : b : c : d : e : x : g :: i : k : l
 d2an:           a : b : c : d : e : x : g : i : k : l
 d2An:           a : b : c : d : e : x : g i : k : l
-d2IN:           a : b : c : d : e : x : g : h : i :  : l
-d2iN:           a : b : c : d : e : x : g : h : i :: l
-d2aN:           a : b : c : d : e : x : g : h : i : l
-d2AN:           a : b : c : d : e : x : g : h : i l
-yIL:            a : b : c : d : e : x : g : h : i : k : l       'd'
-yiL:            a : b : c : d : e : x : g : h : i : k : l       ' d '
-yaL:            a : b : c : d : e : x : g : h : i : k : l       ': d '
-yAL:            a : b : c : d : e : x : g : h : i : k : l       ': d : '
 yIl:            a : b : c : d : e : x : g : h : i : k : l       'e'
 yil:            a : b : c : d : e : x : g : h : i : k : l       ' e '
 yal:            a : b : c : d : e : x : g : h : i : k : l       ': e '
@@ -2884,14 +2544,6 @@ yIn:            a : b : c : d : e : x : g : h : i : k : l       'g'
 yin:            a : b : c : d : e : x : g : h : i : k : l       ' g '
 yan:            a : b : c : d : e : x : g : h : i : k : l       ': g '
 yAn:            a : b : c : d : e : x : g : h : i : k : l       ': g : '
-yIN:            a : b : c : d : e : x : g : h : i : k : l       'h'
-yiN:            a : b : c : d : e : x : g : h : i : k : l       ' h '
-yaN:            a : b : c : d : e : x : g : h : i : k : l       ': h '
-yAN:            a : b : c : d : e : x : g : h : i : k : l       ': h : '
-y1IL:           a : b : c : d : e : x : g : h : i : k : l       'd'
-y1iL:           a : b : c : d : e : x : g : h : i : k : l       ' d '
-y1aL:           a : b : c : d : e : x : g : h : i : k : l       ': d '
-y1AL:           a : b : c : d : e : x : g : h : i : k : l       ': d : '
 y1Il:           a : b : c : d : e : x : g : h : i : k : l       'e'
 y1il:           a : b : c : d : e : x : g : h : i : k : l       ' e '
 y1al:           a : b : c : d : e : x : g : h : i : k : l       ': e '
@@ -2904,14 +2556,6 @@ y1In:           a : b : c : d : e : x : g : h : i : k : l       'g'
 y1in:           a : b : c : d : e : x : g : h : i : k : l       ' g '
 y1an:           a : b : c : d : e : x : g : h : i : k : l       ': g '
 y1An:           a : b : c : d : e : x : g : h : i : k : l       ': g : '
-y1IN:           a : b : c : d : e : x : g : h : i : k : l       'h'
-y1iN:           a : b : c : d : e : x : g : h : i : k : l       ' h '
-y1aN:           a : b : c : d : e : x : g : h : i : k : l       ': h '
-y1AN:           a : b : c : d : e : x : g : h : i : k : l       ': h : '
-y2IL:           a : b : c : d : e : x : g : h : i : k : l       'b'
-y2iL:           a : b : c : d : e : x : g : h : i : k : l       ' b '
-y2aL:           a : b : c : d : e : x : g : h : i : k : l       ': b '
-y2AL:           a : b : c : d : e : x : g : h : i : k : l       ': b : '
 y2Il:           a : b : c : d : e : x : g : h : i : k : l       'd'
 y2il:           a : b : c : d : e : x : g : h : i : k : l       ' d '
 y2al:           a : b : c : d : e : x : g : h : i : k : l       ': d '
@@ -2924,14 +2568,6 @@ y2In:           a : b : c : d : e : x : g : h : i : k : l       'h'
 y2in:           a : b : c : d : e : x : g : h : i : k : l       ' h '
 y2an:           a : b : c : d : e : x : g : h : i : k : l       ': h '
 y2An:           a : b : c : d : e : x : g : h : i : k : l       ': h : '
-y2IN:           a : b : c : d : e : x : g : h : i : k : l       'k'
-y2iN:           a : b : c : d : e : x : g : h : i : k : l       ' k '
-y2aN:           a : b : c : d : e : x : g : h : i : k : l       ': k '
-y2AN:           a : b : c : d : e : x : g : h : i : k : l       ': k : '
-vIL:            a : b : c : _ : e : x : g : h : i : k : l
-viL:            a : b : c :___: e : x : g : h : i : k : l
-vaL:            a : b : c ____: e : x : g : h : i : k : l
-vAL:            a : b : c ______e : x : g : h : i : k : l
 vIl:            a : b : c : d : _ : x : g : h : i : k : l
 vil:            a : b : c : d :___: x : g : h : i : k : l
 val:            a : b : c : d ____: x : g : h : i : k : l
@@ -2944,14 +2580,6 @@ vIn:            a : b : c : d : e : x : _ : h : i : k : l
 vin:            a : b : c : d : e : x :___: h : i : k : l
 van:            a : b : c : d : e : x ____: h : i : k : l
 vAn:            a : b : c : d : e : x ______h : i : k : l
-vIN:            a : b : c : d : e : x : g : _ : i : k : l
-viN:            a : b : c : d : e : x : g :___: i : k : l
-vaN:            a : b : c : d : e : x : g ____: i : k : l
-vAN:            a : b : c : d : e : x : g ______i : k : l
-v1IL:           a : b : c : _ : e : x : g : h : i : k : l
-v1iL:           a : b : c :___: e : x : g : h : i : k : l
-v1aL:           a : b : c ____: e : x : g : h : i : k : l
-v1AL:           a : b : c ______e : x : g : h : i : k : l
 v1Il:           a : b : c : d : _ : x : g : h : i : k : l
 v1il:           a : b : c : d :___: x : g : h : i : k : l
 v1al:           a : b : c : d ____: x : g : h : i : k : l
@@ -2964,14 +2592,6 @@ v1In:           a : b : c : d : e : x : _ : h : i : k : l
 v1in:           a : b : c : d : e : x :___: h : i : k : l
 v1an:           a : b : c : d : e : x ____: h : i : k : l
 v1An:           a : b : c : d : e : x ______h : i : k : l
-v1IN:           a : b : c : d : e : x : g : _ : i : k : l
-v1iN:           a : b : c : d : e : x : g :___: i : k : l
-v1aN:           a : b : c : d : e : x : g ____: i : k : l
-v1AN:           a : b : c : d : e : x : g ______i : k : l
-v2IL:           a : _ : c : d : e : x : g : h : i : k : l
-v2iL:           a :___: c : d : e : x : g : h : i : k : l
-v2aL:           a ____: c : d : e : x : g : h : i : k : l
-v2AL:           a ______c : d : e : x : g : h : i : k : l
 v2Il:           a : b : c : _ : e : x : g : h : i : k : l
 v2il:           a : b : c :___: e : x : g : h : i : k : l
 v2al:           a : b : c ____: e : x : g : h : i : k : l
@@ -2984,15 +2604,7 @@ v2In:           a : b : c : d : e : x : g : _ : i : k : l
 v2in:           a : b : c : d : e : x : g :___: i : k : l
 v2an:           a : b : c : d : e : x : g ____: i : k : l
 v2An:           a : b : c : d : e : x : g ______i : k : l
-v2IN:           a : b : c : d : e : x : g : h : i : _ : l
-v2iN:           a : b : c : d : e : x : g : h : i :___: l
-v2aN:           a : b : c : d : e : x : g : h : i ____: l
-v2AN:           a : b : c : d : e : x : g : h : i ______l
 a + b + c + d + e + x + g + h + i + k + l
-cIL+            a + b + c + _ + e + x + g + h + i + k + l
-ciL+            a + b + c +_+ e + x + g + h + i + k + l
-caL+            a + b + c _+ e + x + g + h + i + k + l
-cAL+            a + b + c _e + x + g + h + i + k + l
 cIl+            a + b + c + d + _ + x + g + h + i + k + l
 cil+            a + b + c + d +_+ x + g + h + i + k + l
 cal+            a + b + c + d _+ x + g + h + i + k + l
@@ -3005,14 +2617,6 @@ cIn+            a + b + c + d + e + x + _ + h + i + k + l
 cin+            a + b + c + d + e + x +_+ h + i + k + l
 can+            a + b + c + d + e + x _+ h + i + k + l
 cAn+            a + b + c + d + e + x _h + i + k + l
-cIN+            a + b + c + d + e + x + g + _ + i + k + l
-ciN+            a + b + c + d + e + x + g +_+ i + k + l
-caN+            a + b + c + d + e + x + g _+ i + k + l
-cAN+            a + b + c + d + e + x + g _i + k + l
-c1IL+           a + b + c + _ + e + x + g + h + i + k + l
-c1iL+           a + b + c +_+ e + x + g + h + i + k + l
-c1aL+           a + b + c _+ e + x + g + h + i + k + l
-c1AL+           a + b + c _e + x + g + h + i + k + l
 c1Il+           a + b + c + d + _ + x + g + h + i + k + l
 c1il+           a + b + c + d +_+ x + g + h + i + k + l
 c1al+           a + b + c + d _+ x + g + h + i + k + l
@@ -3025,14 +2629,6 @@ c1In+           a + b + c + d + e + x + _ + h + i + k + l
 c1in+           a + b + c + d + e + x +_+ h + i + k + l
 c1an+           a + b + c + d + e + x _+ h + i + k + l
 c1An+           a + b + c + d + e + x _h + i + k + l
-c1IN+           a + b + c + d + e + x + g + _ + i + k + l
-c1iN+           a + b + c + d + e + x + g +_+ i + k + l
-c1aN+           a + b + c + d + e + x + g _+ i + k + l
-c1AN+           a + b + c + d + e + x + g _i + k + l
-c2IL+           a + _ + c + d + e + x + g + h + i + k + l
-c2iL+           a +_+ c + d + e + x + g + h + i + k + l
-c2aL+           a _+ c + d + e + x + g + h + i + k + l
-c2AL+           a _c + d + e + x + g + h + i + k + l
 c2Il+           a + b + c + _ + e + x + g + h + i + k + l
 c2il+           a + b + c +_+ e + x + g + h + i + k + l
 c2al+           a + b + c _+ e + x + g + h + i + k + l
@@ -3045,14 +2641,6 @@ c2In+           a + b + c + d + e + x + g + _ + i + k + l
 c2in+           a + b + c + d + e + x + g +_+ i + k + l
 c2an+           a + b + c + d + e + x + g _+ i + k + l
 c2An+           a + b + c + d + e + x + g _i + k + l
-c2IN+           a + b + c + d + e + x + g + h + i + _ + l
-c2iN+           a + b + c + d + e + x + g + h + i +_+ l
-c2aN+           a + b + c + d + e + x + g + h + i _+ l
-c2AN+           a + b + c + d + e + x + g + h + i _l
-dIL+            a + b + c +  + e + x + g + h + i + k + l
-diL+            a + b + c ++ e + x + g + h + i + k + l
-daL+            a + b + c + e + x + g + h + i + k + l
-dAL+            a + b + c e + x + g + h + i + k + l
 dIl+            a + b + c + d +  + x + g + h + i + k + l
 dil+            a + b + c + d ++ x + g + h + i + k + l
 dal+            a + b + c + d + x + g + h + i + k + l
@@ -3065,14 +2653,6 @@ dIn+            a + b + c + d + e + x +  + h + i + k + l
 din+            a + b + c + d + e + x ++ h + i + k + l
 dan+            a + b + c + d + e + x + h + i + k + l
 dAn+            a + b + c + d + e + x h + i + k + l
-dIN+            a + b + c + d + e + x + g +  + i + k + l
-diN+            a + b + c + d + e + x + g ++ i + k + l
-daN+            a + b + c + d + e + x + g + i + k + l
-dAN+            a + b + c + d + e + x + g i + k + l
-d1IL+           a + b + c +  + e + x + g + h + i + k + l
-d1iL+           a + b + c ++ e + x + g + h + i + k + l
-d1aL+           a + b + c + e + x + g + h + i + k + l
-d1AL+           a + b + c e + x + g + h + i + k + l
 d1Il+           a + b + c + d +  + x + g + h + i + k + l
 d1il+           a + b + c + d ++ x + g + h + i + k + l
 d1al+           a + b + c + d + x + g + h + i + k + l
@@ -3085,14 +2665,6 @@ d1In+           a + b + c + d + e + x +  + h + i + k + l
 d1in+           a + b + c + d + e + x ++ h + i + k + l
 d1an+           a + b + c + d + e + x + h + i + k + l
 d1An+           a + b + c + d + e + x h + i + k + l
-d1IN+           a + b + c + d + e + x + g +  + i + k + l
-d1iN+           a + b + c + d + e + x + g ++ i + k + l
-d1aN+           a + b + c + d + e + x + g + i + k + l
-d1AN+           a + b + c + d + e + x + g i + k + l
-d2IL+           a +  + c + d + e + x + g + h + i + k + l
-d2iL+           a ++ c + d + e + x + g + h + i + k + l
-d2aL+           a + c + d + e + x + g + h + i + k + l
-d2AL+           a c + d + e + x + g + h + i + k + l
 d2Il+           a + b + c +  + e + x + g + h + i + k + l
 d2il+           a + b + c ++ e + x + g + h + i + k + l
 d2al+           a + b + c + e + x + g + h + i + k + l
@@ -3105,14 +2677,6 @@ d2In+           a + b + c + d + e + x + g +  + i + k + l
 d2in+           a + b + c + d + e + x + g ++ i + k + l
 d2an+           a + b + c + d + e + x + g + i + k + l
 d2An+           a + b + c + d + e + x + g i + k + l
-d2IN+           a + b + c + d + e + x + g + h + i +  + l
-d2iN+           a + b + c + d + e + x + g + h + i ++ l
-d2aN+           a + b + c + d + e + x + g + h + i + l
-d2AN+           a + b + c + d + e + x + g + h + i l
-yIL+            a + b + c + d + e + x + g + h + i + k + l       'd'
-yiL+            a + b + c + d + e + x + g + h + i + k + l       ' d '
-yaL+            a + b + c + d + e + x + g + h + i + k + l       '+ d '
-yAL+            a + b + c + d + e + x + g + h + i + k + l       '+ d + '
 yIl+            a + b + c + d + e + x + g + h + i + k + l       'e'
 yil+            a + b + c + d + e + x + g + h + i + k + l       ' e '
 yal+            a + b + c + d + e + x + g + h + i + k + l       '+ e '
@@ -3125,14 +2689,6 @@ yIn+            a + b + c + d + e + x + g + h + i + k + l       'g'
 yin+            a + b + c + d + e + x + g + h + i + k + l       ' g '
 yan+            a + b + c + d + e + x + g + h + i + k + l       '+ g '
 yAn+            a + b + c + d + e + x + g + h + i + k + l       '+ g + '
-yIN+            a + b + c + d + e + x + g + h + i + k + l       'h'
-yiN+            a + b + c + d + e + x + g + h + i + k + l       ' h '
-yaN+            a + b + c + d + e + x + g + h + i + k + l       '+ h '
-yAN+            a + b + c + d + e + x + g + h + i + k + l       '+ h + '
-y1IL+           a + b + c + d + e + x + g + h + i + k + l       'd'
-y1iL+           a + b + c + d + e + x + g + h + i + k + l       ' d '
-y1aL+           a + b + c + d + e + x + g + h + i + k + l       '+ d '
-y1AL+           a + b + c + d + e + x + g + h + i + k + l       '+ d + '
 y1Il+           a + b + c + d + e + x + g + h + i + k + l       'e'
 y1il+           a + b + c + d + e + x + g + h + i + k + l       ' e '
 y1al+           a + b + c + d + e + x + g + h + i + k + l       '+ e '
@@ -3145,14 +2701,6 @@ y1In+           a + b + c + d + e + x + g + h + i + k + l       'g'
 y1in+           a + b + c + d + e + x + g + h + i + k + l       ' g '
 y1an+           a + b + c + d + e + x + g + h + i + k + l       '+ g '
 y1An+           a + b + c + d + e + x + g + h + i + k + l       '+ g + '
-y1IN+           a + b + c + d + e + x + g + h + i + k + l       'h'
-y1iN+           a + b + c + d + e + x + g + h + i + k + l       ' h '
-y1aN+           a + b + c + d + e + x + g + h + i + k + l       '+ h '
-y1AN+           a + b + c + d + e + x + g + h + i + k + l       '+ h + '
-y2IL+           a + b + c + d + e + x + g + h + i + k + l       'b'
-y2iL+           a + b + c + d + e + x + g + h + i + k + l       ' b '
-y2aL+           a + b + c + d + e + x + g + h + i + k + l       '+ b '
-y2AL+           a + b + c + d + e + x + g + h + i + k + l       '+ b + '
 y2Il+           a + b + c + d + e + x + g + h + i + k + l       'd'
 y2il+           a + b + c + d + e + x + g + h + i + k + l       ' d '
 y2al+           a + b + c + d + e + x + g + h + i + k + l       '+ d '
@@ -3165,14 +2713,6 @@ y2In+           a + b + c + d + e + x + g + h + i + k + l       'h'
 y2in+           a + b + c + d + e + x + g + h + i + k + l       ' h '
 y2an+           a + b + c + d + e + x + g + h + i + k + l       '+ h '
 y2An+           a + b + c + d + e + x + g + h + i + k + l       '+ h + '
-y2IN+           a + b + c + d + e + x + g + h + i + k + l       'k'
-y2iN+           a + b + c + d + e + x + g + h + i + k + l       ' k '
-y2aN+           a + b + c + d + e + x + g + h + i + k + l       '+ k '
-y2AN+           a + b + c + d + e + x + g + h + i + k + l       '+ k + '
-vIL+            a + b + c + _ + e + x + g + h + i + k + l
-viL+            a + b + c +___+ e + x + g + h + i + k + l
-vaL+            a + b + c ____+ e + x + g + h + i + k + l
-vAL+            a + b + c ______e + x + g + h + i + k + l
 vIl+            a + b + c + d + _ + x + g + h + i + k + l
 vil+            a + b + c + d +___+ x + g + h + i + k + l
 val+            a + b + c + d ____+ x + g + h + i + k + l
@@ -3185,14 +2725,6 @@ vIn+            a + b + c + d + e + x + _ + h + i + k + l
 vin+            a + b + c + d + e + x +___+ h + i + k + l
 van+            a + b + c + d + e + x ____+ h + i + k + l
 vAn+            a + b + c + d + e + x ______h + i + k + l
-vIN+            a + b + c + d + e + x + g + _ + i + k + l
-viN+            a + b + c + d + e + x + g +___+ i + k + l
-vaN+            a + b + c + d + e + x + g ____+ i + k + l
-vAN+            a + b + c + d + e + x + g ______i + k + l
-v1IL+           a + b + c + _ + e + x + g + h + i + k + l
-v1iL+           a + b + c +___+ e + x + g + h + i + k + l
-v1aL+           a + b + c ____+ e + x + g + h + i + k + l
-v1AL+           a + b + c ______e + x + g + h + i + k + l
 v1Il+           a + b + c + d + _ + x + g + h + i + k + l
 v1il+           a + b + c + d +___+ x + g + h + i + k + l
 v1al+           a + b + c + d ____+ x + g + h + i + k + l
@@ -3205,14 +2737,6 @@ v1In+           a + b + c + d + e + x + _ + h + i + k + l
 v1in+           a + b + c + d + e + x +___+ h + i + k + l
 v1an+           a + b + c + d + e + x ____+ h + i + k + l
 v1An+           a + b + c + d + e + x ______h + i + k + l
-v1IN+           a + b + c + d + e + x + g + _ + i + k + l
-v1iN+           a + b + c + d + e + x + g +___+ i + k + l
-v1aN+           a + b + c + d + e + x + g ____+ i + k + l
-v1AN+           a + b + c + d + e + x + g ______i + k + l
-v2IL+           a + _ + c + d + e + x + g + h + i + k + l
-v2iL+           a +___+ c + d + e + x + g + h + i + k + l
-v2aL+           a ____+ c + d + e + x + g + h + i + k + l
-v2AL+           a ______c + d + e + x + g + h + i + k + l
 v2Il+           a + b + c + _ + e + x + g + h + i + k + l
 v2il+           a + b + c +___+ e + x + g + h + i + k + l
 v2al+           a + b + c ____+ e + x + g + h + i + k + l
@@ -3225,15 +2749,7 @@ v2In+           a + b + c + d + e + x + g + _ + i + k + l
 v2in+           a + b + c + d + e + x + g +___+ i + k + l
 v2an+           a + b + c + d + e + x + g ____+ i + k + l
 v2An+           a + b + c + d + e + x + g ______i + k + l
-v2IN+           a + b + c + d + e + x + g + h + i + _ + l
-v2iN+           a + b + c + d + e + x + g + h + i +___+ l
-v2aN+           a + b + c + d + e + x + g + h + i ____+ l
-v2AN+           a + b + c + d + e + x + g + h + i ______l
 a - b - c - d - e - x - g - h - i - k - l
-cIL-            a - b - c - _ - e - x - g - h - i - k - l
-ciL-            a - b - c -_- e - x - g - h - i - k - l
-caL-            a - b - c _- e - x - g - h - i - k - l
-cAL-            a - b - c _e - x - g - h - i - k - l
 cIl-            a - b - c - d - _ - x - g - h - i - k - l
 cil-            a - b - c - d -_- x - g - h - i - k - l
 cal-            a - b - c - d _- x - g - h - i - k - l
@@ -3246,14 +2762,6 @@ cIn-            a - b - c - d - e - x - _ - h - i - k - l
 cin-            a - b - c - d - e - x -_- h - i - k - l
 can-            a - b - c - d - e - x _- h - i - k - l
 cAn-            a - b - c - d - e - x _h - i - k - l
-cIN-            a - b - c - d - e - x - g - _ - i - k - l
-ciN-            a - b - c - d - e - x - g -_- i - k - l
-caN-            a - b - c - d - e - x - g _- i - k - l
-cAN-            a - b - c - d - e - x - g _i - k - l
-c1IL-           a - b - c - _ - e - x - g - h - i - k - l
-c1iL-           a - b - c -_- e - x - g - h - i - k - l
-c1aL-           a - b - c _- e - x - g - h - i - k - l
-c1AL-           a - b - c _e - x - g - h - i - k - l
 c1Il-           a - b - c - d - _ - x - g - h - i - k - l
 c1il-           a - b - c - d -_- x - g - h - i - k - l
 c1al-           a - b - c - d _- x - g - h - i - k - l
@@ -3266,14 +2774,6 @@ c1In-           a - b - c - d - e - x - _ - h - i - k - l
 c1in-           a - b - c - d - e - x -_- h - i - k - l
 c1an-           a - b - c - d - e - x _- h - i - k - l
 c1An-           a - b - c - d - e - x _h - i - k - l
-c1IN-           a - b - c - d - e - x - g - _ - i - k - l
-c1iN-           a - b - c - d - e - x - g -_- i - k - l
-c1aN-           a - b - c - d - e - x - g _- i - k - l
-c1AN-           a - b - c - d - e - x - g _i - k - l
-c2IL-           a - _ - c - d - e - x - g - h - i - k - l
-c2iL-           a -_- c - d - e - x - g - h - i - k - l
-c2aL-           a _- c - d - e - x - g - h - i - k - l
-c2AL-           a _c - d - e - x - g - h - i - k - l
 c2Il-           a - b - c - _ - e - x - g - h - i - k - l
 c2il-           a - b - c -_- e - x - g - h - i - k - l
 c2al-           a - b - c _- e - x - g - h - i - k - l
@@ -3286,14 +2786,6 @@ c2In-           a - b - c - d - e - x - g - _ - i - k - l
 c2in-           a - b - c - d - e - x - g -_- i - k - l
 c2an-           a - b - c - d - e - x - g _- i - k - l
 c2An-           a - b - c - d - e - x - g _i - k - l
-c2IN-           a - b - c - d - e - x - g - h - i - _ - l
-c2iN-           a - b - c - d - e - x - g - h - i -_- l
-c2aN-           a - b - c - d - e - x - g - h - i _- l
-c2AN-           a - b - c - d - e - x - g - h - i _l
-dIL-            a - b - c -  - e - x - g - h - i - k - l
-diL-            a - b - c -- e - x - g - h - i - k - l
-daL-            a - b - c - e - x - g - h - i - k - l
-dAL-            a - b - c e - x - g - h - i - k - l
 dIl-            a - b - c - d -  - x - g - h - i - k - l
 dil-            a - b - c - d -- x - g - h - i - k - l
 dal-            a - b - c - d - x - g - h - i - k - l
@@ -3306,14 +2798,6 @@ dIn-            a - b - c - d - e - x -  - h - i - k - l
 din-            a - b - c - d - e - x -- h - i - k - l
 dan-            a - b - c - d - e - x - h - i - k - l
 dAn-            a - b - c - d - e - x h - i - k - l
-dIN-            a - b - c - d - e - x - g -  - i - k - l
-diN-            a - b - c - d - e - x - g -- i - k - l
-daN-            a - b - c - d - e - x - g - i - k - l
-dAN-            a - b - c - d - e - x - g i - k - l
-d1IL-           a - b - c -  - e - x - g - h - i - k - l
-d1iL-           a - b - c -- e - x - g - h - i - k - l
-d1aL-           a - b - c - e - x - g - h - i - k - l
-d1AL-           a - b - c e - x - g - h - i - k - l
 d1Il-           a - b - c - d -  - x - g - h - i - k - l
 d1il-           a - b - c - d -- x - g - h - i - k - l
 d1al-           a - b - c - d - x - g - h - i - k - l
@@ -3326,14 +2810,6 @@ d1In-           a - b - c - d - e - x -  - h - i - k - l
 d1in-           a - b - c - d - e - x -- h - i - k - l
 d1an-           a - b - c - d - e - x - h - i - k - l
 d1An-           a - b - c - d - e - x h - i - k - l
-d1IN-           a - b - c - d - e - x - g -  - i - k - l
-d1iN-           a - b - c - d - e - x - g -- i - k - l
-d1aN-           a - b - c - d - e - x - g - i - k - l
-d1AN-           a - b - c - d - e - x - g i - k - l
-d2IL-           a -  - c - d - e - x - g - h - i - k - l
-d2iL-           a -- c - d - e - x - g - h - i - k - l
-d2aL-           a - c - d - e - x - g - h - i - k - l
-d2AL-           a c - d - e - x - g - h - i - k - l
 d2Il-           a - b - c -  - e - x - g - h - i - k - l
 d2il-           a - b - c -- e - x - g - h - i - k - l
 d2al-           a - b - c - e - x - g - h - i - k - l
@@ -3346,14 +2822,6 @@ d2In-           a - b - c - d - e - x - g -  - i - k - l
 d2in-           a - b - c - d - e - x - g -- i - k - l
 d2an-           a - b - c - d - e - x - g - i - k - l
 d2An-           a - b - c - d - e - x - g i - k - l
-d2IN-           a - b - c - d - e - x - g - h - i -  - l
-d2iN-           a - b - c - d - e - x - g - h - i -- l
-d2aN-           a - b - c - d - e - x - g - h - i - l
-d2AN-           a - b - c - d - e - x - g - h - i l
-yIL-            a - b - c - d - e - x - g - h - i - k - l       'd'
-yiL-            a - b - c - d - e - x - g - h - i - k - l       ' d '
-yaL-            a - b - c - d - e - x - g - h - i - k - l       '- d '
-yAL-            a - b - c - d - e - x - g - h - i - k - l       '- d - '
 yIl-            a - b - c - d - e - x - g - h - i - k - l       'e'
 yil-            a - b - c - d - e - x - g - h - i - k - l       ' e '
 yal-            a - b - c - d - e - x - g - h - i - k - l       '- e '
@@ -3366,14 +2834,6 @@ yIn-            a - b - c - d - e - x - g - h - i - k - l       'g'
 yin-            a - b - c - d - e - x - g - h - i - k - l       ' g '
 yan-            a - b - c - d - e - x - g - h - i - k - l       '- g '
 yAn-            a - b - c - d - e - x - g - h - i - k - l       '- g - '
-yIN-            a - b - c - d - e - x - g - h - i - k - l       'h'
-yiN-            a - b - c - d - e - x - g - h - i - k - l       ' h '
-yaN-            a - b - c - d - e - x - g - h - i - k - l       '- h '
-yAN-            a - b - c - d - e - x - g - h - i - k - l       '- h - '
-y1IL-           a - b - c - d - e - x - g - h - i - k - l       'd'
-y1iL-           a - b - c - d - e - x - g - h - i - k - l       ' d '
-y1aL-           a - b - c - d - e - x - g - h - i - k - l       '- d '
-y1AL-           a - b - c - d - e - x - g - h - i - k - l       '- d - '
 y1Il-           a - b - c - d - e - x - g - h - i - k - l       'e'
 y1il-           a - b - c - d - e - x - g - h - i - k - l       ' e '
 y1al-           a - b - c - d - e - x - g - h - i - k - l       '- e '
@@ -3386,14 +2846,6 @@ y1In-           a - b - c - d - e - x - g - h - i - k - l       'g'
 y1in-           a - b - c - d - e - x - g - h - i - k - l       ' g '
 y1an-           a - b - c - d - e - x - g - h - i - k - l       '- g '
 y1An-           a - b - c - d - e - x - g - h - i - k - l       '- g - '
-y1IN-           a - b - c - d - e - x - g - h - i - k - l       'h'
-y1iN-           a - b - c - d - e - x - g - h - i - k - l       ' h '
-y1aN-           a - b - c - d - e - x - g - h - i - k - l       '- h '
-y1AN-           a - b - c - d - e - x - g - h - i - k - l       '- h - '
-y2IL-           a - b - c - d - e - x - g - h - i - k - l       'b'
-y2iL-           a - b - c - d - e - x - g - h - i - k - l       ' b '
-y2aL-           a - b - c - d - e - x - g - h - i - k - l       '- b '
-y2AL-           a - b - c - d - e - x - g - h - i - k - l       '- b - '
 y2Il-           a - b - c - d - e - x - g - h - i - k - l       'd'
 y2il-           a - b - c - d - e - x - g - h - i - k - l       ' d '
 y2al-           a - b - c - d - e - x - g - h - i - k - l       '- d '
@@ -3406,14 +2858,6 @@ y2In-           a - b - c - d - e - x - g - h - i - k - l       'h'
 y2in-           a - b - c - d - e - x - g - h - i - k - l       ' h '
 y2an-           a - b - c - d - e - x - g - h - i - k - l       '- h '
 y2An-           a - b - c - d - e - x - g - h - i - k - l       '- h - '
-y2IN-           a - b - c - d - e - x - g - h - i - k - l       'k'
-y2iN-           a - b - c - d - e - x - g - h - i - k - l       ' k '
-y2aN-           a - b - c - d - e - x - g - h - i - k - l       '- k '
-y2AN-           a - b - c - d - e - x - g - h - i - k - l       '- k - '
-vIL-            a - b - c - _ - e - x - g - h - i - k - l
-viL-            a - b - c -___- e - x - g - h - i - k - l
-vaL-            a - b - c ____- e - x - g - h - i - k - l
-vAL-            a - b - c ______e - x - g - h - i - k - l
 vIl-            a - b - c - d - _ - x - g - h - i - k - l
 vil-            a - b - c - d -___- x - g - h - i - k - l
 val-            a - b - c - d ____- x - g - h - i - k - l
@@ -3426,14 +2870,6 @@ vIn-            a - b - c - d - e - x - _ - h - i - k - l
 vin-            a - b - c - d - e - x -___- h - i - k - l
 van-            a - b - c - d - e - x ____- h - i - k - l
 vAn-            a - b - c - d - e - x ______h - i - k - l
-vIN-            a - b - c - d - e - x - g - _ - i - k - l
-viN-            a - b - c - d - e - x - g -___- i - k - l
-vaN-            a - b - c - d - e - x - g ____- i - k - l
-vAN-            a - b - c - d - e - x - g ______i - k - l
-v1IL-           a - b - c - _ - e - x - g - h - i - k - l
-v1iL-           a - b - c -___- e - x - g - h - i - k - l
-v1aL-           a - b - c ____- e - x - g - h - i - k - l
-v1AL-           a - b - c ______e - x - g - h - i - k - l
 v1Il-           a - b - c - d - _ - x - g - h - i - k - l
 v1il-           a - b - c - d -___- x - g - h - i - k - l
 v1al-           a - b - c - d ____- x - g - h - i - k - l
@@ -3446,14 +2882,6 @@ v1In-           a - b - c - d - e - x - _ - h - i - k - l
 v1in-           a - b - c - d - e - x -___- h - i - k - l
 v1an-           a - b - c - d - e - x ____- h - i - k - l
 v1An-           a - b - c - d - e - x ______h - i - k - l
-v1IN-           a - b - c - d - e - x - g - _ - i - k - l
-v1iN-           a - b - c - d - e - x - g -___- i - k - l
-v1aN-           a - b - c - d - e - x - g ____- i - k - l
-v1AN-           a - b - c - d - e - x - g ______i - k - l
-v2IL-           a - _ - c - d - e - x - g - h - i - k - l
-v2iL-           a -___- c - d - e - x - g - h - i - k - l
-v2aL-           a ____- c - d - e - x - g - h - i - k - l
-v2AL-           a ______c - d - e - x - g - h - i - k - l
 v2Il-           a - b - c - _ - e - x - g - h - i - k - l
 v2il-           a - b - c -___- e - x - g - h - i - k - l
 v2al-           a - b - c ____- e - x - g - h - i - k - l
@@ -3466,15 +2894,7 @@ v2In-           a - b - c - d - e - x - g - _ - i - k - l
 v2in-           a - b - c - d - e - x - g -___- i - k - l
 v2an-           a - b - c - d - e - x - g ____- i - k - l
 v2An-           a - b - c - d - e - x - g ______i - k - l
-v2IN-           a - b - c - d - e - x - g - h - i - _ - l
-v2iN-           a - b - c - d - e - x - g - h - i -___- l
-v2aN-           a - b - c - d - e - x - g - h - i ____- l
-v2AN-           a - b - c - d - e - x - g - h - i ______l
 a = b = c = d = e = x = g = h = i = k = l
-cIL=            a = b = c = _ = e = x = g = h = i = k = l
-ciL=            a = b = c =_= e = x = g = h = i = k = l
-caL=            a = b = c _= e = x = g = h = i = k = l
-cAL=            a = b = c _e = x = g = h = i = k = l
 cIl=            a = b = c = d = _ = x = g = h = i = k = l
 cil=            a = b = c = d =_= x = g = h = i = k = l
 cal=            a = b = c = d _= x = g = h = i = k = l
@@ -3487,14 +2907,6 @@ cIn=            a = b = c = d = e = x = _ = h = i = k = l
 cin=            a = b = c = d = e = x =_= h = i = k = l
 can=            a = b = c = d = e = x _= h = i = k = l
 cAn=            a = b = c = d = e = x _h = i = k = l
-cIN=            a = b = c = d = e = x = g = _ = i = k = l
-ciN=            a = b = c = d = e = x = g =_= i = k = l
-caN=            a = b = c = d = e = x = g _= i = k = l
-cAN=            a = b = c = d = e = x = g _i = k = l
-c1IL=           a = b = c = _ = e = x = g = h = i = k = l
-c1iL=           a = b = c =_= e = x = g = h = i = k = l
-c1aL=           a = b = c _= e = x = g = h = i = k = l
-c1AL=           a = b = c _e = x = g = h = i = k = l
 c1Il=           a = b = c = d = _ = x = g = h = i = k = l
 c1il=           a = b = c = d =_= x = g = h = i = k = l
 c1al=           a = b = c = d _= x = g = h = i = k = l
@@ -3507,14 +2919,6 @@ c1In=           a = b = c = d = e = x = _ = h = i = k = l
 c1in=           a = b = c = d = e = x =_= h = i = k = l
 c1an=           a = b = c = d = e = x _= h = i = k = l
 c1An=           a = b = c = d = e = x _h = i = k = l
-c1IN=           a = b = c = d = e = x = g = _ = i = k = l
-c1iN=           a = b = c = d = e = x = g =_= i = k = l
-c1aN=           a = b = c = d = e = x = g _= i = k = l
-c1AN=           a = b = c = d = e = x = g _i = k = l
-c2IL=           a = _ = c = d = e = x = g = h = i = k = l
-c2iL=           a =_= c = d = e = x = g = h = i = k = l
-c2aL=           a _= c = d = e = x = g = h = i = k = l
-c2AL=           a _c = d = e = x = g = h = i = k = l
 c2Il=           a = b = c = _ = e = x = g = h = i = k = l
 c2il=           a = b = c =_= e = x = g = h = i = k = l
 c2al=           a = b = c _= e = x = g = h = i = k = l
@@ -3527,14 +2931,6 @@ c2In=           a = b = c = d = e = x = g = _ = i = k = l
 c2in=           a = b = c = d = e = x = g =_= i = k = l
 c2an=           a = b = c = d = e = x = g _= i = k = l
 c2An=           a = b = c = d = e = x = g _i = k = l
-c2IN=           a = b = c = d = e = x = g = h = i = _ = l
-c2iN=           a = b = c = d = e = x = g = h = i =_= l
-c2aN=           a = b = c = d = e = x = g = h = i _= l
-c2AN=           a = b = c = d = e = x = g = h = i _l
-dIL=            a = b = c =  = e = x = g = h = i = k = l
-diL=            a = b = c == e = x = g = h = i = k = l
-daL=            a = b = c = e = x = g = h = i = k = l
-dAL=            a = b = c e = x = g = h = i = k = l
 dIl=            a = b = c = d =  = x = g = h = i = k = l
 dil=            a = b = c = d == x = g = h = i = k = l
 dal=            a = b = c = d = x = g = h = i = k = l
@@ -3547,14 +2943,6 @@ dIn=            a = b = c = d = e = x =  = h = i = k = l
 din=            a = b = c = d = e = x == h = i = k = l
 dan=            a = b = c = d = e = x = h = i = k = l
 dAn=            a = b = c = d = e = x h = i = k = l
-dIN=            a = b = c = d = e = x = g =  = i = k = l
-diN=            a = b = c = d = e = x = g == i = k = l
-daN=            a = b = c = d = e = x = g = i = k = l
-dAN=            a = b = c = d = e = x = g i = k = l
-d1IL=           a = b = c =  = e = x = g = h = i = k = l
-d1iL=           a = b = c == e = x = g = h = i = k = l
-d1aL=           a = b = c = e = x = g = h = i = k = l
-d1AL=           a = b = c e = x = g = h = i = k = l
 d1Il=           a = b = c = d =  = x = g = h = i = k = l
 d1il=           a = b = c = d == x = g = h = i = k = l
 d1al=           a = b = c = d = x = g = h = i = k = l
@@ -3567,14 +2955,6 @@ d1In=           a = b = c = d = e = x =  = h = i = k = l
 d1in=           a = b = c = d = e = x == h = i = k = l
 d1an=           a = b = c = d = e = x = h = i = k = l
 d1An=           a = b = c = d = e = x h = i = k = l
-d1IN=           a = b = c = d = e = x = g =  = i = k = l
-d1iN=           a = b = c = d = e = x = g == i = k = l
-d1aN=           a = b = c = d = e = x = g = i = k = l
-d1AN=           a = b = c = d = e = x = g i = k = l
-d2IL=           a =  = c = d = e = x = g = h = i = k = l
-d2iL=           a == c = d = e = x = g = h = i = k = l
-d2aL=           a = c = d = e = x = g = h = i = k = l
-d2AL=           a c = d = e = x = g = h = i = k = l
 d2Il=           a = b = c =  = e = x = g = h = i = k = l
 d2il=           a = b = c == e = x = g = h = i = k = l
 d2al=           a = b = c = e = x = g = h = i = k = l
@@ -3587,14 +2967,6 @@ d2In=           a = b = c = d = e = x = g =  = i = k = l
 d2in=           a = b = c = d = e = x = g == i = k = l
 d2an=           a = b = c = d = e = x = g = i = k = l
 d2An=           a = b = c = d = e = x = g i = k = l
-d2IN=           a = b = c = d = e = x = g = h = i =  = l
-d2iN=           a = b = c = d = e = x = g = h = i == l
-d2aN=           a = b = c = d = e = x = g = h = i = l
-d2AN=           a = b = c = d = e = x = g = h = i l
-yIL=            a = b = c = d = e = x = g = h = i = k = l       'd'
-yiL=            a = b = c = d = e = x = g = h = i = k = l       ' d '
-yaL=            a = b = c = d = e = x = g = h = i = k = l       '= d '
-yAL=            a = b = c = d = e = x = g = h = i = k = l       '= d = '
 yIl=            a = b = c = d = e = x = g = h = i = k = l       'e'
 yil=            a = b = c = d = e = x = g = h = i = k = l       ' e '
 yal=            a = b = c = d = e = x = g = h = i = k = l       '= e '
@@ -3607,14 +2979,6 @@ yIn=            a = b = c = d = e = x = g = h = i = k = l       'g'
 yin=            a = b = c = d = e = x = g = h = i = k = l       ' g '
 yan=            a = b = c = d = e = x = g = h = i = k = l       '= g '
 yAn=            a = b = c = d = e = x = g = h = i = k = l       '= g = '
-yIN=            a = b = c = d = e = x = g = h = i = k = l       'h'
-yiN=            a = b = c = d = e = x = g = h = i = k = l       ' h '
-yaN=            a = b = c = d = e = x = g = h = i = k = l       '= h '
-yAN=            a = b = c = d = e = x = g = h = i = k = l       '= h = '
-y1IL=           a = b = c = d = e = x = g = h = i = k = l       'd'
-y1iL=           a = b = c = d = e = x = g = h = i = k = l       ' d '
-y1aL=           a = b = c = d = e = x = g = h = i = k = l       '= d '
-y1AL=           a = b = c = d = e = x = g = h = i = k = l       '= d = '
 y1Il=           a = b = c = d = e = x = g = h = i = k = l       'e'
 y1il=           a = b = c = d = e = x = g = h = i = k = l       ' e '
 y1al=           a = b = c = d = e = x = g = h = i = k = l       '= e '
@@ -3627,14 +2991,6 @@ y1In=           a = b = c = d = e = x = g = h = i = k = l       'g'
 y1in=           a = b = c = d = e = x = g = h = i = k = l       ' g '
 y1an=           a = b = c = d = e = x = g = h = i = k = l       '= g '
 y1An=           a = b = c = d = e = x = g = h = i = k = l       '= g = '
-y1IN=           a = b = c = d = e = x = g = h = i = k = l       'h'
-y1iN=           a = b = c = d = e = x = g = h = i = k = l       ' h '
-y1aN=           a = b = c = d = e = x = g = h = i = k = l       '= h '
-y1AN=           a = b = c = d = e = x = g = h = i = k = l       '= h = '
-y2IL=           a = b = c = d = e = x = g = h = i = k = l       'b'
-y2iL=           a = b = c = d = e = x = g = h = i = k = l       ' b '
-y2aL=           a = b = c = d = e = x = g = h = i = k = l       '= b '
-y2AL=           a = b = c = d = e = x = g = h = i = k = l       '= b = '
 y2Il=           a = b = c = d = e = x = g = h = i = k = l       'd'
 y2il=           a = b = c = d = e = x = g = h = i = k = l       ' d '
 y2al=           a = b = c = d = e = x = g = h = i = k = l       '= d '
@@ -3647,14 +3003,6 @@ y2In=           a = b = c = d = e = x = g = h = i = k = l       'h'
 y2in=           a = b = c = d = e = x = g = h = i = k = l       ' h '
 y2an=           a = b = c = d = e = x = g = h = i = k = l       '= h '
 y2An=           a = b = c = d = e = x = g = h = i = k = l       '= h = '
-y2IN=           a = b = c = d = e = x = g = h = i = k = l       'k'
-y2iN=           a = b = c = d = e = x = g = h = i = k = l       ' k '
-y2aN=           a = b = c = d = e = x = g = h = i = k = l       '= k '
-y2AN=           a = b = c = d = e = x = g = h = i = k = l       '= k = '
-vIL=            a = b = c = _ = e = x = g = h = i = k = l
-viL=            a = b = c =___= e = x = g = h = i = k = l
-vaL=            a = b = c ____= e = x = g = h = i = k = l
-vAL=            a = b = c ______e = x = g = h = i = k = l
 vIl=            a = b = c = d = _ = x = g = h = i = k = l
 vil=            a = b = c = d =___= x = g = h = i = k = l
 val=            a = b = c = d ____= x = g = h = i = k = l
@@ -3667,14 +3015,6 @@ vIn=            a = b = c = d = e = x = _ = h = i = k = l
 vin=            a = b = c = d = e = x =___= h = i = k = l
 van=            a = b = c = d = e = x ____= h = i = k = l
 vAn=            a = b = c = d = e = x ______h = i = k = l
-vIN=            a = b = c = d = e = x = g = _ = i = k = l
-viN=            a = b = c = d = e = x = g =___= i = k = l
-vaN=            a = b = c = d = e = x = g ____= i = k = l
-vAN=            a = b = c = d = e = x = g ______i = k = l
-v1IL=           a = b = c = _ = e = x = g = h = i = k = l
-v1iL=           a = b = c =___= e = x = g = h = i = k = l
-v1aL=           a = b = c ____= e = x = g = h = i = k = l
-v1AL=           a = b = c ______e = x = g = h = i = k = l
 v1Il=           a = b = c = d = _ = x = g = h = i = k = l
 v1il=           a = b = c = d =___= x = g = h = i = k = l
 v1al=           a = b = c = d ____= x = g = h = i = k = l
@@ -3687,14 +3027,6 @@ v1In=           a = b = c = d = e = x = _ = h = i = k = l
 v1in=           a = b = c = d = e = x =___= h = i = k = l
 v1an=           a = b = c = d = e = x ____= h = i = k = l
 v1An=           a = b = c = d = e = x ______h = i = k = l
-v1IN=           a = b = c = d = e = x = g = _ = i = k = l
-v1iN=           a = b = c = d = e = x = g =___= i = k = l
-v1aN=           a = b = c = d = e = x = g ____= i = k = l
-v1AN=           a = b = c = d = e = x = g ______i = k = l
-v2IL=           a = _ = c = d = e = x = g = h = i = k = l
-v2iL=           a =___= c = d = e = x = g = h = i = k = l
-v2aL=           a ____= c = d = e = x = g = h = i = k = l
-v2AL=           a ______c = d = e = x = g = h = i = k = l
 v2Il=           a = b = c = _ = e = x = g = h = i = k = l
 v2il=           a = b = c =___= e = x = g = h = i = k = l
 v2al=           a = b = c ____= e = x = g = h = i = k = l
@@ -3707,15 +3039,7 @@ v2In=           a = b = c = d = e = x = g = _ = i = k = l
 v2in=           a = b = c = d = e = x = g =___= i = k = l
 v2an=           a = b = c = d = e = x = g ____= i = k = l
 v2An=           a = b = c = d = e = x = g ______i = k = l
-v2IN=           a = b = c = d = e = x = g = h = i = _ = l
-v2iN=           a = b = c = d = e = x = g = h = i =___= l
-v2aN=           a = b = c = d = e = x = g = h = i ____= l
-v2AN=           a = b = c = d = e = x = g = h = i ______l
 a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-cIL~            a ~ b ~ c ~ _ ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-ciL~            a ~ b ~ c ~_~ e ~ x ~ g ~ h ~ i ~ k ~ l
-caL~            a ~ b ~ c _~ e ~ x ~ g ~ h ~ i ~ k ~ l
-cAL~            a ~ b ~ c _e ~ x ~ g ~ h ~ i ~ k ~ l
 cIl~            a ~ b ~ c ~ d ~ _ ~ x ~ g ~ h ~ i ~ k ~ l
 cil~            a ~ b ~ c ~ d ~_~ x ~ g ~ h ~ i ~ k ~ l
 cal~            a ~ b ~ c ~ d _~ x ~ g ~ h ~ i ~ k ~ l
@@ -3728,14 +3052,6 @@ cIn~            a ~ b ~ c ~ d ~ e ~ x ~ _ ~ h ~ i ~ k ~ l
 cin~            a ~ b ~ c ~ d ~ e ~ x ~_~ h ~ i ~ k ~ l
 can~            a ~ b ~ c ~ d ~ e ~ x _~ h ~ i ~ k ~ l
 cAn~            a ~ b ~ c ~ d ~ e ~ x _h ~ i ~ k ~ l
-cIN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ _ ~ i ~ k ~ l
-ciN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~_~ i ~ k ~ l
-caN~            a ~ b ~ c ~ d ~ e ~ x ~ g _~ i ~ k ~ l
-cAN~            a ~ b ~ c ~ d ~ e ~ x ~ g _i ~ k ~ l
-c1IL~           a ~ b ~ c ~ _ ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-c1iL~           a ~ b ~ c ~_~ e ~ x ~ g ~ h ~ i ~ k ~ l
-c1aL~           a ~ b ~ c _~ e ~ x ~ g ~ h ~ i ~ k ~ l
-c1AL~           a ~ b ~ c _e ~ x ~ g ~ h ~ i ~ k ~ l
 c1Il~           a ~ b ~ c ~ d ~ _ ~ x ~ g ~ h ~ i ~ k ~ l
 c1il~           a ~ b ~ c ~ d ~_~ x ~ g ~ h ~ i ~ k ~ l
 c1al~           a ~ b ~ c ~ d _~ x ~ g ~ h ~ i ~ k ~ l
@@ -3748,14 +3064,6 @@ c1In~           a ~ b ~ c ~ d ~ e ~ x ~ _ ~ h ~ i ~ k ~ l
 c1in~           a ~ b ~ c ~ d ~ e ~ x ~_~ h ~ i ~ k ~ l
 c1an~           a ~ b ~ c ~ d ~ e ~ x _~ h ~ i ~ k ~ l
 c1An~           a ~ b ~ c ~ d ~ e ~ x _h ~ i ~ k ~ l
-c1IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ _ ~ i ~ k ~ l
-c1iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~_~ i ~ k ~ l
-c1aN~           a ~ b ~ c ~ d ~ e ~ x ~ g _~ i ~ k ~ l
-c1AN~           a ~ b ~ c ~ d ~ e ~ x ~ g _i ~ k ~ l
-c2IL~           a ~ _ ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-c2iL~           a ~_~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-c2aL~           a _~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-c2AL~           a _c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
 c2Il~           a ~ b ~ c ~ _ ~ e ~ x ~ g ~ h ~ i ~ k ~ l
 c2il~           a ~ b ~ c ~_~ e ~ x ~ g ~ h ~ i ~ k ~ l
 c2al~           a ~ b ~ c _~ e ~ x ~ g ~ h ~ i ~ k ~ l
@@ -3768,14 +3076,6 @@ c2In~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ _ ~ i ~ k ~ l
 c2in~           a ~ b ~ c ~ d ~ e ~ x ~ g ~_~ i ~ k ~ l
 c2an~           a ~ b ~ c ~ d ~ e ~ x ~ g _~ i ~ k ~ l
 c2An~           a ~ b ~ c ~ d ~ e ~ x ~ g _i ~ k ~ l
-c2IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ _ ~ l
-c2iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~_~ l
-c2aN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i _~ l
-c2AN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i _l
-dIL~            a ~ b ~ c ~  ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-diL~            a ~ b ~ c ~~ e ~ x ~ g ~ h ~ i ~ k ~ l
-daL~            a ~ b ~ c ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-dAL~            a ~ b ~ c e ~ x ~ g ~ h ~ i ~ k ~ l
 dIl~            a ~ b ~ c ~ d ~  ~ x ~ g ~ h ~ i ~ k ~ l
 dil~            a ~ b ~ c ~ d ~~ x ~ g ~ h ~ i ~ k ~ l
 dal~            a ~ b ~ c ~ d ~ x ~ g ~ h ~ i ~ k ~ l
@@ -3788,14 +3088,6 @@ dIn~            a ~ b ~ c ~ d ~ e ~ x ~  ~ h ~ i ~ k ~ l
 din~            a ~ b ~ c ~ d ~ e ~ x ~~ h ~ i ~ k ~ l
 dan~            a ~ b ~ c ~ d ~ e ~ x ~ h ~ i ~ k ~ l
 dAn~            a ~ b ~ c ~ d ~ e ~ x h ~ i ~ k ~ l
-dIN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~  ~ i ~ k ~ l
-diN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~~ i ~ k ~ l
-daN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ i ~ k ~ l
-dAN~            a ~ b ~ c ~ d ~ e ~ x ~ g i ~ k ~ l
-d1IL~           a ~ b ~ c ~  ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-d1iL~           a ~ b ~ c ~~ e ~ x ~ g ~ h ~ i ~ k ~ l
-d1aL~           a ~ b ~ c ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-d1AL~           a ~ b ~ c e ~ x ~ g ~ h ~ i ~ k ~ l
 d1Il~           a ~ b ~ c ~ d ~  ~ x ~ g ~ h ~ i ~ k ~ l
 d1il~           a ~ b ~ c ~ d ~~ x ~ g ~ h ~ i ~ k ~ l
 d1al~           a ~ b ~ c ~ d ~ x ~ g ~ h ~ i ~ k ~ l
@@ -3808,14 +3100,6 @@ d1In~           a ~ b ~ c ~ d ~ e ~ x ~  ~ h ~ i ~ k ~ l
 d1in~           a ~ b ~ c ~ d ~ e ~ x ~~ h ~ i ~ k ~ l
 d1an~           a ~ b ~ c ~ d ~ e ~ x ~ h ~ i ~ k ~ l
 d1An~           a ~ b ~ c ~ d ~ e ~ x h ~ i ~ k ~ l
-d1IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~  ~ i ~ k ~ l
-d1iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~~ i ~ k ~ l
-d1aN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ i ~ k ~ l
-d1AN~           a ~ b ~ c ~ d ~ e ~ x ~ g i ~ k ~ l
-d2IL~           a ~  ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-d2iL~           a ~~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-d2aL~           a ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-d2AL~           a c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
 d2Il~           a ~ b ~ c ~  ~ e ~ x ~ g ~ h ~ i ~ k ~ l
 d2il~           a ~ b ~ c ~~ e ~ x ~ g ~ h ~ i ~ k ~ l
 d2al~           a ~ b ~ c ~ e ~ x ~ g ~ h ~ i ~ k ~ l
@@ -3828,14 +3112,6 @@ d2In~           a ~ b ~ c ~ d ~ e ~ x ~ g ~  ~ i ~ k ~ l
 d2in~           a ~ b ~ c ~ d ~ e ~ x ~ g ~~ i ~ k ~ l
 d2an~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ i ~ k ~ l
 d2An~           a ~ b ~ c ~ d ~ e ~ x ~ g i ~ k ~ l
-d2IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~  ~ l
-d2iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~~ l
-d2aN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ l
-d2AN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i l
-yIL~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'd'
-yiL~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' d '
-yaL~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ d '
-yAL~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ d ~ '
 yIl~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'e'
 yil~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' e '
 yal~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ e '
@@ -3848,14 +3124,6 @@ yIn~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'g'
 yin~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' g '
 yan~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ g '
 yAn~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ g ~ '
-yIN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'h'
-yiN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' h '
-yaN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ h '
-yAN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ h ~ '
-y1IL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'd'
-y1iL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' d '
-y1aL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ d '
-y1AL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ d ~ '
 y1Il~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'e'
 y1il~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' e '
 y1al~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ e '
@@ -3868,14 +3136,6 @@ y1In~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'g'
 y1in~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' g '
 y1an~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ g '
 y1An~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ g ~ '
-y1IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'h'
-y1iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' h '
-y1aN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ h '
-y1AN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ h ~ '
-y2IL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'b'
-y2iL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' b '
-y2aL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ b '
-y2AL~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ b ~ '
 y2Il~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'd'
 y2il~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' d '
 y2al~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ d '
@@ -3888,14 +3148,6 @@ y2In~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'h'
 y2in~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' h '
 y2an~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ h '
 y2An~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ h ~ '
-y2IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       'k'
-y2iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       ' k '
-y2aN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ k '
-y2AN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l       '~ k ~ '
-vIL~            a ~ b ~ c ~ _ ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-viL~            a ~ b ~ c ~___~ e ~ x ~ g ~ h ~ i ~ k ~ l
-vaL~            a ~ b ~ c ____~ e ~ x ~ g ~ h ~ i ~ k ~ l
-vAL~            a ~ b ~ c ______e ~ x ~ g ~ h ~ i ~ k ~ l
 vIl~            a ~ b ~ c ~ d ~ _ ~ x ~ g ~ h ~ i ~ k ~ l
 vil~            a ~ b ~ c ~ d ~___~ x ~ g ~ h ~ i ~ k ~ l
 val~            a ~ b ~ c ~ d ____~ x ~ g ~ h ~ i ~ k ~ l
@@ -3908,14 +3160,6 @@ vIn~            a ~ b ~ c ~ d ~ e ~ x ~ _ ~ h ~ i ~ k ~ l
 vin~            a ~ b ~ c ~ d ~ e ~ x ~___~ h ~ i ~ k ~ l
 van~            a ~ b ~ c ~ d ~ e ~ x ____~ h ~ i ~ k ~ l
 vAn~            a ~ b ~ c ~ d ~ e ~ x ______h ~ i ~ k ~ l
-vIN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~ _ ~ i ~ k ~ l
-viN~            a ~ b ~ c ~ d ~ e ~ x ~ g ~___~ i ~ k ~ l
-vaN~            a ~ b ~ c ~ d ~ e ~ x ~ g ____~ i ~ k ~ l
-vAN~            a ~ b ~ c ~ d ~ e ~ x ~ g ______i ~ k ~ l
-v1IL~           a ~ b ~ c ~ _ ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-v1iL~           a ~ b ~ c ~___~ e ~ x ~ g ~ h ~ i ~ k ~ l
-v1aL~           a ~ b ~ c ____~ e ~ x ~ g ~ h ~ i ~ k ~ l
-v1AL~           a ~ b ~ c ______e ~ x ~ g ~ h ~ i ~ k ~ l
 v1Il~           a ~ b ~ c ~ d ~ _ ~ x ~ g ~ h ~ i ~ k ~ l
 v1il~           a ~ b ~ c ~ d ~___~ x ~ g ~ h ~ i ~ k ~ l
 v1al~           a ~ b ~ c ~ d ____~ x ~ g ~ h ~ i ~ k ~ l
@@ -3928,14 +3172,6 @@ v1In~           a ~ b ~ c ~ d ~ e ~ x ~ _ ~ h ~ i ~ k ~ l
 v1in~           a ~ b ~ c ~ d ~ e ~ x ~___~ h ~ i ~ k ~ l
 v1an~           a ~ b ~ c ~ d ~ e ~ x ____~ h ~ i ~ k ~ l
 v1An~           a ~ b ~ c ~ d ~ e ~ x ______h ~ i ~ k ~ l
-v1IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ _ ~ i ~ k ~ l
-v1iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~___~ i ~ k ~ l
-v1aN~           a ~ b ~ c ~ d ~ e ~ x ~ g ____~ i ~ k ~ l
-v1AN~           a ~ b ~ c ~ d ~ e ~ x ~ g ______i ~ k ~ l
-v2IL~           a ~ _ ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-v2iL~           a ~___~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-v2aL~           a ____~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
-v2AL~           a ______c ~ d ~ e ~ x ~ g ~ h ~ i ~ k ~ l
 v2Il~           a ~ b ~ c ~ _ ~ e ~ x ~ g ~ h ~ i ~ k ~ l
 v2il~           a ~ b ~ c ~___~ e ~ x ~ g ~ h ~ i ~ k ~ l
 v2al~           a ~ b ~ c ____~ e ~ x ~ g ~ h ~ i ~ k ~ l
@@ -3948,15 +3184,7 @@ v2In~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ _ ~ i ~ k ~ l
 v2in~           a ~ b ~ c ~ d ~ e ~ x ~ g ~___~ i ~ k ~ l
 v2an~           a ~ b ~ c ~ d ~ e ~ x ~ g ____~ i ~ k ~ l
 v2An~           a ~ b ~ c ~ d ~ e ~ x ~ g ______i ~ k ~ l
-v2IN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~ _ ~ l
-v2iN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ~___~ l
-v2aN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ____~ l
-v2AN~           a ~ b ~ c ~ d ~ e ~ x ~ g ~ h ~ i ______l
 a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l
-cIL_            a _ b _ c _ _ _ e _ x _ g _ h _ i _ k _ l
-ciL_            a _ b _ c ___ e _ x _ g _ h _ i _ k _ l
-caL_            a _ b _ c __ e _ x _ g _ h _ i _ k _ l
-cAL_            a _ b _ c _e _ x _ g _ h _ i _ k _ l
 cIl_            a _ b _ c _ d _ _ _ x _ g _ h _ i _ k _ l
 cil_            a _ b _ c _ d ___ x _ g _ h _ i _ k _ l
 cal_            a _ b _ c _ d __ x _ g _ h _ i _ k _ l
@@ -3969,14 +3197,6 @@ cIn_            a _ b _ c _ d _ e _ x _ _ _ h _ i _ k _ l
 cin_            a _ b _ c _ d _ e _ x ___ h _ i _ k _ l
 can_            a _ b _ c _ d _ e _ x __ h _ i _ k _ l
 cAn_            a _ b _ c _ d _ e _ x _h _ i _ k _ l
-cIN_            a _ b _ c _ d _ e _ x _ g _ _ _ i _ k _ l
-ciN_            a _ b _ c _ d _ e _ x _ g ___ i _ k _ l
-caN_            a _ b _ c _ d _ e _ x _ g __ i _ k _ l
-cAN_            a _ b _ c _ d _ e _ x _ g _i _ k _ l
-c1IL_           a _ b _ c _ _ _ e _ x _ g _ h _ i _ k _ l
-c1iL_           a _ b _ c ___ e _ x _ g _ h _ i _ k _ l
-c1aL_           a _ b _ c __ e _ x _ g _ h _ i _ k _ l
-c1AL_           a _ b _ c _e _ x _ g _ h _ i _ k _ l
 c1Il_           a _ b _ c _ d _ _ _ x _ g _ h _ i _ k _ l
 c1il_           a _ b _ c _ d ___ x _ g _ h _ i _ k _ l
 c1al_           a _ b _ c _ d __ x _ g _ h _ i _ k _ l
@@ -3989,14 +3209,6 @@ c1In_           a _ b _ c _ d _ e _ x _ _ _ h _ i _ k _ l
 c1in_           a _ b _ c _ d _ e _ x ___ h _ i _ k _ l
 c1an_           a _ b _ c _ d _ e _ x __ h _ i _ k _ l
 c1An_           a _ b _ c _ d _ e _ x _h _ i _ k _ l
-c1IN_           a _ b _ c _ d _ e _ x _ g _ _ _ i _ k _ l
-c1iN_           a _ b _ c _ d _ e _ x _ g ___ i _ k _ l
-c1aN_           a _ b _ c _ d _ e _ x _ g __ i _ k _ l
-c1AN_           a _ b _ c _ d _ e _ x _ g _i _ k _ l
-c2IL_           a _ _ _ c _ d _ e _ x _ g _ h _ i _ k _ l
-c2iL_           a ___ c _ d _ e _ x _ g _ h _ i _ k _ l
-c2aL_           a __ c _ d _ e _ x _ g _ h _ i _ k _ l
-c2AL_           a _c _ d _ e _ x _ g _ h _ i _ k _ l
 c2Il_           a _ b _ c _ _ _ e _ x _ g _ h _ i _ k _ l
 c2il_           a _ b _ c ___ e _ x _ g _ h _ i _ k _ l
 c2al_           a _ b _ c __ e _ x _ g _ h _ i _ k _ l
@@ -4009,14 +3221,6 @@ c2In_           a _ b _ c _ d _ e _ x _ g _ _ _ i _ k _ l
 c2in_           a _ b _ c _ d _ e _ x _ g ___ i _ k _ l
 c2an_           a _ b _ c _ d _ e _ x _ g __ i _ k _ l
 c2An_           a _ b _ c _ d _ e _ x _ g _i _ k _ l
-c2IN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ _ _ l
-c2iN_           a _ b _ c _ d _ e _ x _ g _ h _ i ___ l
-c2aN_           a _ b _ c _ d _ e _ x _ g _ h _ i __ l
-c2AN_           a _ b _ c _ d _ e _ x _ g _ h _ i _l
-dIL_            a _ b _ c _  _ e _ x _ g _ h _ i _ k _ l
-diL_            a _ b _ c __ e _ x _ g _ h _ i _ k _ l
-daL_            a _ b _ c _ e _ x _ g _ h _ i _ k _ l
-dAL_            a _ b _ c e _ x _ g _ h _ i _ k _ l
 dIl_            a _ b _ c _ d _  _ x _ g _ h _ i _ k _ l
 dil_            a _ b _ c _ d __ x _ g _ h _ i _ k _ l
 dal_            a _ b _ c _ d _ x _ g _ h _ i _ k _ l
@@ -4029,14 +3233,6 @@ dIn_            a _ b _ c _ d _ e _ x _  _ h _ i _ k _ l
 din_            a _ b _ c _ d _ e _ x __ h _ i _ k _ l
 dan_            a _ b _ c _ d _ e _ x _ h _ i _ k _ l
 dAn_            a _ b _ c _ d _ e _ x h _ i _ k _ l
-dIN_            a _ b _ c _ d _ e _ x _ g _  _ i _ k _ l
-diN_            a _ b _ c _ d _ e _ x _ g __ i _ k _ l
-daN_            a _ b _ c _ d _ e _ x _ g _ i _ k _ l
-dAN_            a _ b _ c _ d _ e _ x _ g i _ k _ l
-d1IL_           a _ b _ c _  _ e _ x _ g _ h _ i _ k _ l
-d1iL_           a _ b _ c __ e _ x _ g _ h _ i _ k _ l
-d1aL_           a _ b _ c _ e _ x _ g _ h _ i _ k _ l
-d1AL_           a _ b _ c e _ x _ g _ h _ i _ k _ l
 d1Il_           a _ b _ c _ d _  _ x _ g _ h _ i _ k _ l
 d1il_           a _ b _ c _ d __ x _ g _ h _ i _ k _ l
 d1al_           a _ b _ c _ d _ x _ g _ h _ i _ k _ l
@@ -4049,14 +3245,6 @@ d1In_           a _ b _ c _ d _ e _ x _  _ h _ i _ k _ l
 d1in_           a _ b _ c _ d _ e _ x __ h _ i _ k _ l
 d1an_           a _ b _ c _ d _ e _ x _ h _ i _ k _ l
 d1An_           a _ b _ c _ d _ e _ x h _ i _ k _ l
-d1IN_           a _ b _ c _ d _ e _ x _ g _  _ i _ k _ l
-d1iN_           a _ b _ c _ d _ e _ x _ g __ i _ k _ l
-d1aN_           a _ b _ c _ d _ e _ x _ g _ i _ k _ l
-d1AN_           a _ b _ c _ d _ e _ x _ g i _ k _ l
-d2IL_           a _  _ c _ d _ e _ x _ g _ h _ i _ k _ l
-d2iL_           a __ c _ d _ e _ x _ g _ h _ i _ k _ l
-d2aL_           a _ c _ d _ e _ x _ g _ h _ i _ k _ l
-d2AL_           a c _ d _ e _ x _ g _ h _ i _ k _ l
 d2Il_           a _ b _ c _  _ e _ x _ g _ h _ i _ k _ l
 d2il_           a _ b _ c __ e _ x _ g _ h _ i _ k _ l
 d2al_           a _ b _ c _ e _ x _ g _ h _ i _ k _ l
@@ -4069,14 +3257,6 @@ d2In_           a _ b _ c _ d _ e _ x _ g _  _ i _ k _ l
 d2in_           a _ b _ c _ d _ e _ x _ g __ i _ k _ l
 d2an_           a _ b _ c _ d _ e _ x _ g _ i _ k _ l
 d2An_           a _ b _ c _ d _ e _ x _ g i _ k _ l
-d2IN_           a _ b _ c _ d _ e _ x _ g _ h _ i _  _ l
-d2iN_           a _ b _ c _ d _ e _ x _ g _ h _ i __ l
-d2aN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ l
-d2AN_           a _ b _ c _ d _ e _ x _ g _ h _ i l
-yIL_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'd'
-yiL_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' d '
-yaL_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ d '
-yAL_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ d _ '
 yIl_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'e'
 yil_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' e '
 yal_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ e '
@@ -4089,14 +3269,6 @@ yIn_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'g'
 yin_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' g '
 yan_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ g '
 yAn_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ g _ '
-yIN_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'h'
-yiN_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' h '
-yaN_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ h '
-yAN_            a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ h _ '
-y1IL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'd'
-y1iL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' d '
-y1aL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ d '
-y1AL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ d _ '
 y1Il_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'e'
 y1il_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' e '
 y1al_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ e '
@@ -4109,14 +3281,6 @@ y1In_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'g'
 y1in_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' g '
 y1an_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ g '
 y1An_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ g _ '
-y1IN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'h'
-y1iN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' h '
-y1aN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ h '
-y1AN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ h _ '
-y2IL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'b'
-y2iL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' b '
-y2aL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ b '
-y2AL_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ b _ '
 y2Il_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'd'
 y2il_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' d '
 y2al_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ d '
@@ -4129,14 +3293,6 @@ y2In_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'h'
 y2in_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' h '
 y2an_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ h '
 y2An_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ h _ '
-y2IN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       'k'
-y2iN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       ' k '
-y2aN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ k '
-y2AN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ k _ l       '_ k _ '
-vIL_            a _ b _ c _ _ _ e _ x _ g _ h _ i _ k _ l
-viL_            a _ b _ c _____ e _ x _ g _ h _ i _ k _ l
-vaL_            a _ b _ c _____ e _ x _ g _ h _ i _ k _ l
-vAL_            a _ b _ c ______e _ x _ g _ h _ i _ k _ l
 vIl_            a _ b _ c _ d _ _ _ x _ g _ h _ i _ k _ l
 vil_            a _ b _ c _ d _____ x _ g _ h _ i _ k _ l
 val_            a _ b _ c _ d _____ x _ g _ h _ i _ k _ l
@@ -4149,14 +3305,6 @@ vIn_            a _ b _ c _ d _ e _ x _ _ _ h _ i _ k _ l
 vin_            a _ b _ c _ d _ e _ x _____ h _ i _ k _ l
 van_            a _ b _ c _ d _ e _ x _____ h _ i _ k _ l
 vAn_            a _ b _ c _ d _ e _ x ______h _ i _ k _ l
-vIN_            a _ b _ c _ d _ e _ x _ g _ _ _ i _ k _ l
-viN_            a _ b _ c _ d _ e _ x _ g _____ i _ k _ l
-vaN_            a _ b _ c _ d _ e _ x _ g _____ i _ k _ l
-vAN_            a _ b _ c _ d _ e _ x _ g ______i _ k _ l
-v1IL_           a _ b _ c _ _ _ e _ x _ g _ h _ i _ k _ l
-v1iL_           a _ b _ c _____ e _ x _ g _ h _ i _ k _ l
-v1aL_           a _ b _ c _____ e _ x _ g _ h _ i _ k _ l
-v1AL_           a _ b _ c ______e _ x _ g _ h _ i _ k _ l
 v1Il_           a _ b _ c _ d _ _ _ x _ g _ h _ i _ k _ l
 v1il_           a _ b _ c _ d _____ x _ g _ h _ i _ k _ l
 v1al_           a _ b _ c _ d _____ x _ g _ h _ i _ k _ l
@@ -4169,14 +3317,6 @@ v1In_           a _ b _ c _ d _ e _ x _ _ _ h _ i _ k _ l
 v1in_           a _ b _ c _ d _ e _ x _____ h _ i _ k _ l
 v1an_           a _ b _ c _ d _ e _ x _____ h _ i _ k _ l
 v1An_           a _ b _ c _ d _ e _ x ______h _ i _ k _ l
-v1IN_           a _ b _ c _ d _ e _ x _ g _ _ _ i _ k _ l
-v1iN_           a _ b _ c _ d _ e _ x _ g _____ i _ k _ l
-v1aN_           a _ b _ c _ d _ e _ x _ g _____ i _ k _ l
-v1AN_           a _ b _ c _ d _ e _ x _ g ______i _ k _ l
-v2IL_           a _ _ _ c _ d _ e _ x _ g _ h _ i _ k _ l
-v2iL_           a _____ c _ d _ e _ x _ g _ h _ i _ k _ l
-v2aL_           a _____ c _ d _ e _ x _ g _ h _ i _ k _ l
-v2AL_           a ______c _ d _ e _ x _ g _ h _ i _ k _ l
 v2Il_           a _ b _ c _ _ _ e _ x _ g _ h _ i _ k _ l
 v2il_           a _ b _ c _____ e _ x _ g _ h _ i _ k _ l
 v2al_           a _ b _ c _____ e _ x _ g _ h _ i _ k _ l
@@ -4189,15 +3329,7 @@ v2In_           a _ b _ c _ d _ e _ x _ g _ _ _ i _ k _ l
 v2in_           a _ b _ c _ d _ e _ x _ g _____ i _ k _ l
 v2an_           a _ b _ c _ d _ e _ x _ g _____ i _ k _ l
 v2An_           a _ b _ c _ d _ e _ x _ g ______i _ k _ l
-v2IN_           a _ b _ c _ d _ e _ x _ g _ h _ i _ _ _ l
-v2iN_           a _ b _ c _ d _ e _ x _ g _ h _ i _____ l
-v2aN_           a _ b _ c _ d _ e _ x _ g _ h _ i _____ l
-v2AN_           a _ b _ c _ d _ e _ x _ g _ h _ i ______l
 a * b * c * d * e * x * g * h * i * k * l
-cIL*            a * b * c * _ * e * x * g * h * i * k * l
-ciL*            a * b * c *_* e * x * g * h * i * k * l
-caL*            a * b * c _* e * x * g * h * i * k * l
-cAL*            a * b * c _e * x * g * h * i * k * l
 cIl*            a * b * c * d * _ * x * g * h * i * k * l
 cil*            a * b * c * d *_* x * g * h * i * k * l
 cal*            a * b * c * d _* x * g * h * i * k * l
@@ -4210,14 +3342,6 @@ cIn*            a * b * c * d * e * x * _ * h * i * k * l
 cin*            a * b * c * d * e * x *_* h * i * k * l
 can*            a * b * c * d * e * x _* h * i * k * l
 cAn*            a * b * c * d * e * x _h * i * k * l
-cIN*            a * b * c * d * e * x * g * _ * i * k * l
-ciN*            a * b * c * d * e * x * g *_* i * k * l
-caN*            a * b * c * d * e * x * g _* i * k * l
-cAN*            a * b * c * d * e * x * g _i * k * l
-c1IL*           a * b * c * _ * e * x * g * h * i * k * l
-c1iL*           a * b * c *_* e * x * g * h * i * k * l
-c1aL*           a * b * c _* e * x * g * h * i * k * l
-c1AL*           a * b * c _e * x * g * h * i * k * l
 c1Il*           a * b * c * d * _ * x * g * h * i * k * l
 c1il*           a * b * c * d *_* x * g * h * i * k * l
 c1al*           a * b * c * d _* x * g * h * i * k * l
@@ -4230,14 +3354,6 @@ c1In*           a * b * c * d * e * x * _ * h * i * k * l
 c1in*           a * b * c * d * e * x *_* h * i * k * l
 c1an*           a * b * c * d * e * x _* h * i * k * l
 c1An*           a * b * c * d * e * x _h * i * k * l
-c1IN*           a * b * c * d * e * x * g * _ * i * k * l
-c1iN*           a * b * c * d * e * x * g *_* i * k * l
-c1aN*           a * b * c * d * e * x * g _* i * k * l
-c1AN*           a * b * c * d * e * x * g _i * k * l
-c2IL*           a * _ * c * d * e * x * g * h * i * k * l
-c2iL*           a *_* c * d * e * x * g * h * i * k * l
-c2aL*           a _* c * d * e * x * g * h * i * k * l
-c2AL*           a _c * d * e * x * g * h * i * k * l
 c2Il*           a * b * c * _ * e * x * g * h * i * k * l
 c2il*           a * b * c *_* e * x * g * h * i * k * l
 c2al*           a * b * c _* e * x * g * h * i * k * l
@@ -4250,14 +3366,6 @@ c2In*           a * b * c * d * e * x * g * _ * i * k * l
 c2in*           a * b * c * d * e * x * g *_* i * k * l
 c2an*           a * b * c * d * e * x * g _* i * k * l
 c2An*           a * b * c * d * e * x * g _i * k * l
-c2IN*           a * b * c * d * e * x * g * h * i * _ * l
-c2iN*           a * b * c * d * e * x * g * h * i *_* l
-c2aN*           a * b * c * d * e * x * g * h * i _* l
-c2AN*           a * b * c * d * e * x * g * h * i _l
-dIL*            a * b * c *  * e * x * g * h * i * k * l
-diL*            a * b * c ** e * x * g * h * i * k * l
-daL*            a * b * c * e * x * g * h * i * k * l
-dAL*            a * b * c e * x * g * h * i * k * l
 dIl*            a * b * c * d *  * x * g * h * i * k * l
 dil*            a * b * c * d ** x * g * h * i * k * l
 dal*            a * b * c * d * x * g * h * i * k * l
@@ -4270,14 +3378,6 @@ dIn*            a * b * c * d * e * x *  * h * i * k * l
 din*            a * b * c * d * e * x ** h * i * k * l
 dan*            a * b * c * d * e * x * h * i * k * l
 dAn*            a * b * c * d * e * x h * i * k * l
-dIN*            a * b * c * d * e * x * g *  * i * k * l
-diN*            a * b * c * d * e * x * g ** i * k * l
-daN*            a * b * c * d * e * x * g * i * k * l
-dAN*            a * b * c * d * e * x * g i * k * l
-d1IL*           a * b * c *  * e * x * g * h * i * k * l
-d1iL*           a * b * c ** e * x * g * h * i * k * l
-d1aL*           a * b * c * e * x * g * h * i * k * l
-d1AL*           a * b * c e * x * g * h * i * k * l
 d1Il*           a * b * c * d *  * x * g * h * i * k * l
 d1il*           a * b * c * d ** x * g * h * i * k * l
 d1al*           a * b * c * d * x * g * h * i * k * l
@@ -4290,14 +3390,6 @@ d1In*           a * b * c * d * e * x *  * h * i * k * l
 d1in*           a * b * c * d * e * x ** h * i * k * l
 d1an*           a * b * c * d * e * x * h * i * k * l
 d1An*           a * b * c * d * e * x h * i * k * l
-d1IN*           a * b * c * d * e * x * g *  * i * k * l
-d1iN*           a * b * c * d * e * x * g ** i * k * l
-d1aN*           a * b * c * d * e * x * g * i * k * l
-d1AN*           a * b * c * d * e * x * g i * k * l
-d2IL*           a *  * c * d * e * x * g * h * i * k * l
-d2iL*           a ** c * d * e * x * g * h * i * k * l
-d2aL*           a * c * d * e * x * g * h * i * k * l
-d2AL*           a c * d * e * x * g * h * i * k * l
 d2Il*           a * b * c *  * e * x * g * h * i * k * l
 d2il*           a * b * c ** e * x * g * h * i * k * l
 d2al*           a * b * c * e * x * g * h * i * k * l
@@ -4310,14 +3402,6 @@ d2In*           a * b * c * d * e * x * g *  * i * k * l
 d2in*           a * b * c * d * e * x * g ** i * k * l
 d2an*           a * b * c * d * e * x * g * i * k * l
 d2An*           a * b * c * d * e * x * g i * k * l
-d2IN*           a * b * c * d * e * x * g * h * i *  * l
-d2iN*           a * b * c * d * e * x * g * h * i ** l
-d2aN*           a * b * c * d * e * x * g * h * i * l
-d2AN*           a * b * c * d * e * x * g * h * i l
-yIL*            a * b * c * d * e * x * g * h * i * k * l       'd'
-yiL*            a * b * c * d * e * x * g * h * i * k * l       ' d '
-yaL*            a * b * c * d * e * x * g * h * i * k * l       '* d '
-yAL*            a * b * c * d * e * x * g * h * i * k * l       '* d * '
 yIl*            a * b * c * d * e * x * g * h * i * k * l       'e'
 yil*            a * b * c * d * e * x * g * h * i * k * l       ' e '
 yal*            a * b * c * d * e * x * g * h * i * k * l       '* e '
@@ -4330,14 +3414,6 @@ yIn*            a * b * c * d * e * x * g * h * i * k * l       'g'
 yin*            a * b * c * d * e * x * g * h * i * k * l       ' g '
 yan*            a * b * c * d * e * x * g * h * i * k * l       '* g '
 yAn*            a * b * c * d * e * x * g * h * i * k * l       '* g * '
-yIN*            a * b * c * d * e * x * g * h * i * k * l       'h'
-yiN*            a * b * c * d * e * x * g * h * i * k * l       ' h '
-yaN*            a * b * c * d * e * x * g * h * i * k * l       '* h '
-yAN*            a * b * c * d * e * x * g * h * i * k * l       '* h * '
-y1IL*           a * b * c * d * e * x * g * h * i * k * l       'd'
-y1iL*           a * b * c * d * e * x * g * h * i * k * l       ' d '
-y1aL*           a * b * c * d * e * x * g * h * i * k * l       '* d '
-y1AL*           a * b * c * d * e * x * g * h * i * k * l       '* d * '
 y1Il*           a * b * c * d * e * x * g * h * i * k * l       'e'
 y1il*           a * b * c * d * e * x * g * h * i * k * l       ' e '
 y1al*           a * b * c * d * e * x * g * h * i * k * l       '* e '
@@ -4350,14 +3426,6 @@ y1In*           a * b * c * d * e * x * g * h * i * k * l       'g'
 y1in*           a * b * c * d * e * x * g * h * i * k * l       ' g '
 y1an*           a * b * c * d * e * x * g * h * i * k * l       '* g '
 y1An*           a * b * c * d * e * x * g * h * i * k * l       '* g * '
-y1IN*           a * b * c * d * e * x * g * h * i * k * l       'h'
-y1iN*           a * b * c * d * e * x * g * h * i * k * l       ' h '
-y1aN*           a * b * c * d * e * x * g * h * i * k * l       '* h '
-y1AN*           a * b * c * d * e * x * g * h * i * k * l       '* h * '
-y2IL*           a * b * c * d * e * x * g * h * i * k * l       'b'
-y2iL*           a * b * c * d * e * x * g * h * i * k * l       ' b '
-y2aL*           a * b * c * d * e * x * g * h * i * k * l       '* b '
-y2AL*           a * b * c * d * e * x * g * h * i * k * l       '* b * '
 y2Il*           a * b * c * d * e * x * g * h * i * k * l       'd'
 y2il*           a * b * c * d * e * x * g * h * i * k * l       ' d '
 y2al*           a * b * c * d * e * x * g * h * i * k * l       '* d '
@@ -4370,14 +3438,6 @@ y2In*           a * b * c * d * e * x * g * h * i * k * l       'h'
 y2in*           a * b * c * d * e * x * g * h * i * k * l       ' h '
 y2an*           a * b * c * d * e * x * g * h * i * k * l       '* h '
 y2An*           a * b * c * d * e * x * g * h * i * k * l       '* h * '
-y2IN*           a * b * c * d * e * x * g * h * i * k * l       'k'
-y2iN*           a * b * c * d * e * x * g * h * i * k * l       ' k '
-y2aN*           a * b * c * d * e * x * g * h * i * k * l       '* k '
-y2AN*           a * b * c * d * e * x * g * h * i * k * l       '* k * '
-vIL*            a * b * c * _ * e * x * g * h * i * k * l
-viL*            a * b * c *___* e * x * g * h * i * k * l
-vaL*            a * b * c ____* e * x * g * h * i * k * l
-vAL*            a * b * c ______e * x * g * h * i * k * l
 vIl*            a * b * c * d * _ * x * g * h * i * k * l
 vil*            a * b * c * d *___* x * g * h * i * k * l
 val*            a * b * c * d ____* x * g * h * i * k * l
@@ -4390,14 +3450,6 @@ vIn*            a * b * c * d * e * x * _ * h * i * k * l
 vin*            a * b * c * d * e * x *___* h * i * k * l
 van*            a * b * c * d * e * x ____* h * i * k * l
 vAn*            a * b * c * d * e * x ______h * i * k * l
-vIN*            a * b * c * d * e * x * g * _ * i * k * l
-viN*            a * b * c * d * e * x * g *___* i * k * l
-vaN*            a * b * c * d * e * x * g ____* i * k * l
-vAN*            a * b * c * d * e * x * g ______i * k * l
-v1IL*           a * b * c * _ * e * x * g * h * i * k * l
-v1iL*           a * b * c *___* e * x * g * h * i * k * l
-v1aL*           a * b * c ____* e * x * g * h * i * k * l
-v1AL*           a * b * c ______e * x * g * h * i * k * l
 v1Il*           a * b * c * d * _ * x * g * h * i * k * l
 v1il*           a * b * c * d *___* x * g * h * i * k * l
 v1al*           a * b * c * d ____* x * g * h * i * k * l
@@ -4410,14 +3462,6 @@ v1In*           a * b * c * d * e * x * _ * h * i * k * l
 v1in*           a * b * c * d * e * x *___* h * i * k * l
 v1an*           a * b * c * d * e * x ____* h * i * k * l
 v1An*           a * b * c * d * e * x ______h * i * k * l
-v1IN*           a * b * c * d * e * x * g * _ * i * k * l
-v1iN*           a * b * c * d * e * x * g *___* i * k * l
-v1aN*           a * b * c * d * e * x * g ____* i * k * l
-v1AN*           a * b * c * d * e * x * g ______i * k * l
-v2IL*           a * _ * c * d * e * x * g * h * i * k * l
-v2iL*           a *___* c * d * e * x * g * h * i * k * l
-v2aL*           a ____* c * d * e * x * g * h * i * k * l
-v2AL*           a ______c * d * e * x * g * h * i * k * l
 v2Il*           a * b * c * _ * e * x * g * h * i * k * l
 v2il*           a * b * c *___* e * x * g * h * i * k * l
 v2al*           a * b * c ____* e * x * g * h * i * k * l
@@ -4430,15 +3474,7 @@ v2In*           a * b * c * d * e * x * g * _ * i * k * l
 v2in*           a * b * c * d * e * x * g *___* i * k * l
 v2an*           a * b * c * d * e * x * g ____* i * k * l
 v2An*           a * b * c * d * e * x * g ______i * k * l
-v2IN*           a * b * c * d * e * x * g * h * i * _ * l
-v2iN*           a * b * c * d * e * x * g * h * i *___* l
-v2aN*           a * b * c * d * e * x * g * h * i ____* l
-v2AN*           a * b * c * d * e * x * g * h * i ______l
 a # b # c # d # e # x # g # h # i # k # l
-cIL#            a # b # c # _ # e # x # g # h # i # k # l
-ciL#            a # b # c #_# e # x # g # h # i # k # l
-caL#            a # b # c _# e # x # g # h # i # k # l
-cAL#            a # b # c _e # x # g # h # i # k # l
 cIl#            a # b # c # d # _ # x # g # h # i # k # l
 cil#            a # b # c # d #_# x # g # h # i # k # l
 cal#            a # b # c # d _# x # g # h # i # k # l
@@ -4451,14 +3487,6 @@ cIn#            a # b # c # d # e # x # _ # h # i # k # l
 cin#            a # b # c # d # e # x #_# h # i # k # l
 can#            a # b # c # d # e # x _# h # i # k # l
 cAn#            a # b # c # d # e # x _h # i # k # l
-cIN#            a # b # c # d # e # x # g # _ # i # k # l
-ciN#            a # b # c # d # e # x # g #_# i # k # l
-caN#            a # b # c # d # e # x # g _# i # k # l
-cAN#            a # b # c # d # e # x # g _i # k # l
-c1IL#           a # b # c # _ # e # x # g # h # i # k # l
-c1iL#           a # b # c #_# e # x # g # h # i # k # l
-c1aL#           a # b # c _# e # x # g # h # i # k # l
-c1AL#           a # b # c _e # x # g # h # i # k # l
 c1Il#           a # b # c # d # _ # x # g # h # i # k # l
 c1il#           a # b # c # d #_# x # g # h # i # k # l
 c1al#           a # b # c # d _# x # g # h # i # k # l
@@ -4471,14 +3499,6 @@ c1In#           a # b # c # d # e # x # _ # h # i # k # l
 c1in#           a # b # c # d # e # x #_# h # i # k # l
 c1an#           a # b # c # d # e # x _# h # i # k # l
 c1An#           a # b # c # d # e # x _h # i # k # l
-c1IN#           a # b # c # d # e # x # g # _ # i # k # l
-c1iN#           a # b # c # d # e # x # g #_# i # k # l
-c1aN#           a # b # c # d # e # x # g _# i # k # l
-c1AN#           a # b # c # d # e # x # g _i # k # l
-c2IL#           a # _ # c # d # e # x # g # h # i # k # l
-c2iL#           a #_# c # d # e # x # g # h # i # k # l
-c2aL#           a _# c # d # e # x # g # h # i # k # l
-c2AL#           a _c # d # e # x # g # h # i # k # l
 c2Il#           a # b # c # _ # e # x # g # h # i # k # l
 c2il#           a # b # c #_# e # x # g # h # i # k # l
 c2al#           a # b # c _# e # x # g # h # i # k # l
@@ -4491,14 +3511,6 @@ c2In#           a # b # c # d # e # x # g # _ # i # k # l
 c2in#           a # b # c # d # e # x # g #_# i # k # l
 c2an#           a # b # c # d # e # x # g _# i # k # l
 c2An#           a # b # c # d # e # x # g _i # k # l
-c2IN#           a # b # c # d # e # x # g # h # i # _ # l
-c2iN#           a # b # c # d # e # x # g # h # i #_# l
-c2aN#           a # b # c # d # e # x # g # h # i _# l
-c2AN#           a # b # c # d # e # x # g # h # i _l
-dIL#            a # b # c #  # e # x # g # h # i # k # l
-diL#            a # b # c ## e # x # g # h # i # k # l
-daL#            a # b # c # e # x # g # h # i # k # l
-dAL#            a # b # c e # x # g # h # i # k # l
 dIl#            a # b # c # d #  # x # g # h # i # k # l
 dil#            a # b # c # d ## x # g # h # i # k # l
 dal#            a # b # c # d # x # g # h # i # k # l
@@ -4511,14 +3523,6 @@ dIn#            a # b # c # d # e # x #  # h # i # k # l
 din#            a # b # c # d # e # x ## h # i # k # l
 dan#            a # b # c # d # e # x # h # i # k # l
 dAn#            a # b # c # d # e # x h # i # k # l
-dIN#            a # b # c # d # e # x # g #  # i # k # l
-diN#            a # b # c # d # e # x # g ## i # k # l
-daN#            a # b # c # d # e # x # g # i # k # l
-dAN#            a # b # c # d # e # x # g i # k # l
-d1IL#           a # b # c #  # e # x # g # h # i # k # l
-d1iL#           a # b # c ## e # x # g # h # i # k # l
-d1aL#           a # b # c # e # x # g # h # i # k # l
-d1AL#           a # b # c e # x # g # h # i # k # l
 d1Il#           a # b # c # d #  # x # g # h # i # k # l
 d1il#           a # b # c # d ## x # g # h # i # k # l
 d1al#           a # b # c # d # x # g # h # i # k # l
@@ -4531,14 +3535,6 @@ d1In#           a # b # c # d # e # x #  # h # i # k # l
 d1in#           a # b # c # d # e # x ## h # i # k # l
 d1an#           a # b # c # d # e # x # h # i # k # l
 d1An#           a # b # c # d # e # x h # i # k # l
-d1IN#           a # b # c # d # e # x # g #  # i # k # l
-d1iN#           a # b # c # d # e # x # g ## i # k # l
-d1aN#           a # b # c # d # e # x # g # i # k # l
-d1AN#           a # b # c # d # e # x # g i # k # l
-d2IL#           a #  # c # d # e # x # g # h # i # k # l
-d2iL#           a ## c # d # e # x # g # h # i # k # l
-d2aL#           a # c # d # e # x # g # h # i # k # l
-d2AL#           a c # d # e # x # g # h # i # k # l
 d2Il#           a # b # c #  # e # x # g # h # i # k # l
 d2il#           a # b # c ## e # x # g # h # i # k # l
 d2al#           a # b # c # e # x # g # h # i # k # l
@@ -4551,14 +3547,6 @@ d2In#           a # b # c # d # e # x # g #  # i # k # l
 d2in#           a # b # c # d # e # x # g ## i # k # l
 d2an#           a # b # c # d # e # x # g # i # k # l
 d2An#           a # b # c # d # e # x # g i # k # l
-d2IN#           a # b # c # d # e # x # g # h # i #  # l
-d2iN#           a # b # c # d # e # x # g # h # i ## l
-d2aN#           a # b # c # d # e # x # g # h # i # l
-d2AN#           a # b # c # d # e # x # g # h # i l
-yIL#            a # b # c # d # e # x # g # h # i # k # l       'd'
-yiL#            a # b # c # d # e # x # g # h # i # k # l       ' d '
-yaL#            a # b # c # d # e # x # g # h # i # k # l       '# d '
-yAL#            a # b # c # d # e # x # g # h # i # k # l       '# d # '
 yIl#            a # b # c # d # e # x # g # h # i # k # l       'e'
 yil#            a # b # c # d # e # x # g # h # i # k # l       ' e '
 yal#            a # b # c # d # e # x # g # h # i # k # l       '# e '
@@ -4571,14 +3559,6 @@ yIn#            a # b # c # d # e # x # g # h # i # k # l       'g'
 yin#            a # b # c # d # e # x # g # h # i # k # l       ' g '
 yan#            a # b # c # d # e # x # g # h # i # k # l       '# g '
 yAn#            a # b # c # d # e # x # g # h # i # k # l       '# g # '
-yIN#            a # b # c # d # e # x # g # h # i # k # l       'h'
-yiN#            a # b # c # d # e # x # g # h # i # k # l       ' h '
-yaN#            a # b # c # d # e # x # g # h # i # k # l       '# h '
-yAN#            a # b # c # d # e # x # g # h # i # k # l       '# h # '
-y1IL#           a # b # c # d # e # x # g # h # i # k # l       'd'
-y1iL#           a # b # c # d # e # x # g # h # i # k # l       ' d '
-y1aL#           a # b # c # d # e # x # g # h # i # k # l       '# d '
-y1AL#           a # b # c # d # e # x # g # h # i # k # l       '# d # '
 y1Il#           a # b # c # d # e # x # g # h # i # k # l       'e'
 y1il#           a # b # c # d # e # x # g # h # i # k # l       ' e '
 y1al#           a # b # c # d # e # x # g # h # i # k # l       '# e '
@@ -4591,14 +3571,6 @@ y1In#           a # b # c # d # e # x # g # h # i # k # l       'g'
 y1in#           a # b # c # d # e # x # g # h # i # k # l       ' g '
 y1an#           a # b # c # d # e # x # g # h # i # k # l       '# g '
 y1An#           a # b # c # d # e # x # g # h # i # k # l       '# g # '
-y1IN#           a # b # c # d # e # x # g # h # i # k # l       'h'
-y1iN#           a # b # c # d # e # x # g # h # i # k # l       ' h '
-y1aN#           a # b # c # d # e # x # g # h # i # k # l       '# h '
-y1AN#           a # b # c # d # e # x # g # h # i # k # l       '# h # '
-y2IL#           a # b # c # d # e # x # g # h # i # k # l       'b'
-y2iL#           a # b # c # d # e # x # g # h # i # k # l       ' b '
-y2aL#           a # b # c # d # e # x # g # h # i # k # l       '# b '
-y2AL#           a # b # c # d # e # x # g # h # i # k # l       '# b # '
 y2Il#           a # b # c # d # e # x # g # h # i # k # l       'd'
 y2il#           a # b # c # d # e # x # g # h # i # k # l       ' d '
 y2al#           a # b # c # d # e # x # g # h # i # k # l       '# d '
@@ -4611,14 +3583,6 @@ y2In#           a # b # c # d # e # x # g # h # i # k # l       'h'
 y2in#           a # b # c # d # e # x # g # h # i # k # l       ' h '
 y2an#           a # b # c # d # e # x # g # h # i # k # l       '# h '
 y2An#           a # b # c # d # e # x # g # h # i # k # l       '# h # '
-y2IN#           a # b # c # d # e # x # g # h # i # k # l       'k'
-y2iN#           a # b # c # d # e # x # g # h # i # k # l       ' k '
-y2aN#           a # b # c # d # e # x # g # h # i # k # l       '# k '
-y2AN#           a # b # c # d # e # x # g # h # i # k # l       '# k # '
-vIL#            a # b # c # _ # e # x # g # h # i # k # l
-viL#            a # b # c #___# e # x # g # h # i # k # l
-vaL#            a # b # c ____# e # x # g # h # i # k # l
-vAL#            a # b # c ______e # x # g # h # i # k # l
 vIl#            a # b # c # d # _ # x # g # h # i # k # l
 vil#            a # b # c # d #___# x # g # h # i # k # l
 val#            a # b # c # d ____# x # g # h # i # k # l
@@ -4631,14 +3595,6 @@ vIn#            a # b # c # d # e # x # _ # h # i # k # l
 vin#            a # b # c # d # e # x #___# h # i # k # l
 van#            a # b # c # d # e # x ____# h # i # k # l
 vAn#            a # b # c # d # e # x ______h # i # k # l
-vIN#            a # b # c # d # e # x # g # _ # i # k # l
-viN#            a # b # c # d # e # x # g #___# i # k # l
-vaN#            a # b # c # d # e # x # g ____# i # k # l
-vAN#            a # b # c # d # e # x # g ______i # k # l
-v1IL#           a # b # c # _ # e # x # g # h # i # k # l
-v1iL#           a # b # c #___# e # x # g # h # i # k # l
-v1aL#           a # b # c ____# e # x # g # h # i # k # l
-v1AL#           a # b # c ______e # x # g # h # i # k # l
 v1Il#           a # b # c # d # _ # x # g # h # i # k # l
 v1il#           a # b # c # d #___# x # g # h # i # k # l
 v1al#           a # b # c # d ____# x # g # h # i # k # l
@@ -4651,14 +3607,6 @@ v1In#           a # b # c # d # e # x # _ # h # i # k # l
 v1in#           a # b # c # d # e # x #___# h # i # k # l
 v1an#           a # b # c # d # e # x ____# h # i # k # l
 v1An#           a # b # c # d # e # x ______h # i # k # l
-v1IN#           a # b # c # d # e # x # g # _ # i # k # l
-v1iN#           a # b # c # d # e # x # g #___# i # k # l
-v1aN#           a # b # c # d # e # x # g ____# i # k # l
-v1AN#           a # b # c # d # e # x # g ______i # k # l
-v2IL#           a # _ # c # d # e # x # g # h # i # k # l
-v2iL#           a #___# c # d # e # x # g # h # i # k # l
-v2aL#           a ____# c # d # e # x # g # h # i # k # l
-v2AL#           a ______c # d # e # x # g # h # i # k # l
 v2Il#           a # b # c # _ # e # x # g # h # i # k # l
 v2il#           a # b # c #___# e # x # g # h # i # k # l
 v2al#           a # b # c ____# e # x # g # h # i # k # l
@@ -4671,15 +3619,7 @@ v2In#           a # b # c # d # e # x # g # _ # i # k # l
 v2in#           a # b # c # d # e # x # g #___# i # k # l
 v2an#           a # b # c # d # e # x # g ____# i # k # l
 v2An#           a # b # c # d # e # x # g ______i # k # l
-v2IN#           a # b # c # d # e # x # g # h # i # _ # l
-v2iN#           a # b # c # d # e # x # g # h # i #___# l
-v2aN#           a # b # c # d # e # x # g # h # i ____# l
-v2AN#           a # b # c # d # e # x # g # h # i ______l
 a / b / c / d / e / x / g / h / i / k / l
-cIL/            a / b / c / _ / e / x / g / h / i / k / l
-ciL/            a / b / c /_/ e / x / g / h / i / k / l
-caL/            a / b / c _/ e / x / g / h / i / k / l
-cAL/            a / b / c _e / x / g / h / i / k / l
 cIl/            a / b / c / d / _ / x / g / h / i / k / l
 cil/            a / b / c / d /_/ x / g / h / i / k / l
 cal/            a / b / c / d _/ x / g / h / i / k / l
@@ -4692,14 +3632,6 @@ cIn/            a / b / c / d / e / x / _ / h / i / k / l
 cin/            a / b / c / d / e / x /_/ h / i / k / l
 can/            a / b / c / d / e / x _/ h / i / k / l
 cAn/            a / b / c / d / e / x _h / i / k / l
-cIN/            a / b / c / d / e / x / g / _ / i / k / l
-ciN/            a / b / c / d / e / x / g /_/ i / k / l
-caN/            a / b / c / d / e / x / g _/ i / k / l
-cAN/            a / b / c / d / e / x / g _i / k / l
-c1IL/           a / b / c / _ / e / x / g / h / i / k / l
-c1iL/           a / b / c /_/ e / x / g / h / i / k / l
-c1aL/           a / b / c _/ e / x / g / h / i / k / l
-c1AL/           a / b / c _e / x / g / h / i / k / l
 c1Il/           a / b / c / d / _ / x / g / h / i / k / l
 c1il/           a / b / c / d /_/ x / g / h / i / k / l
 c1al/           a / b / c / d _/ x / g / h / i / k / l
@@ -4712,14 +3644,6 @@ c1In/           a / b / c / d / e / x / _ / h / i / k / l
 c1in/           a / b / c / d / e / x /_/ h / i / k / l
 c1an/           a / b / c / d / e / x _/ h / i / k / l
 c1An/           a / b / c / d / e / x _h / i / k / l
-c1IN/           a / b / c / d / e / x / g / _ / i / k / l
-c1iN/           a / b / c / d / e / x / g /_/ i / k / l
-c1aN/           a / b / c / d / e / x / g _/ i / k / l
-c1AN/           a / b / c / d / e / x / g _i / k / l
-c2IL/           a / _ / c / d / e / x / g / h / i / k / l
-c2iL/           a /_/ c / d / e / x / g / h / i / k / l
-c2aL/           a _/ c / d / e / x / g / h / i / k / l
-c2AL/           a _c / d / e / x / g / h / i / k / l
 c2Il/           a / b / c / _ / e / x / g / h / i / k / l
 c2il/           a / b / c /_/ e / x / g / h / i / k / l
 c2al/           a / b / c _/ e / x / g / h / i / k / l
@@ -4732,14 +3656,6 @@ c2In/           a / b / c / d / e / x / g / _ / i / k / l
 c2in/           a / b / c / d / e / x / g /_/ i / k / l
 c2an/           a / b / c / d / e / x / g _/ i / k / l
 c2An/           a / b / c / d / e / x / g _i / k / l
-c2IN/           a / b / c / d / e / x / g / h / i / _ / l
-c2iN/           a / b / c / d / e / x / g / h / i /_/ l
-c2aN/           a / b / c / d / e / x / g / h / i _/ l
-c2AN/           a / b / c / d / e / x / g / h / i _l
-dIL/            a / b / c /  / e / x / g / h / i / k / l
-diL/            a / b / c // e / x / g / h / i / k / l
-daL/            a / b / c / e / x / g / h / i / k / l
-dAL/            a / b / c e / x / g / h / i / k / l
 dIl/            a / b / c / d /  / x / g / h / i / k / l
 dil/            a / b / c / d // x / g / h / i / k / l
 dal/            a / b / c / d / x / g / h / i / k / l
@@ -4752,14 +3668,6 @@ dIn/            a / b / c / d / e / x /  / h / i / k / l
 din/            a / b / c / d / e / x // h / i / k / l
 dan/            a / b / c / d / e / x / h / i / k / l
 dAn/            a / b / c / d / e / x h / i / k / l
-dIN/            a / b / c / d / e / x / g /  / i / k / l
-diN/            a / b / c / d / e / x / g // i / k / l
-daN/            a / b / c / d / e / x / g / i / k / l
-dAN/            a / b / c / d / e / x / g i / k / l
-d1IL/           a / b / c /  / e / x / g / h / i / k / l
-d1iL/           a / b / c // e / x / g / h / i / k / l
-d1aL/           a / b / c / e / x / g / h / i / k / l
-d1AL/           a / b / c e / x / g / h / i / k / l
 d1Il/           a / b / c / d /  / x / g / h / i / k / l
 d1il/           a / b / c / d // x / g / h / i / k / l
 d1al/           a / b / c / d / x / g / h / i / k / l
@@ -4772,14 +3680,6 @@ d1In/           a / b / c / d / e / x /  / h / i / k / l
 d1in/           a / b / c / d / e / x // h / i / k / l
 d1an/           a / b / c / d / e / x / h / i / k / l
 d1An/           a / b / c / d / e / x h / i / k / l
-d1IN/           a / b / c / d / e / x / g /  / i / k / l
-d1iN/           a / b / c / d / e / x / g // i / k / l
-d1aN/           a / b / c / d / e / x / g / i / k / l
-d1AN/           a / b / c / d / e / x / g i / k / l
-d2IL/           a /  / c / d / e / x / g / h / i / k / l
-d2iL/           a // c / d / e / x / g / h / i / k / l
-d2aL/           a / c / d / e / x / g / h / i / k / l
-d2AL/           a c / d / e / x / g / h / i / k / l
 d2Il/           a / b / c /  / e / x / g / h / i / k / l
 d2il/           a / b / c // e / x / g / h / i / k / l
 d2al/           a / b / c / e / x / g / h / i / k / l
@@ -4792,14 +3692,6 @@ d2In/           a / b / c / d / e / x / g /  / i / k / l
 d2in/           a / b / c / d / e / x / g // i / k / l
 d2an/           a / b / c / d / e / x / g / i / k / l
 d2An/           a / b / c / d / e / x / g i / k / l
-d2IN/           a / b / c / d / e / x / g / h / i /  / l
-d2iN/           a / b / c / d / e / x / g / h / i // l
-d2aN/           a / b / c / d / e / x / g / h / i / l
-d2AN/           a / b / c / d / e / x / g / h / i l
-yIL/            a / b / c / d / e / x / g / h / i / k / l       'd'
-yiL/            a / b / c / d / e / x / g / h / i / k / l       ' d '
-yaL/            a / b / c / d / e / x / g / h / i / k / l       '/ d '
-yAL/            a / b / c / d / e / x / g / h / i / k / l       '/ d / '
 yIl/            a / b / c / d / e / x / g / h / i / k / l       'e'
 yil/            a / b / c / d / e / x / g / h / i / k / l       ' e '
 yal/            a / b / c / d / e / x / g / h / i / k / l       '/ e '
@@ -4812,14 +3704,6 @@ yIn/            a / b / c / d / e / x / g / h / i / k / l       'g'
 yin/            a / b / c / d / e / x / g / h / i / k / l       ' g '
 yan/            a / b / c / d / e / x / g / h / i / k / l       '/ g '
 yAn/            a / b / c / d / e / x / g / h / i / k / l       '/ g / '
-yIN/            a / b / c / d / e / x / g / h / i / k / l       'h'
-yiN/            a / b / c / d / e / x / g / h / i / k / l       ' h '
-yaN/            a / b / c / d / e / x / g / h / i / k / l       '/ h '
-yAN/            a / b / c / d / e / x / g / h / i / k / l       '/ h / '
-y1IL/           a / b / c / d / e / x / g / h / i / k / l       'd'
-y1iL/           a / b / c / d / e / x / g / h / i / k / l       ' d '
-y1aL/           a / b / c / d / e / x / g / h / i / k / l       '/ d '
-y1AL/           a / b / c / d / e / x / g / h / i / k / l       '/ d / '
 y1Il/           a / b / c / d / e / x / g / h / i / k / l       'e'
 y1il/           a / b / c / d / e / x / g / h / i / k / l       ' e '
 y1al/           a / b / c / d / e / x / g / h / i / k / l       '/ e '
@@ -4832,14 +3716,6 @@ y1In/           a / b / c / d / e / x / g / h / i / k / l       'g'
 y1in/           a / b / c / d / e / x / g / h / i / k / l       ' g '
 y1an/           a / b / c / d / e / x / g / h / i / k / l       '/ g '
 y1An/           a / b / c / d / e / x / g / h / i / k / l       '/ g / '
-y1IN/           a / b / c / d / e / x / g / h / i / k / l       'h'
-y1iN/           a / b / c / d / e / x / g / h / i / k / l       ' h '
-y1aN/           a / b / c / d / e / x / g / h / i / k / l       '/ h '
-y1AN/           a / b / c / d / e / x / g / h / i / k / l       '/ h / '
-y2IL/           a / b / c / d / e / x / g / h / i / k / l       'b'
-y2iL/           a / b / c / d / e / x / g / h / i / k / l       ' b '
-y2aL/           a / b / c / d / e / x / g / h / i / k / l       '/ b '
-y2AL/           a / b / c / d / e / x / g / h / i / k / l       '/ b / '
 y2Il/           a / b / c / d / e / x / g / h / i / k / l       'd'
 y2il/           a / b / c / d / e / x / g / h / i / k / l       ' d '
 y2al/           a / b / c / d / e / x / g / h / i / k / l       '/ d '
@@ -4852,14 +3728,6 @@ y2In/           a / b / c / d / e / x / g / h / i / k / l       'h'
 y2in/           a / b / c / d / e / x / g / h / i / k / l       ' h '
 y2an/           a / b / c / d / e / x / g / h / i / k / l       '/ h '
 y2An/           a / b / c / d / e / x / g / h / i / k / l       '/ h / '
-y2IN/           a / b / c / d / e / x / g / h / i / k / l       'k'
-y2iN/           a / b / c / d / e / x / g / h / i / k / l       ' k '
-y2aN/           a / b / c / d / e / x / g / h / i / k / l       '/ k '
-y2AN/           a / b / c / d / e / x / g / h / i / k / l       '/ k / '
-vIL/            a / b / c / _ / e / x / g / h / i / k / l
-viL/            a / b / c /___/ e / x / g / h / i / k / l
-vaL/            a / b / c ____/ e / x / g / h / i / k / l
-vAL/            a / b / c ______e / x / g / h / i / k / l
 vIl/            a / b / c / d / _ / x / g / h / i / k / l
 vil/            a / b / c / d /___/ x / g / h / i / k / l
 val/            a / b / c / d ____/ x / g / h / i / k / l
@@ -4872,14 +3740,6 @@ vIn/            a / b / c / d / e / x / _ / h / i / k / l
 vin/            a / b / c / d / e / x /___/ h / i / k / l
 van/            a / b / c / d / e / x ____/ h / i / k / l
 vAn/            a / b / c / d / e / x ______h / i / k / l
-vIN/            a / b / c / d / e / x / g / _ / i / k / l
-viN/            a / b / c / d / e / x / g /___/ i / k / l
-vaN/            a / b / c / d / e / x / g ____/ i / k / l
-vAN/            a / b / c / d / e / x / g ______i / k / l
-v1IL/           a / b / c / _ / e / x / g / h / i / k / l
-v1iL/           a / b / c /___/ e / x / g / h / i / k / l
-v1aL/           a / b / c ____/ e / x / g / h / i / k / l
-v1AL/           a / b / c ______e / x / g / h / i / k / l
 v1Il/           a / b / c / d / _ / x / g / h / i / k / l
 v1il/           a / b / c / d /___/ x / g / h / i / k / l
 v1al/           a / b / c / d ____/ x / g / h / i / k / l
@@ -4892,14 +3752,6 @@ v1In/           a / b / c / d / e / x / _ / h / i / k / l
 v1in/           a / b / c / d / e / x /___/ h / i / k / l
 v1an/           a / b / c / d / e / x ____/ h / i / k / l
 v1An/           a / b / c / d / e / x ______h / i / k / l
-v1IN/           a / b / c / d / e / x / g / _ / i / k / l
-v1iN/           a / b / c / d / e / x / g /___/ i / k / l
-v1aN/           a / b / c / d / e / x / g ____/ i / k / l
-v1AN/           a / b / c / d / e / x / g ______i / k / l
-v2IL/           a / _ / c / d / e / x / g / h / i / k / l
-v2iL/           a /___/ c / d / e / x / g / h / i / k / l
-v2aL/           a ____/ c / d / e / x / g / h / i / k / l
-v2AL/           a ______c / d / e / x / g / h / i / k / l
 v2Il/           a / b / c / _ / e / x / g / h / i / k / l
 v2il/           a / b / c /___/ e / x / g / h / i / k / l
 v2al/           a / b / c ____/ e / x / g / h / i / k / l
@@ -4912,15 +3764,7 @@ v2In/           a / b / c / d / e / x / g / _ / i / k / l
 v2in/           a / b / c / d / e / x / g /___/ i / k / l
 v2an/           a / b / c / d / e / x / g ____/ i / k / l
 v2An/           a / b / c / d / e / x / g ______i / k / l
-v2IN/           a / b / c / d / e / x / g / h / i / _ / l
-v2iN/           a / b / c / d / e / x / g / h / i /___/ l
-v2aN/           a / b / c / d / e / x / g / h / i ____/ l
-v2AN/           a / b / c / d / e / x / g / h / i ______l
 a | b | c | d | e | x | g | h | i | k | l
-cIL|            a | b | c | _ | e | x | g | h | i | k | l
-ciL|            a | b | c |_| e | x | g | h | i | k | l
-caL|            a | b | c _| e | x | g | h | i | k | l
-cAL|            a | b | c _e | x | g | h | i | k | l
 cIl|            a | b | c | d | _ | x | g | h | i | k | l
 cil|            a | b | c | d |_| x | g | h | i | k | l
 cal|            a | b | c | d _| x | g | h | i | k | l
@@ -4933,14 +3777,6 @@ cIn|            a | b | c | d | e | x | _ | h | i | k | l
 cin|            a | b | c | d | e | x |_| h | i | k | l
 can|            a | b | c | d | e | x _| h | i | k | l
 cAn|            a | b | c | d | e | x _h | i | k | l
-cIN|            a | b | c | d | e | x | g | _ | i | k | l
-ciN|            a | b | c | d | e | x | g |_| i | k | l
-caN|            a | b | c | d | e | x | g _| i | k | l
-cAN|            a | b | c | d | e | x | g _i | k | l
-c1IL|           a | b | c | _ | e | x | g | h | i | k | l
-c1iL|           a | b | c |_| e | x | g | h | i | k | l
-c1aL|           a | b | c _| e | x | g | h | i | k | l
-c1AL|           a | b | c _e | x | g | h | i | k | l
 c1Il|           a | b | c | d | _ | x | g | h | i | k | l
 c1il|           a | b | c | d |_| x | g | h | i | k | l
 c1al|           a | b | c | d _| x | g | h | i | k | l
@@ -4953,14 +3789,6 @@ c1In|           a | b | c | d | e | x | _ | h | i | k | l
 c1in|           a | b | c | d | e | x |_| h | i | k | l
 c1an|           a | b | c | d | e | x _| h | i | k | l
 c1An|           a | b | c | d | e | x _h | i | k | l
-c1IN|           a | b | c | d | e | x | g | _ | i | k | l
-c1iN|           a | b | c | d | e | x | g |_| i | k | l
-c1aN|           a | b | c | d | e | x | g _| i | k | l
-c1AN|           a | b | c | d | e | x | g _i | k | l
-c2IL|           a | _ | c | d | e | x | g | h | i | k | l
-c2iL|           a |_| c | d | e | x | g | h | i | k | l
-c2aL|           a _| c | d | e | x | g | h | i | k | l
-c2AL|           a _c | d | e | x | g | h | i | k | l
 c2Il|           a | b | c | _ | e | x | g | h | i | k | l
 c2il|           a | b | c |_| e | x | g | h | i | k | l
 c2al|           a | b | c _| e | x | g | h | i | k | l
@@ -4973,14 +3801,6 @@ c2In|           a | b | c | d | e | x | g | _ | i | k | l
 c2in|           a | b | c | d | e | x | g |_| i | k | l
 c2an|           a | b | c | d | e | x | g _| i | k | l
 c2An|           a | b | c | d | e | x | g _i | k | l
-c2IN|           a | b | c | d | e | x | g | h | i | _ | l
-c2iN|           a | b | c | d | e | x | g | h | i |_| l
-c2aN|           a | b | c | d | e | x | g | h | i _| l
-c2AN|           a | b | c | d | e | x | g | h | i _l
-dIL|            a | b | c |  | e | x | g | h | i | k | l
-diL|            a | b | c || e | x | g | h | i | k | l
-daL|            a | b | c | e | x | g | h | i | k | l
-dAL|            a | b | c e | x | g | h | i | k | l
 dIl|            a | b | c | d |  | x | g | h | i | k | l
 dil|            a | b | c | d || x | g | h | i | k | l
 dal|            a | b | c | d | x | g | h | i | k | l
@@ -4993,14 +3813,6 @@ dIn|            a | b | c | d | e | x |  | h | i | k | l
 din|            a | b | c | d | e | x || h | i | k | l
 dan|            a | b | c | d | e | x | h | i | k | l
 dAn|            a | b | c | d | e | x h | i | k | l
-dIN|            a | b | c | d | e | x | g |  | i | k | l
-diN|            a | b | c | d | e | x | g || i | k | l
-daN|            a | b | c | d | e | x | g | i | k | l
-dAN|            a | b | c | d | e | x | g i | k | l
-d1IL|           a | b | c |  | e | x | g | h | i | k | l
-d1iL|           a | b | c || e | x | g | h | i | k | l
-d1aL|           a | b | c | e | x | g | h | i | k | l
-d1AL|           a | b | c e | x | g | h | i | k | l
 d1Il|           a | b | c | d |  | x | g | h | i | k | l
 d1il|           a | b | c | d || x | g | h | i | k | l
 d1al|           a | b | c | d | x | g | h | i | k | l
@@ -5013,14 +3825,6 @@ d1In|           a | b | c | d | e | x |  | h | i | k | l
 d1in|           a | b | c | d | e | x || h | i | k | l
 d1an|           a | b | c | d | e | x | h | i | k | l
 d1An|           a | b | c | d | e | x h | i | k | l
-d1IN|           a | b | c | d | e | x | g |  | i | k | l
-d1iN|           a | b | c | d | e | x | g || i | k | l
-d1aN|           a | b | c | d | e | x | g | i | k | l
-d1AN|           a | b | c | d | e | x | g i | k | l
-d2IL|           a |  | c | d | e | x | g | h | i | k | l
-d2iL|           a || c | d | e | x | g | h | i | k | l
-d2aL|           a | c | d | e | x | g | h | i | k | l
-d2AL|           a c | d | e | x | g | h | i | k | l
 d2Il|           a | b | c |  | e | x | g | h | i | k | l
 d2il|           a | b | c || e | x | g | h | i | k | l
 d2al|           a | b | c | e | x | g | h | i | k | l
@@ -5033,14 +3837,6 @@ d2In|           a | b | c | d | e | x | g |  | i | k | l
 d2in|           a | b | c | d | e | x | g || i | k | l
 d2an|           a | b | c | d | e | x | g | i | k | l
 d2An|           a | b | c | d | e | x | g i | k | l
-d2IN|           a | b | c | d | e | x | g | h | i |  | l
-d2iN|           a | b | c | d | e | x | g | h | i || l
-d2aN|           a | b | c | d | e | x | g | h | i | l
-d2AN|           a | b | c | d | e | x | g | h | i l
-yIL|            a | b | c | d | e | x | g | h | i | k | l       'd'
-yiL|            a | b | c | d | e | x | g | h | i | k | l       ' d '
-yaL|            a | b | c | d | e | x | g | h | i | k | l       '| d '
-yAL|            a | b | c | d | e | x | g | h | i | k | l       '| d | '
 yIl|            a | b | c | d | e | x | g | h | i | k | l       'e'
 yil|            a | b | c | d | e | x | g | h | i | k | l       ' e '
 yal|            a | b | c | d | e | x | g | h | i | k | l       '| e '
@@ -5053,14 +3849,6 @@ yIn|            a | b | c | d | e | x | g | h | i | k | l       'g'
 yin|            a | b | c | d | e | x | g | h | i | k | l       ' g '
 yan|            a | b | c | d | e | x | g | h | i | k | l       '| g '
 yAn|            a | b | c | d | e | x | g | h | i | k | l       '| g | '
-yIN|            a | b | c | d | e | x | g | h | i | k | l       'h'
-yiN|            a | b | c | d | e | x | g | h | i | k | l       ' h '
-yaN|            a | b | c | d | e | x | g | h | i | k | l       '| h '
-yAN|            a | b | c | d | e | x | g | h | i | k | l       '| h | '
-y1IL|           a | b | c | d | e | x | g | h | i | k | l       'd'
-y1iL|           a | b | c | d | e | x | g | h | i | k | l       ' d '
-y1aL|           a | b | c | d | e | x | g | h | i | k | l       '| d '
-y1AL|           a | b | c | d | e | x | g | h | i | k | l       '| d | '
 y1Il|           a | b | c | d | e | x | g | h | i | k | l       'e'
 y1il|           a | b | c | d | e | x | g | h | i | k | l       ' e '
 y1al|           a | b | c | d | e | x | g | h | i | k | l       '| e '
@@ -5073,14 +3861,6 @@ y1In|           a | b | c | d | e | x | g | h | i | k | l       'g'
 y1in|           a | b | c | d | e | x | g | h | i | k | l       ' g '
 y1an|           a | b | c | d | e | x | g | h | i | k | l       '| g '
 y1An|           a | b | c | d | e | x | g | h | i | k | l       '| g | '
-y1IN|           a | b | c | d | e | x | g | h | i | k | l       'h'
-y1iN|           a | b | c | d | e | x | g | h | i | k | l       ' h '
-y1aN|           a | b | c | d | e | x | g | h | i | k | l       '| h '
-y1AN|           a | b | c | d | e | x | g | h | i | k | l       '| h | '
-y2IL|           a | b | c | d | e | x | g | h | i | k | l       'b'
-y2iL|           a | b | c | d | e | x | g | h | i | k | l       ' b '
-y2aL|           a | b | c | d | e | x | g | h | i | k | l       '| b '
-y2AL|           a | b | c | d | e | x | g | h | i | k | l       '| b | '
 y2Il|           a | b | c | d | e | x | g | h | i | k | l       'd'
 y2il|           a | b | c | d | e | x | g | h | i | k | l       ' d '
 y2al|           a | b | c | d | e | x | g | h | i | k | l       '| d '
@@ -5093,14 +3873,6 @@ y2In|           a | b | c | d | e | x | g | h | i | k | l       'h'
 y2in|           a | b | c | d | e | x | g | h | i | k | l       ' h '
 y2an|           a | b | c | d | e | x | g | h | i | k | l       '| h '
 y2An|           a | b | c | d | e | x | g | h | i | k | l       '| h | '
-y2IN|           a | b | c | d | e | x | g | h | i | k | l       'k'
-y2iN|           a | b | c | d | e | x | g | h | i | k | l       ' k '
-y2aN|           a | b | c | d | e | x | g | h | i | k | l       '| k '
-y2AN|           a | b | c | d | e | x | g | h | i | k | l       '| k | '
-vIL|            a | b | c | _ | e | x | g | h | i | k | l
-viL|            a | b | c |___| e | x | g | h | i | k | l
-vaL|            a | b | c ____| e | x | g | h | i | k | l
-vAL|            a | b | c ______e | x | g | h | i | k | l
 vIl|            a | b | c | d | _ | x | g | h | i | k | l
 vil|            a | b | c | d |___| x | g | h | i | k | l
 val|            a | b | c | d ____| x | g | h | i | k | l
@@ -5113,14 +3885,6 @@ vIn|            a | b | c | d | e | x | _ | h | i | k | l
 vin|            a | b | c | d | e | x |___| h | i | k | l
 van|            a | b | c | d | e | x ____| h | i | k | l
 vAn|            a | b | c | d | e | x ______h | i | k | l
-vIN|            a | b | c | d | e | x | g | _ | i | k | l
-viN|            a | b | c | d | e | x | g |___| i | k | l
-vaN|            a | b | c | d | e | x | g ____| i | k | l
-vAN|            a | b | c | d | e | x | g ______i | k | l
-v1IL|           a | b | c | _ | e | x | g | h | i | k | l
-v1iL|           a | b | c |___| e | x | g | h | i | k | l
-v1aL|           a | b | c ____| e | x | g | h | i | k | l
-v1AL|           a | b | c ______e | x | g | h | i | k | l
 v1Il|           a | b | c | d | _ | x | g | h | i | k | l
 v1il|           a | b | c | d |___| x | g | h | i | k | l
 v1al|           a | b | c | d ____| x | g | h | i | k | l
@@ -5133,14 +3897,6 @@ v1In|           a | b | c | d | e | x | _ | h | i | k | l
 v1in|           a | b | c | d | e | x |___| h | i | k | l
 v1an|           a | b | c | d | e | x ____| h | i | k | l
 v1An|           a | b | c | d | e | x ______h | i | k | l
-v1IN|           a | b | c | d | e | x | g | _ | i | k | l
-v1iN|           a | b | c | d | e | x | g |___| i | k | l
-v1aN|           a | b | c | d | e | x | g ____| i | k | l
-v1AN|           a | b | c | d | e | x | g ______i | k | l
-v2IL|           a | _ | c | d | e | x | g | h | i | k | l
-v2iL|           a |___| c | d | e | x | g | h | i | k | l
-v2aL|           a ____| c | d | e | x | g | h | i | k | l
-v2AL|           a ______c | d | e | x | g | h | i | k | l
 v2Il|           a | b | c | _ | e | x | g | h | i | k | l
 v2il|           a | b | c |___| e | x | g | h | i | k | l
 v2al|           a | b | c ____| e | x | g | h | i | k | l
@@ -5153,15 +3909,7 @@ v2In|           a | b | c | d | e | x | g | _ | i | k | l
 v2in|           a | b | c | d | e | x | g |___| i | k | l
 v2an|           a | b | c | d | e | x | g ____| i | k | l
 v2An|           a | b | c | d | e | x | g ______i | k | l
-v2IN|           a | b | c | d | e | x | g | h | i | _ | l
-v2iN|           a | b | c | d | e | x | g | h | i |___| l
-v2aN|           a | b | c | d | e | x | g | h | i ____| l
-v2AN|           a | b | c | d | e | x | g | h | i ______l
 a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l
-cIL\            a \ b \ c \ _ \ e \ x \ g \ h \ i \ k \ l
-ciL\            a \ b \ c \_\ e \ x \ g \ h \ i \ k \ l
-caL\            a \ b \ c _\ e \ x \ g \ h \ i \ k \ l
-cAL\            a \ b \ c _e \ x \ g \ h \ i \ k \ l
 cIl\            a \ b \ c \ d \ _ \ x \ g \ h \ i \ k \ l
 cil\            a \ b \ c \ d \_\ x \ g \ h \ i \ k \ l
 cal\            a \ b \ c \ d _\ x \ g \ h \ i \ k \ l
@@ -5174,14 +3922,6 @@ cIn\            a \ b \ c \ d \ e \ x \ _ \ h \ i \ k \ l
 cin\            a \ b \ c \ d \ e \ x \_\ h \ i \ k \ l
 can\            a \ b \ c \ d \ e \ x _\ h \ i \ k \ l
 cAn\            a \ b \ c \ d \ e \ x _h \ i \ k \ l
-cIN\            a \ b \ c \ d \ e \ x \ g \ _ \ i \ k \ l
-ciN\            a \ b \ c \ d \ e \ x \ g \_\ i \ k \ l
-caN\            a \ b \ c \ d \ e \ x \ g _\ i \ k \ l
-cAN\            a \ b \ c \ d \ e \ x \ g _i \ k \ l
-c1IL\           a \ b \ c \ _ \ e \ x \ g \ h \ i \ k \ l
-c1iL\           a \ b \ c \_\ e \ x \ g \ h \ i \ k \ l
-c1aL\           a \ b \ c _\ e \ x \ g \ h \ i \ k \ l
-c1AL\           a \ b \ c _e \ x \ g \ h \ i \ k \ l
 c1Il\           a \ b \ c \ d \ _ \ x \ g \ h \ i \ k \ l
 c1il\           a \ b \ c \ d \_\ x \ g \ h \ i \ k \ l
 c1al\           a \ b \ c \ d _\ x \ g \ h \ i \ k \ l
@@ -5194,14 +3934,6 @@ c1In\           a \ b \ c \ d \ e \ x \ _ \ h \ i \ k \ l
 c1in\           a \ b \ c \ d \ e \ x \_\ h \ i \ k \ l
 c1an\           a \ b \ c \ d \ e \ x _\ h \ i \ k \ l
 c1An\           a \ b \ c \ d \ e \ x _h \ i \ k \ l
-c1IN\           a \ b \ c \ d \ e \ x \ g \ _ \ i \ k \ l
-c1iN\           a \ b \ c \ d \ e \ x \ g \_\ i \ k \ l
-c1aN\           a \ b \ c \ d \ e \ x \ g _\ i \ k \ l
-c1AN\           a \ b \ c \ d \ e \ x \ g _i \ k \ l
-c2IL\           a \ _ \ c \ d \ e \ x \ g \ h \ i \ k \ l
-c2iL\           a \_\ c \ d \ e \ x \ g \ h \ i \ k \ l
-c2aL\           a _\ c \ d \ e \ x \ g \ h \ i \ k \ l
-c2AL\           a _c \ d \ e \ x \ g \ h \ i \ k \ l
 c2Il\           a \ b \ c \ _ \ e \ x \ g \ h \ i \ k \ l
 c2il\           a \ b \ c \_\ e \ x \ g \ h \ i \ k \ l
 c2al\           a \ b \ c _\ e \ x \ g \ h \ i \ k \ l
@@ -5214,14 +3946,6 @@ c2In\           a \ b \ c \ d \ e \ x \ g \ _ \ i \ k \ l
 c2in\           a \ b \ c \ d \ e \ x \ g \_\ i \ k \ l
 c2an\           a \ b \ c \ d \ e \ x \ g _\ i \ k \ l
 c2An\           a \ b \ c \ d \ e \ x \ g _i \ k \ l
-c2IN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ _ \ l
-c2iN\           a \ b \ c \ d \ e \ x \ g \ h \ i \_\ l
-c2aN\           a \ b \ c \ d \ e \ x \ g \ h \ i _\ l
-c2AN\           a \ b \ c \ d \ e \ x \ g \ h \ i _l
-dIL\            a \ b \ c \  \ e \ x \ g \ h \ i \ k \ l
-diL\            a \ b \ c \\ e \ x \ g \ h \ i \ k \ l
-daL\            a \ b \ c \ e \ x \ g \ h \ i \ k \ l
-dAL\            a \ b \ c e \ x \ g \ h \ i \ k \ l
 dIl\            a \ b \ c \ d \  \ x \ g \ h \ i \ k \ l
 dil\            a \ b \ c \ d \\ x \ g \ h \ i \ k \ l
 dal\            a \ b \ c \ d \ x \ g \ h \ i \ k \ l
@@ -5234,14 +3958,6 @@ dIn\            a \ b \ c \ d \ e \ x \  \ h \ i \ k \ l
 din\            a \ b \ c \ d \ e \ x \\ h \ i \ k \ l
 dan\            a \ b \ c \ d \ e \ x \ h \ i \ k \ l
 dAn\            a \ b \ c \ d \ e \ x h \ i \ k \ l
-dIN\            a \ b \ c \ d \ e \ x \ g \  \ i \ k \ l
-diN\            a \ b \ c \ d \ e \ x \ g \\ i \ k \ l
-daN\            a \ b \ c \ d \ e \ x \ g \ i \ k \ l
-dAN\            a \ b \ c \ d \ e \ x \ g i \ k \ l
-d1IL\           a \ b \ c \  \ e \ x \ g \ h \ i \ k \ l
-d1iL\           a \ b \ c \\ e \ x \ g \ h \ i \ k \ l
-d1aL\           a \ b \ c \ e \ x \ g \ h \ i \ k \ l
-d1AL\           a \ b \ c e \ x \ g \ h \ i \ k \ l
 d1Il\           a \ b \ c \ d \  \ x \ g \ h \ i \ k \ l
 d1il\           a \ b \ c \ d \\ x \ g \ h \ i \ k \ l
 d1al\           a \ b \ c \ d \ x \ g \ h \ i \ k \ l
@@ -5254,14 +3970,6 @@ d1In\           a \ b \ c \ d \ e \ x \  \ h \ i \ k \ l
 d1in\           a \ b \ c \ d \ e \ x \\ h \ i \ k \ l
 d1an\           a \ b \ c \ d \ e \ x \ h \ i \ k \ l
 d1An\           a \ b \ c \ d \ e \ x h \ i \ k \ l
-d1IN\           a \ b \ c \ d \ e \ x \ g \  \ i \ k \ l
-d1iN\           a \ b \ c \ d \ e \ x \ g \\ i \ k \ l
-d1aN\           a \ b \ c \ d \ e \ x \ g \ i \ k \ l
-d1AN\           a \ b \ c \ d \ e \ x \ g i \ k \ l
-d2IL\           a \  \ c \ d \ e \ x \ g \ h \ i \ k \ l
-d2iL\           a \\ c \ d \ e \ x \ g \ h \ i \ k \ l
-d2aL\           a \ c \ d \ e \ x \ g \ h \ i \ k \ l
-d2AL\           a c \ d \ e \ x \ g \ h \ i \ k \ l
 d2Il\           a \ b \ c \  \ e \ x \ g \ h \ i \ k \ l
 d2il\           a \ b \ c \\ e \ x \ g \ h \ i \ k \ l
 d2al\           a \ b \ c \ e \ x \ g \ h \ i \ k \ l
@@ -5274,14 +3982,6 @@ d2In\           a \ b \ c \ d \ e \ x \ g \  \ i \ k \ l
 d2in\           a \ b \ c \ d \ e \ x \ g \\ i \ k \ l
 d2an\           a \ b \ c \ d \ e \ x \ g \ i \ k \ l
 d2An\           a \ b \ c \ d \ e \ x \ g i \ k \ l
-d2IN\           a \ b \ c \ d \ e \ x \ g \ h \ i \  \ l
-d2iN\           a \ b \ c \ d \ e \ x \ g \ h \ i \\ l
-d2aN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ l
-d2AN\           a \ b \ c \ d \ e \ x \ g \ h \ i l
-yIL\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'd'
-yiL\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' d '
-yaL\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ d '
-yAL\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ d \ '
 yIl\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'e'
 yil\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' e '
 yal\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ e '
@@ -5294,14 +3994,6 @@ yIn\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'g'
 yin\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' g '
 yan\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ g '
 yAn\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ g \ '
-yIN\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'h'
-yiN\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' h '
-yaN\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ h '
-yAN\            a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ h \ '
-y1IL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'd'
-y1iL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' d '
-y1aL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ d '
-y1AL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ d \ '
 y1Il\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'e'
 y1il\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' e '
 y1al\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ e '
@@ -5314,14 +4006,6 @@ y1In\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'g'
 y1in\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' g '
 y1an\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ g '
 y1An\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ g \ '
-y1IN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'h'
-y1iN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' h '
-y1aN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ h '
-y1AN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ h \ '
-y2IL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'b'
-y2iL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' b '
-y2aL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ b '
-y2AL\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ b \ '
 y2Il\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'd'
 y2il\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' d '
 y2al\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ d '
@@ -5334,14 +4018,6 @@ y2In\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'h'
 y2in\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' h '
 y2an\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ h '
 y2An\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ h \ '
-y2IN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       'k'
-y2iN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       ' k '
-y2aN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ k '
-y2AN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ k \ l       '\ k \ '
-vIL\            a \ b \ c \ _ \ e \ x \ g \ h \ i \ k \ l
-viL\            a \ b \ c \___\ e \ x \ g \ h \ i \ k \ l
-vaL\            a \ b \ c ____\ e \ x \ g \ h \ i \ k \ l
-vAL\            a \ b \ c ______e \ x \ g \ h \ i \ k \ l
 vIl\            a \ b \ c \ d \ _ \ x \ g \ h \ i \ k \ l
 vil\            a \ b \ c \ d \___\ x \ g \ h \ i \ k \ l
 val\            a \ b \ c \ d ____\ x \ g \ h \ i \ k \ l
@@ -5354,14 +4030,6 @@ vIn\            a \ b \ c \ d \ e \ x \ _ \ h \ i \ k \ l
 vin\            a \ b \ c \ d \ e \ x \___\ h \ i \ k \ l
 van\            a \ b \ c \ d \ e \ x ____\ h \ i \ k \ l
 vAn\            a \ b \ c \ d \ e \ x ______h \ i \ k \ l
-vIN\            a \ b \ c \ d \ e \ x \ g \ _ \ i \ k \ l
-viN\            a \ b \ c \ d \ e \ x \ g \___\ i \ k \ l
-vaN\            a \ b \ c \ d \ e \ x \ g ____\ i \ k \ l
-vAN\            a \ b \ c \ d \ e \ x \ g ______i \ k \ l
-v1IL\           a \ b \ c \ _ \ e \ x \ g \ h \ i \ k \ l
-v1iL\           a \ b \ c \___\ e \ x \ g \ h \ i \ k \ l
-v1aL\           a \ b \ c ____\ e \ x \ g \ h \ i \ k \ l
-v1AL\           a \ b \ c ______e \ x \ g \ h \ i \ k \ l
 v1Il\           a \ b \ c \ d \ _ \ x \ g \ h \ i \ k \ l
 v1il\           a \ b \ c \ d \___\ x \ g \ h \ i \ k \ l
 v1al\           a \ b \ c \ d ____\ x \ g \ h \ i \ k \ l
@@ -5374,14 +4042,6 @@ v1In\           a \ b \ c \ d \ e \ x \ _ \ h \ i \ k \ l
 v1in\           a \ b \ c \ d \ e \ x \___\ h \ i \ k \ l
 v1an\           a \ b \ c \ d \ e \ x ____\ h \ i \ k \ l
 v1An\           a \ b \ c \ d \ e \ x ______h \ i \ k \ l
-v1IN\           a \ b \ c \ d \ e \ x \ g \ _ \ i \ k \ l
-v1iN\           a \ b \ c \ d \ e \ x \ g \___\ i \ k \ l
-v1aN\           a \ b \ c \ d \ e \ x \ g ____\ i \ k \ l
-v1AN\           a \ b \ c \ d \ e \ x \ g ______i \ k \ l
-v2IL\           a \ _ \ c \ d \ e \ x \ g \ h \ i \ k \ l
-v2iL\           a \___\ c \ d \ e \ x \ g \ h \ i \ k \ l
-v2aL\           a ____\ c \ d \ e \ x \ g \ h \ i \ k \ l
-v2AL\           a ______c \ d \ e \ x \ g \ h \ i \ k \ l
 v2Il\           a \ b \ c \ _ \ e \ x \ g \ h \ i \ k \ l
 v2il\           a \ b \ c \___\ e \ x \ g \ h \ i \ k \ l
 v2al\           a \ b \ c ____\ e \ x \ g \ h \ i \ k \ l
@@ -5394,15 +4054,7 @@ v2In\           a \ b \ c \ d \ e \ x \ g \ _ \ i \ k \ l
 v2in\           a \ b \ c \ d \ e \ x \ g \___\ i \ k \ l
 v2an\           a \ b \ c \ d \ e \ x \ g ____\ i \ k \ l
 v2An\           a \ b \ c \ d \ e \ x \ g ______i \ k \ l
-v2IN\           a \ b \ c \ d \ e \ x \ g \ h \ i \ _ \ l
-v2iN\           a \ b \ c \ d \ e \ x \ g \ h \ i \___\ l
-v2aN\           a \ b \ c \ d \ e \ x \ g \ h \ i ____\ l
-v2AN\           a \ b \ c \ d \ e \ x \ g \ h \ i ______l
 a & b & c & d & e & x & g & h & i & k & l
-cIL&            a & b & c & _ & e & x & g & h & i & k & l
-ciL&            a & b & c &_& e & x & g & h & i & k & l
-caL&            a & b & c _& e & x & g & h & i & k & l
-cAL&            a & b & c _e & x & g & h & i & k & l
 cIl&            a & b & c & d & _ & x & g & h & i & k & l
 cil&            a & b & c & d &_& x & g & h & i & k & l
 cal&            a & b & c & d _& x & g & h & i & k & l
@@ -5415,14 +4067,6 @@ cIn&            a & b & c & d & e & x & _ & h & i & k & l
 cin&            a & b & c & d & e & x &_& h & i & k & l
 can&            a & b & c & d & e & x _& h & i & k & l
 cAn&            a & b & c & d & e & x _h & i & k & l
-cIN&            a & b & c & d & e & x & g & _ & i & k & l
-ciN&            a & b & c & d & e & x & g &_& i & k & l
-caN&            a & b & c & d & e & x & g _& i & k & l
-cAN&            a & b & c & d & e & x & g _i & k & l
-c1IL&           a & b & c & _ & e & x & g & h & i & k & l
-c1iL&           a & b & c &_& e & x & g & h & i & k & l
-c1aL&           a & b & c _& e & x & g & h & i & k & l
-c1AL&           a & b & c _e & x & g & h & i & k & l
 c1Il&           a & b & c & d & _ & x & g & h & i & k & l
 c1il&           a & b & c & d &_& x & g & h & i & k & l
 c1al&           a & b & c & d _& x & g & h & i & k & l
@@ -5435,14 +4079,6 @@ c1In&           a & b & c & d & e & x & _ & h & i & k & l
 c1in&           a & b & c & d & e & x &_& h & i & k & l
 c1an&           a & b & c & d & e & x _& h & i & k & l
 c1An&           a & b & c & d & e & x _h & i & k & l
-c1IN&           a & b & c & d & e & x & g & _ & i & k & l
-c1iN&           a & b & c & d & e & x & g &_& i & k & l
-c1aN&           a & b & c & d & e & x & g _& i & k & l
-c1AN&           a & b & c & d & e & x & g _i & k & l
-c2IL&           a & _ & c & d & e & x & g & h & i & k & l
-c2iL&           a &_& c & d & e & x & g & h & i & k & l
-c2aL&           a _& c & d & e & x & g & h & i & k & l
-c2AL&           a _c & d & e & x & g & h & i & k & l
 c2Il&           a & b & c & _ & e & x & g & h & i & k & l
 c2il&           a & b & c &_& e & x & g & h & i & k & l
 c2al&           a & b & c _& e & x & g & h & i & k & l
@@ -5455,14 +4091,6 @@ c2In&           a & b & c & d & e & x & g & _ & i & k & l
 c2in&           a & b & c & d & e & x & g &_& i & k & l
 c2an&           a & b & c & d & e & x & g _& i & k & l
 c2An&           a & b & c & d & e & x & g _i & k & l
-c2IN&           a & b & c & d & e & x & g & h & i & _ & l
-c2iN&           a & b & c & d & e & x & g & h & i &_& l
-c2aN&           a & b & c & d & e & x & g & h & i _& l
-c2AN&           a & b & c & d & e & x & g & h & i _l
-dIL&            a & b & c &  & e & x & g & h & i & k & l
-diL&            a & b & c && e & x & g & h & i & k & l
-daL&            a & b & c & e & x & g & h & i & k & l
-dAL&            a & b & c e & x & g & h & i & k & l
 dIl&            a & b & c & d &  & x & g & h & i & k & l
 dil&            a & b & c & d && x & g & h & i & k & l
 dal&            a & b & c & d & x & g & h & i & k & l
@@ -5475,14 +4103,6 @@ dIn&            a & b & c & d & e & x &  & h & i & k & l
 din&            a & b & c & d & e & x && h & i & k & l
 dan&            a & b & c & d & e & x & h & i & k & l
 dAn&            a & b & c & d & e & x h & i & k & l
-dIN&            a & b & c & d & e & x & g &  & i & k & l
-diN&            a & b & c & d & e & x & g && i & k & l
-daN&            a & b & c & d & e & x & g & i & k & l
-dAN&            a & b & c & d & e & x & g i & k & l
-d1IL&           a & b & c &  & e & x & g & h & i & k & l
-d1iL&           a & b & c && e & x & g & h & i & k & l
-d1aL&           a & b & c & e & x & g & h & i & k & l
-d1AL&           a & b & c e & x & g & h & i & k & l
 d1Il&           a & b & c & d &  & x & g & h & i & k & l
 d1il&           a & b & c & d && x & g & h & i & k & l
 d1al&           a & b & c & d & x & g & h & i & k & l
@@ -5495,14 +4115,6 @@ d1In&           a & b & c & d & e & x &  & h & i & k & l
 d1in&           a & b & c & d & e & x && h & i & k & l
 d1an&           a & b & c & d & e & x & h & i & k & l
 d1An&           a & b & c & d & e & x h & i & k & l
-d1IN&           a & b & c & d & e & x & g &  & i & k & l
-d1iN&           a & b & c & d & e & x & g && i & k & l
-d1aN&           a & b & c & d & e & x & g & i & k & l
-d1AN&           a & b & c & d & e & x & g i & k & l
-d2IL&           a &  & c & d & e & x & g & h & i & k & l
-d2iL&           a && c & d & e & x & g & h & i & k & l
-d2aL&           a & c & d & e & x & g & h & i & k & l
-d2AL&           a c & d & e & x & g & h & i & k & l
 d2Il&           a & b & c &  & e & x & g & h & i & k & l
 d2il&           a & b & c && e & x & g & h & i & k & l
 d2al&           a & b & c & e & x & g & h & i & k & l
@@ -5515,14 +4127,6 @@ d2In&           a & b & c & d & e & x & g &  & i & k & l
 d2in&           a & b & c & d & e & x & g && i & k & l
 d2an&           a & b & c & d & e & x & g & i & k & l
 d2An&           a & b & c & d & e & x & g i & k & l
-d2IN&           a & b & c & d & e & x & g & h & i &  & l
-d2iN&           a & b & c & d & e & x & g & h & i && l
-d2aN&           a & b & c & d & e & x & g & h & i & l
-d2AN&           a & b & c & d & e & x & g & h & i l
-yIL&            a & b & c & d & e & x & g & h & i & k & l       'd'
-yiL&            a & b & c & d & e & x & g & h & i & k & l       ' d '
-yaL&            a & b & c & d & e & x & g & h & i & k & l       '& d '
-yAL&            a & b & c & d & e & x & g & h & i & k & l       '& d & '
 yIl&            a & b & c & d & e & x & g & h & i & k & l       'e'
 yil&            a & b & c & d & e & x & g & h & i & k & l       ' e '
 yal&            a & b & c & d & e & x & g & h & i & k & l       '& e '
@@ -5535,14 +4139,6 @@ yIn&            a & b & c & d & e & x & g & h & i & k & l       'g'
 yin&            a & b & c & d & e & x & g & h & i & k & l       ' g '
 yan&            a & b & c & d & e & x & g & h & i & k & l       '& g '
 yAn&            a & b & c & d & e & x & g & h & i & k & l       '& g & '
-yIN&            a & b & c & d & e & x & g & h & i & k & l       'h'
-yiN&            a & b & c & d & e & x & g & h & i & k & l       ' h '
-yaN&            a & b & c & d & e & x & g & h & i & k & l       '& h '
-yAN&            a & b & c & d & e & x & g & h & i & k & l       '& h & '
-y1IL&           a & b & c & d & e & x & g & h & i & k & l       'd'
-y1iL&           a & b & c & d & e & x & g & h & i & k & l       ' d '
-y1aL&           a & b & c & d & e & x & g & h & i & k & l       '& d '
-y1AL&           a & b & c & d & e & x & g & h & i & k & l       '& d & '
 y1Il&           a & b & c & d & e & x & g & h & i & k & l       'e'
 y1il&           a & b & c & d & e & x & g & h & i & k & l       ' e '
 y1al&           a & b & c & d & e & x & g & h & i & k & l       '& e '
@@ -5555,14 +4151,6 @@ y1In&           a & b & c & d & e & x & g & h & i & k & l       'g'
 y1in&           a & b & c & d & e & x & g & h & i & k & l       ' g '
 y1an&           a & b & c & d & e & x & g & h & i & k & l       '& g '
 y1An&           a & b & c & d & e & x & g & h & i & k & l       '& g & '
-y1IN&           a & b & c & d & e & x & g & h & i & k & l       'h'
-y1iN&           a & b & c & d & e & x & g & h & i & k & l       ' h '
-y1aN&           a & b & c & d & e & x & g & h & i & k & l       '& h '
-y1AN&           a & b & c & d & e & x & g & h & i & k & l       '& h & '
-y2IL&           a & b & c & d & e & x & g & h & i & k & l       'b'
-y2iL&           a & b & c & d & e & x & g & h & i & k & l       ' b '
-y2aL&           a & b & c & d & e & x & g & h & i & k & l       '& b '
-y2AL&           a & b & c & d & e & x & g & h & i & k & l       '& b & '
 y2Il&           a & b & c & d & e & x & g & h & i & k & l       'd'
 y2il&           a & b & c & d & e & x & g & h & i & k & l       ' d '
 y2al&           a & b & c & d & e & x & g & h & i & k & l       '& d '
@@ -5575,14 +4163,6 @@ y2In&           a & b & c & d & e & x & g & h & i & k & l       'h'
 y2in&           a & b & c & d & e & x & g & h & i & k & l       ' h '
 y2an&           a & b & c & d & e & x & g & h & i & k & l       '& h '
 y2An&           a & b & c & d & e & x & g & h & i & k & l       '& h & '
-y2IN&           a & b & c & d & e & x & g & h & i & k & l       'k'
-y2iN&           a & b & c & d & e & x & g & h & i & k & l       ' k '
-y2aN&           a & b & c & d & e & x & g & h & i & k & l       '& k '
-y2AN&           a & b & c & d & e & x & g & h & i & k & l       '& k & '
-vIL&            a & b & c & _ & e & x & g & h & i & k & l
-viL&            a & b & c &___& e & x & g & h & i & k & l
-vaL&            a & b & c ____& e & x & g & h & i & k & l
-vAL&            a & b & c ______e & x & g & h & i & k & l
 vIl&            a & b & c & d & _ & x & g & h & i & k & l
 vil&            a & b & c & d &___& x & g & h & i & k & l
 val&            a & b & c & d ____& x & g & h & i & k & l
@@ -5595,14 +4175,6 @@ vIn&            a & b & c & d & e & x & _ & h & i & k & l
 vin&            a & b & c & d & e & x &___& h & i & k & l
 van&            a & b & c & d & e & x ____& h & i & k & l
 vAn&            a & b & c & d & e & x ______h & i & k & l
-vIN&            a & b & c & d & e & x & g & _ & i & k & l
-viN&            a & b & c & d & e & x & g &___& i & k & l
-vaN&            a & b & c & d & e & x & g ____& i & k & l
-vAN&            a & b & c & d & e & x & g ______i & k & l
-v1IL&           a & b & c & _ & e & x & g & h & i & k & l
-v1iL&           a & b & c &___& e & x & g & h & i & k & l
-v1aL&           a & b & c ____& e & x & g & h & i & k & l
-v1AL&           a & b & c ______e & x & g & h & i & k & l
 v1Il&           a & b & c & d & _ & x & g & h & i & k & l
 v1il&           a & b & c & d &___& x & g & h & i & k & l
 v1al&           a & b & c & d ____& x & g & h & i & k & l
@@ -5615,14 +4187,6 @@ v1In&           a & b & c & d & e & x & _ & h & i & k & l
 v1in&           a & b & c & d & e & x &___& h & i & k & l
 v1an&           a & b & c & d & e & x ____& h & i & k & l
 v1An&           a & b & c & d & e & x ______h & i & k & l
-v1IN&           a & b & c & d & e & x & g & _ & i & k & l
-v1iN&           a & b & c & d & e & x & g &___& i & k & l
-v1aN&           a & b & c & d & e & x & g ____& i & k & l
-v1AN&           a & b & c & d & e & x & g ______i & k & l
-v2IL&           a & _ & c & d & e & x & g & h & i & k & l
-v2iL&           a &___& c & d & e & x & g & h & i & k & l
-v2aL&           a ____& c & d & e & x & g & h & i & k & l
-v2AL&           a ______c & d & e & x & g & h & i & k & l
 v2Il&           a & b & c & _ & e & x & g & h & i & k & l
 v2il&           a & b & c &___& e & x & g & h & i & k & l
 v2al&           a & b & c ____& e & x & g & h & i & k & l
@@ -5635,15 +4199,7 @@ v2In&           a & b & c & d & e & x & g & _ & i & k & l
 v2in&           a & b & c & d & e & x & g &___& i & k & l
 v2an&           a & b & c & d & e & x & g ____& i & k & l
 v2An&           a & b & c & d & e & x & g ______i & k & l
-v2IN&           a & b & c & d & e & x & g & h & i & _ & l
-v2iN&           a & b & c & d & e & x & g & h & i &___& l
-v2aN&           a & b & c & d & e & x & g & h & i ____& l
-v2AN&           a & b & c & d & e & x & g & h & i ______l
 a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l
-cIL$            a $ b $ c $ _ $ e $ x $ g $ h $ i $ k $ l
-ciL$            a $ b $ c $_$ e $ x $ g $ h $ i $ k $ l
-caL$            a $ b $ c _$ e $ x $ g $ h $ i $ k $ l
-cAL$            a $ b $ c _e $ x $ g $ h $ i $ k $ l
 cIl$            a $ b $ c $ d $ _ $ x $ g $ h $ i $ k $ l
 cil$            a $ b $ c $ d $_$ x $ g $ h $ i $ k $ l
 cal$            a $ b $ c $ d _$ x $ g $ h $ i $ k $ l
@@ -5656,14 +4212,6 @@ cIn$            a $ b $ c $ d $ e $ x $ _ $ h $ i $ k $ l
 cin$            a $ b $ c $ d $ e $ x $_$ h $ i $ k $ l
 can$            a $ b $ c $ d $ e $ x _$ h $ i $ k $ l
 cAn$            a $ b $ c $ d $ e $ x _h $ i $ k $ l
-cIN$            a $ b $ c $ d $ e $ x $ g $ _ $ i $ k $ l
-ciN$            a $ b $ c $ d $ e $ x $ g $_$ i $ k $ l
-caN$            a $ b $ c $ d $ e $ x $ g _$ i $ k $ l
-cAN$            a $ b $ c $ d $ e $ x $ g _i $ k $ l
-c1IL$           a $ b $ c $ _ $ e $ x $ g $ h $ i $ k $ l
-c1iL$           a $ b $ c $_$ e $ x $ g $ h $ i $ k $ l
-c1aL$           a $ b $ c _$ e $ x $ g $ h $ i $ k $ l
-c1AL$           a $ b $ c _e $ x $ g $ h $ i $ k $ l
 c1Il$           a $ b $ c $ d $ _ $ x $ g $ h $ i $ k $ l
 c1il$           a $ b $ c $ d $_$ x $ g $ h $ i $ k $ l
 c1al$           a $ b $ c $ d _$ x $ g $ h $ i $ k $ l
@@ -5676,14 +4224,6 @@ c1In$           a $ b $ c $ d $ e $ x $ _ $ h $ i $ k $ l
 c1in$           a $ b $ c $ d $ e $ x $_$ h $ i $ k $ l
 c1an$           a $ b $ c $ d $ e $ x _$ h $ i $ k $ l
 c1An$           a $ b $ c $ d $ e $ x _h $ i $ k $ l
-c1IN$           a $ b $ c $ d $ e $ x $ g $ _ $ i $ k $ l
-c1iN$           a $ b $ c $ d $ e $ x $ g $_$ i $ k $ l
-c1aN$           a $ b $ c $ d $ e $ x $ g _$ i $ k $ l
-c1AN$           a $ b $ c $ d $ e $ x $ g _i $ k $ l
-c2IL$           a $ _ $ c $ d $ e $ x $ g $ h $ i $ k $ l
-c2iL$           a $_$ c $ d $ e $ x $ g $ h $ i $ k $ l
-c2aL$           a _$ c $ d $ e $ x $ g $ h $ i $ k $ l
-c2AL$           a _c $ d $ e $ x $ g $ h $ i $ k $ l
 c2Il$           a $ b $ c $ _ $ e $ x $ g $ h $ i $ k $ l
 c2il$           a $ b $ c $_$ e $ x $ g $ h $ i $ k $ l
 c2al$           a $ b $ c _$ e $ x $ g $ h $ i $ k $ l
@@ -5696,14 +4236,6 @@ c2In$           a $ b $ c $ d $ e $ x $ g $ _ $ i $ k $ l
 c2in$           a $ b $ c $ d $ e $ x $ g $_$ i $ k $ l
 c2an$           a $ b $ c $ d $ e $ x $ g _$ i $ k $ l
 c2An$           a $ b $ c $ d $ e $ x $ g _i $ k $ l
-c2IN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ _ $ l
-c2iN$           a $ b $ c $ d $ e $ x $ g $ h $ i $_$ l
-c2aN$           a $ b $ c $ d $ e $ x $ g $ h $ i _$ l
-c2AN$           a $ b $ c $ d $ e $ x $ g $ h $ i _l
-dIL$            a $ b $ c $  $ e $ x $ g $ h $ i $ k $ l
-diL$            a $ b $ c $$ e $ x $ g $ h $ i $ k $ l
-daL$            a $ b $ c $ e $ x $ g $ h $ i $ k $ l
-dAL$            a $ b $ c e $ x $ g $ h $ i $ k $ l
 dIl$            a $ b $ c $ d $  $ x $ g $ h $ i $ k $ l
 dil$            a $ b $ c $ d $$ x $ g $ h $ i $ k $ l
 dal$            a $ b $ c $ d $ x $ g $ h $ i $ k $ l
@@ -5716,14 +4248,6 @@ dIn$            a $ b $ c $ d $ e $ x $  $ h $ i $ k $ l
 din$            a $ b $ c $ d $ e $ x $$ h $ i $ k $ l
 dan$            a $ b $ c $ d $ e $ x $ h $ i $ k $ l
 dAn$            a $ b $ c $ d $ e $ x h $ i $ k $ l
-dIN$            a $ b $ c $ d $ e $ x $ g $  $ i $ k $ l
-diN$            a $ b $ c $ d $ e $ x $ g $$ i $ k $ l
-daN$            a $ b $ c $ d $ e $ x $ g $ i $ k $ l
-dAN$            a $ b $ c $ d $ e $ x $ g i $ k $ l
-d1IL$           a $ b $ c $  $ e $ x $ g $ h $ i $ k $ l
-d1iL$           a $ b $ c $$ e $ x $ g $ h $ i $ k $ l
-d1aL$           a $ b $ c $ e $ x $ g $ h $ i $ k $ l
-d1AL$           a $ b $ c e $ x $ g $ h $ i $ k $ l
 d1Il$           a $ b $ c $ d $  $ x $ g $ h $ i $ k $ l
 d1il$           a $ b $ c $ d $$ x $ g $ h $ i $ k $ l
 d1al$           a $ b $ c $ d $ x $ g $ h $ i $ k $ l
@@ -5736,14 +4260,6 @@ d1In$           a $ b $ c $ d $ e $ x $  $ h $ i $ k $ l
 d1in$           a $ b $ c $ d $ e $ x $$ h $ i $ k $ l
 d1an$           a $ b $ c $ d $ e $ x $ h $ i $ k $ l
 d1An$           a $ b $ c $ d $ e $ x h $ i $ k $ l
-d1IN$           a $ b $ c $ d $ e $ x $ g $  $ i $ k $ l
-d1iN$           a $ b $ c $ d $ e $ x $ g $$ i $ k $ l
-d1aN$           a $ b $ c $ d $ e $ x $ g $ i $ k $ l
-d1AN$           a $ b $ c $ d $ e $ x $ g i $ k $ l
-d2IL$           a $  $ c $ d $ e $ x $ g $ h $ i $ k $ l
-d2iL$           a $$ c $ d $ e $ x $ g $ h $ i $ k $ l
-d2aL$           a $ c $ d $ e $ x $ g $ h $ i $ k $ l
-d2AL$           a c $ d $ e $ x $ g $ h $ i $ k $ l
 d2Il$           a $ b $ c $  $ e $ x $ g $ h $ i $ k $ l
 d2il$           a $ b $ c $$ e $ x $ g $ h $ i $ k $ l
 d2al$           a $ b $ c $ e $ x $ g $ h $ i $ k $ l
@@ -5756,14 +4272,6 @@ d2In$           a $ b $ c $ d $ e $ x $ g $  $ i $ k $ l
 d2in$           a $ b $ c $ d $ e $ x $ g $$ i $ k $ l
 d2an$           a $ b $ c $ d $ e $ x $ g $ i $ k $ l
 d2An$           a $ b $ c $ d $ e $ x $ g i $ k $ l
-d2IN$           a $ b $ c $ d $ e $ x $ g $ h $ i $  $ l
-d2iN$           a $ b $ c $ d $ e $ x $ g $ h $ i $$ l
-d2aN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ l
-d2AN$           a $ b $ c $ d $ e $ x $ g $ h $ i l
-yIL$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'd'
-yiL$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' d '
-yaL$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ d '
-yAL$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ d $ '
 yIl$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'e'
 yil$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' e '
 yal$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ e '
@@ -5776,14 +4284,6 @@ yIn$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'g'
 yin$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' g '
 yan$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ g '
 yAn$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ g $ '
-yIN$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'h'
-yiN$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' h '
-yaN$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ h '
-yAN$            a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ h $ '
-y1IL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'd'
-y1iL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' d '
-y1aL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ d '
-y1AL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ d $ '
 y1Il$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'e'
 y1il$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' e '
 y1al$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ e '
@@ -5796,14 +4296,6 @@ y1In$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'g'
 y1in$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' g '
 y1an$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ g '
 y1An$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ g $ '
-y1IN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'h'
-y1iN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' h '
-y1aN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ h '
-y1AN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ h $ '
-y2IL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'b'
-y2iL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' b '
-y2aL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ b '
-y2AL$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ b $ '
 y2Il$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'd'
 y2il$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' d '
 y2al$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ d '
@@ -5816,14 +4308,6 @@ y2In$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'h'
 y2in$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' h '
 y2an$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ h '
 y2An$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ h $ '
-y2IN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       'k'
-y2iN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       ' k '
-y2aN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ k '
-y2AN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ k $ l       '$ k $ '
-vIL$            a $ b $ c $ _ $ e $ x $ g $ h $ i $ k $ l
-viL$            a $ b $ c $___$ e $ x $ g $ h $ i $ k $ l
-vaL$            a $ b $ c ____$ e $ x $ g $ h $ i $ k $ l
-vAL$            a $ b $ c ______e $ x $ g $ h $ i $ k $ l
 vIl$            a $ b $ c $ d $ _ $ x $ g $ h $ i $ k $ l
 vil$            a $ b $ c $ d $___$ x $ g $ h $ i $ k $ l
 val$            a $ b $ c $ d ____$ x $ g $ h $ i $ k $ l
@@ -5836,14 +4320,6 @@ vIn$            a $ b $ c $ d $ e $ x $ _ $ h $ i $ k $ l
 vin$            a $ b $ c $ d $ e $ x $___$ h $ i $ k $ l
 van$            a $ b $ c $ d $ e $ x ____$ h $ i $ k $ l
 vAn$            a $ b $ c $ d $ e $ x ______h $ i $ k $ l
-vIN$            a $ b $ c $ d $ e $ x $ g $ _ $ i $ k $ l
-viN$            a $ b $ c $ d $ e $ x $ g $___$ i $ k $ l
-vaN$            a $ b $ c $ d $ e $ x $ g ____$ i $ k $ l
-vAN$            a $ b $ c $ d $ e $ x $ g ______i $ k $ l
-v1IL$           a $ b $ c $ _ $ e $ x $ g $ h $ i $ k $ l
-v1iL$           a $ b $ c $___$ e $ x $ g $ h $ i $ k $ l
-v1aL$           a $ b $ c ____$ e $ x $ g $ h $ i $ k $ l
-v1AL$           a $ b $ c ______e $ x $ g $ h $ i $ k $ l
 v1Il$           a $ b $ c $ d $ _ $ x $ g $ h $ i $ k $ l
 v1il$           a $ b $ c $ d $___$ x $ g $ h $ i $ k $ l
 v1al$           a $ b $ c $ d ____$ x $ g $ h $ i $ k $ l
@@ -5856,14 +4332,6 @@ v1In$           a $ b $ c $ d $ e $ x $ _ $ h $ i $ k $ l
 v1in$           a $ b $ c $ d $ e $ x $___$ h $ i $ k $ l
 v1an$           a $ b $ c $ d $ e $ x ____$ h $ i $ k $ l
 v1An$           a $ b $ c $ d $ e $ x ______h $ i $ k $ l
-v1IN$           a $ b $ c $ d $ e $ x $ g $ _ $ i $ k $ l
-v1iN$           a $ b $ c $ d $ e $ x $ g $___$ i $ k $ l
-v1aN$           a $ b $ c $ d $ e $ x $ g ____$ i $ k $ l
-v1AN$           a $ b $ c $ d $ e $ x $ g ______i $ k $ l
-v2IL$           a $ _ $ c $ d $ e $ x $ g $ h $ i $ k $ l
-v2iL$           a $___$ c $ d $ e $ x $ g $ h $ i $ k $ l
-v2aL$           a ____$ c $ d $ e $ x $ g $ h $ i $ k $ l
-v2AL$           a ______c $ d $ e $ x $ g $ h $ i $ k $ l
 v2Il$           a $ b $ c $ _ $ e $ x $ g $ h $ i $ k $ l
 v2il$           a $ b $ c $___$ e $ x $ g $ h $ i $ k $ l
 v2al$           a $ b $ c ____$ e $ x $ g $ h $ i $ k $ l
@@ -5876,10 +4344,6 @@ v2In$           a $ b $ c $ d $ e $ x $ g $ _ $ i $ k $ l
 v2in$           a $ b $ c $ d $ e $ x $ g $___$ i $ k $ l
 v2an$           a $ b $ c $ d $ e $ x $ g ____$ i $ k $ l
 v2An$           a $ b $ c $ d $ e $ x $ g ______i $ k $ l
-v2IN$           a $ b $ c $ d $ e $ x $ g $ h $ i $ _ $ l
-v2iN$           a $ b $ c $ d $ e $ x $ g $ h $ i $___$ l
-v2aN$           a $ b $ c $ d $ e $ x $ g $ h $ i ____$ l
-v2AN$           a $ b $ c $ d $ e $ x $ g $ h $ i ______l
 
 a ( b , c ( d ) , d ( x , e ) , f ) g
 cIla            a ( b , _ , d ( x , e ) , f ) g

--- a/test/testM.ok
+++ b/test/testM.ok
@@ -2,7 +2,7 @@
 "test1.in" 28L, 1059C
 Warning: terminal cannot highlight
 "test1.out"
-"test1.out" [New] 6028L, 357518C written
+"test1.out" [New] 4492L, 265934C written
 "test2.in"
 "test2.in" 25L, 263C
 /comment 1

--- a/test/testM.out
+++ b/test/testM.out
@@ -2,7 +2,7 @@
 "test1.in" 28L, 1059C
 Warning: terminal cannot highlight
 "test1.out"
-"test1.out" [New] 6028L, 357518C written
+"test1.out" [New] 4492L, 265934C written
 "test2.in"
 "test2.in" 25L, 263C
 /comment 1


### PR DESCRIPTION
As discussed in #174 they don't really serve any purpose anymore. Renamed the setting `g:targets_nlNL` to `g:targets_nl`, but the old version should still be working in order not to break compatibility. 

@nkgm: You want to have a look at the doc changes to confirm they make sense to you?

Close #174 
