### PR TITLE
191 Fix legacy fallback for g:targets_nlNL setting

### DIFF
--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -209,7 +209,7 @@ function! s:loadSettings()
     endif
     if !exists('g:targets_nl')
         if exists('g:targets_nlNL')
-            let g:targets_nl = g:targets_nlNL[0:2] " legacy fallback
+            let g:targets_nl = g:targets_nlNL[0:1] " legacy fallback
         else
             let g:targets_nl = 'nl'
         endif

--- a/test/test.vim
+++ b/test/test.vim
@@ -134,6 +134,11 @@ function s:testSeeking()
     edit! test3.in
     normal gg0
 
+    for c in split('PQ', '\zs')
+        execute "normal /"   . c . "\<CR>"
+        execute "normal cia" . c . "\<Esc>"
+    endfor
+
     for c in split('ABCDEFGHI', '\zs')
         execute "normal /"   . c . "\<CR>"
         execute "normal ci)" . c . "\<Esc>"
@@ -142,11 +147,6 @@ function s:testSeeking()
     for c in split('JKLMNO', '\zs')
         execute "normal /"   . c . "\<CR>"
         execute "normal ci'" . c . "\<Esc>"
-    endfor
-
-    for c in split('PQ', '\zs')
-        execute "normal /"   . c . "\<CR>"
-        execute "normal cia" . c . "\<Esc>"
     endfor
 
     write! test3.out

--- a/test/test3.in
+++ b/test/test3.in
@@ -1,3 +1,6 @@
+, P (x)
+(x) Q ,
+
 A
 a ( b ) c
 
@@ -39,6 +42,3 @@ d ' e
 
 a ' b ' c
 O " this must be the last quote test
-
-, P ( x )
-( x ) Q ,

--- a/test/test3.ok
+++ b/test/test3.ok
@@ -1,3 +1,6 @@
+, P (P)
+(Q) Q ,
+
 A
 a (A) c
 
@@ -35,6 +38,3 @@ c 'N' e
 
 a 'O' c
 O " this must be the last quote test
-
-, P (P)
-(Q) Q ,

--- a/test/test3.out
+++ b/test/test3.out
@@ -1,3 +1,6 @@
+, P (P)
+(Q) Q ,
+
 A
 a (A) c
 
@@ -35,6 +38,3 @@ c 'N' e
 
 a 'O' c
 O " this must be the last quote test
-
-, P (P)
-(Q) Q ,

--- a/test/testM.ok
+++ b/test/testM.ok
@@ -13,9 +13,10 @@ Warning: terminal cannot highlight
 "test2.out"
 "test2.out" [New] 20L, 202C written
 "test3.in"
-"test3.in" 44L, 302C
+"test3.in" 44L, 298C
+/P
+/Q
 /A
-search hit BOTTOM, continuing at TOP
 /B
 /C
 /D
@@ -30,8 +31,6 @@ search hit BOTTOM, continuing at TOP
 /M
 /N
 /O
-/P
-/Q
 "test3.out"
 "test3.out" [New] 40L, 270C written
 "test4.in"

--- a/test/testM.out
+++ b/test/testM.out
@@ -13,9 +13,10 @@ Warning: terminal cannot highlight
 "test2.out"
 "test2.out" [New] 20L, 202C written
 "test3.in"
-"test3.in" 44L, 302C
+"test3.in" 44L, 298C
+/P
+/Q
 /A
-search hit BOTTOM, continuing at TOP
 /B
 /C
 /D
@@ -30,8 +31,6 @@ search hit BOTTOM, continuing at TOP
 /M
 /N
 /O
-/P
-/Q
 "test3.out"
 "test3.out" [New] 40L, 270C written
 "test4.in"


### PR DESCRIPTION
Close #191 

Fixes issue (introduced in https://github.com/wellle/targets.vim/pull/183) related to mapping legacy setting `g:targets_nlNL` to new setting `g:targets_nl`.

Also fixes a test introduced in the same PR.