### PR TITLE
Fix substring extraction in old Vim versions

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -577,7 +577,7 @@ function! s:quoteDir()
     " cut line in left of, on and right of cursor
     let left = col > 1 ? line[:col-2] : ""
     let cursor = line[col-1]
-    let right = line[col:]
+    let right = line[col :]
 
     " how many delitimers left, on and right of cursor
     let lc = s:count(s:opening, left)

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,6 +5,7 @@ clean:
 
 test: clean
 	@vim -N -u NONE --noplugin -S test.vim
+	# @/usr/bin/vim -N -u NONE --noplugin -S test.vim # test old vim version
 
 check:
 	@git diff --no-index test1.ok test1.out > test1.diff && rm test1.diff && echo "test1 OK" || echo "test1 failed, check test1.diff"


### PR DESCRIPTION
>Apparently Vim versions 7.3 and 7.4 don't manage to properly parse a[b:]
where a is a list or string and b is an index, while Vim 8 and Neovim
handle it just fine. Interestingly a[2:] works in all versions.
>
>This commit adds a space to not confuse old Vim versions, and use a[b :]
instead.

As discussed on #195.