### PR TITLE
Speed up plugin load times by using expression mappings

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -8,14 +8,18 @@ set cpo&vim
 
 " called once when loaded
 function! s:setup()
-    let s:argOpeningS = g:targets_argOpening . '\|' . g:targets_argSeparator
-    let s:argClosingS = g:targets_argClosing . '\|' . g:targets_argSeparator
-    let s:argOuter    = g:targets_argOpening . '\|' . g:targets_argClosing
-    let s:argAll      = s:argOpeningS        . '\|' . g:targets_argClosing
-    let s:none        = 'a^' " matches nothing
+    let s:argOpening   = get(g:, 'targets_argOpening', '[([]')
+    let s:argClosing   = get(g:, 'targets_argClosing', '[])]')
+    let s:argSeparator = get(g:, 'targets_argSeparator', ',')
+    let s:argOpeningS  = s:argOpening  . '\|' . s:argSeparator
+    let s:argClosingS  = s:argClosing  . '\|' . s:argSeparator
+    let s:argOuter     = s:argOpening  . '\|' . s:argClosing
+    let s:argAll       = s:argOpeningS . '\|' . s:argClosing
+    let s:none         = 'a^' " matches nothing
 
     let s:rangeScores = {}
-    let ranges = split(g:targets_seekRanges)
+    let ranges = split(get(g:, 'targets_seekRanges',
+                \ 'cr cb cB lc ac Ac lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA'))
     let rangesN = len(ranges)
     let i = 0
     while i < rangesN
@@ -24,13 +28,36 @@ function! s:setup()
     endwhile
 
     let s:rangeJumps = {}
-    let ranges = split(g:targets_jumpRanges)
+    let ranges = split(get(g:, 'targets_jumpRanges', 'bb bB BB aa Aa AA'))
     let rangesN = len(ranges)
     let i = 0
     while i < rangesN
         let s:rangeJumps[ranges[i]] = 1
         let i = i + 1
     endwhile
+
+    " currently undocumented, currently not supposed to be user defined
+    " but could be used to disable 'smart' quote skipping
+    " some technicalities: inverse mapping from quote reps to quote arg reps
+    " quote rep '102' means:
+    "   1: even number of quotation character left from cursor
+    "   0: no quotation char under cursor
+    "   2: even number (but nonzero) of quote chars right of cursor
+    " arg rep 'r1l' means:
+    "   r: select to right (l: to left; n: not at all)
+    "   1: single speed (each quote char starts one text object)
+    "      (2: double speed, skip pseudo quotes)
+    "   l: skip first quote when going left ("last" quote objects)
+    "      (r: skip once when going right ("next"); b: both; n: none)
+    let s:quoteDirsConf = get(g:, 'targets_quoteDirs', {
+                \ 'r1n': ['001', '201', '100', '102'],
+                \ 'r1l': ['010', '012', '111', '210', '212'],
+                \ 'r2n': ['101'],
+                \ 'r2l': ['011', '211'],
+                \ 'r2b': ['000'],
+                \ 'l2r': ['110', '112'],
+                \ 'n2b': ['002', '200', '202'],
+                \ })
 
     " args in order: dir, rate, skipL, skipR, error
     let s:quoteArgs = {
@@ -45,7 +72,7 @@ function! s:setup()
     let s:quoteDirs = {}
     for key in keys(s:quoteArgs)
         let args = s:quoteArgs[key]
-        for rep in get(g:targets_quoteDirs, key, [])
+        for rep in get(s:quoteDirsConf, key, [])
             let s:quoteDirs[rep] = args
         endfor
     endfor
@@ -735,7 +762,7 @@ endfunction
 function! s:selecta(direction)
     let oldpos = getpos('.')
 
-    let [opening, closing] = [g:targets_argOpening, g:targets_argClosing]
+    let [opening, closing] = [s:argOpening, s:argClosing]
     if a:direction ==# '^'
         let [sl, sc, el, ec, err] = s:findArg(a:direction, 'W', 'bcW', 'bW', opening, closing)
         let message = 'selecta 1'
@@ -763,7 +790,7 @@ endfunction
 function! s:findArg(direction, flags1, flags2, flags3, opening, closing)
     let oldpos = getpos('.')
     let char = s:getchar()
-    let separator = g:targets_argSeparator
+    let separator = s:argSeparator
 
     if char =~# a:closing && a:direction !=# '^' " started on closing, but not up
         let [el, ec] = oldpos[1:2] " use old position as end
@@ -773,7 +800,7 @@ function! s:findArg(direction, flags1, flags2, flags3, opening, closing)
             return [0, 0, 0, 0, s:fail('findArg 1', a:)]
         endif
 
-        let separator = g:targets_argSeparator
+        let separator = s:argSeparator
         if char =~# a:opening || char =~# separator " started on opening or separator
             let [sl, sc] = oldpos[1:2] " use old position as start
             return [sl, sc, el, ec, 0]
@@ -795,7 +822,7 @@ endfunction
 " matching `skip`s
 " example: find ',' or ')' while skipping a pair when finding '('
 " args (flags1, flags2, skip, finish, all=s:argAll,
-" separator=g:targets_argSeparator, cnt=2)
+" separator=s:argSeparator, cnt=2)
 " return (line, column, err)
 function! s:findArgBoundary(...)
     let flags1    =            a:1 " required
@@ -803,7 +830,7 @@ function! s:findArgBoundary(...)
     let skip      =            a:3
     let finish    =            a:4
     let all       = a:0 >= 5 ? a:5 : s:argAll
-    let separator = a:0 >= 6 ? a:6 : g:targets_argSeparator
+    let separator = a:0 >= 6 ? a:6 : s:argSeparator
     let cnt       = a:0 >= 7 ? a:7 : 1
 
     let [tl, rl, rc] = [0, 0, 0]
@@ -839,13 +866,13 @@ endfunction
 " selects and argument, supports growing and seeking
 function! s:seekselecta(context, count)
     if a:count > 1
-        if s:getchar() =~# g:targets_argClosing
+        if s:getchar() =~# s:argClosing
             let [cnt, message] = [a:count - 2, 'seekselecta 1']
         else
             let [cnt, message] = [a:count - 1, 'seekselecta 2']
         endif
         " find cnt closing while skipping matched openings
-        let [opening, closing] = [g:targets_argOpening, g:targets_argClosing]
+        let [opening, closing] = [s:argOpening, s:argClosing]
         if s:findArgBoundary('W', 'W', opening, closing, s:argOuter, s:none, cnt)[2] > 0
             return targets#target#withError(message . ' count')
         endif
@@ -890,12 +917,12 @@ function! s:nextselecta(...)
         return target
     endif
 
-    if char !~# g:targets_argSeparator " start wasn't on comma
+    if char !~# s:argSeparator " start wasn't on comma
         return targets#target#withError('nextselecta 2')
     endif
 
     call setpos('.', context.oldpos)
-    let opening = g:targets_argOpening
+    let opening = s:argOpening
     if s:search(cnt, opening, 'W', stopline) > 0 " no start found
         return targets#target#withError('nextselecta 3')
     endif
@@ -916,7 +943,7 @@ function! s:lastselecta(...)
     let stopline = a:0 >= 3 ? a:3 : 0
 
     " special case to handle vala when invoked on a separator
-    let separator = g:targets_argSeparator
+    let separator = s:argSeparator
     if s:getchar() =~# separator && s:newSelection
         let target = s:selecta('<')
         if target.state().isValid()
@@ -939,7 +966,7 @@ function! s:lastselecta(...)
     endif
 
     call setpos('.', context.oldpos)
-    let closing = g:targets_argClosing
+    let closing = s:argClosing
     if s:search(cnt, closing, 'bW', stopline) > 0 " no start found
         return targets#target#withError('lastselecta 3')
     endif
@@ -1088,8 +1115,8 @@ endfunction
 " line │ ( x ) ( x , a ) (a , x , b) ( a , x )
 " out  │  └─┘    └──┘       └──┘        └──┘
 function! s:dropa(target)
-    let startOpening = a:target.getcharS() !~# g:targets_argSeparator
-    let endOpening   = a:target.getcharE() !~# g:targets_argSeparator
+    let startOpening = a:target.getcharS() !~# s:argSeparator
+    let endOpening   = a:target.getcharE() !~# s:argSeparator
 
     if startOpening
         if endOpening

--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -75,8 +75,15 @@ endfunction
 
 " 'e' is for expression; return expression to execute, used for visual
 " mappings to not break non-targets visual mappings
+" and for operator pending mode as well if possible to speed up plugin loading
+" time
 function! targets#e(modifier)
-    if mode() !=? 'v'
+    let mode = mode(1)
+    if mode ==? 'v' " visual mode, from xnoremap
+        let prefix = "\<Esc>:\<C-U>call targets#x('"
+    elseif mode ==# 'no' " operator pending, from onoremap
+        let prefix = ":call targets#o('"
+    else
         return a:modifier
     endif
 
@@ -102,7 +109,7 @@ function! targets#e(modifier)
         let delimiter = "''"
     endif
 
-    return "\<Esc>:\<C-U>call targets#x('" . delimiter . which . a:modifier . "', " . v:count1 . ")\<CR>"
+    return prefix . delimiter . which . a:modifier . "', " . v:count1 . ")\<CR>"
 endfunction
 
 " 'x' is for visual (as in :xnoremap, not in select mode)

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -186,20 +186,34 @@ function! s:createArgTextObjects(mapType)
     call s:addMapping2(a:mapType, triggerMap . "lA', v:count1)<CR>", s:A, s:l)
 endfunction
 
-" add expression mappings for `A` and `I` in visual mode #23 unless
-" deactivated #49. Manually make mappings for older verions of vim #117.
-function! s:addVisualMappings()
+function! s:addMappings()
     if v:version >= 704 || (v:version == 703 && has('patch338'))
+        " if possible, create only a few expression mappings to speed up loading times
+        silent! execute 'onoremap <expr> <silent> <unique> ' . s:i . " targets#e('i')"
+        silent! execute 'onoremap <expr> <silent> <unique> ' . s:a . " targets#e('a')"
+        silent! execute 'onoremap <expr> <silent> <unique> ' . s:I . " targets#e('I')"
+        silent! execute 'onoremap <expr> <silent> <unique> ' . s:A . " targets#e('A')"
+
         silent! execute 'xnoremap <expr> <silent> <unique> ' . s:i . " targets#e('i')"
         silent! execute 'xnoremap <expr> <silent> <unique> ' . s:a . " targets#e('a')"
         silent! execute 'xnoremap <expr> <silent> <unique> ' . s:I . " targets#e('I')"
         silent! execute 'xnoremap <expr> <silent> <unique> ' . s:A . " targets#e('A')"
+
     else
-        call s:createPairTextObjects('x')
+        " otherwise create individual mappings #117
+
+        " more specific ones first for #145
+        call s:createTagTextObjects('o')
+        call s:createArgTextObjects('o')
+        call s:createPairTextObjects('o')
+        call s:createQuoteTextObjects('o')
+        call s:createSeparatorTextObjects('o')
+
         call s:createTagTextObjects('x')
+        call s:createArgTextObjects('x')
+        call s:createPairTextObjects('x')
         call s:createQuoteTextObjects('x')
         call s:createSeparatorTextObjects('x')
-        call s:createArgTextObjects('x')
     endif
 endfunction
 
@@ -275,15 +289,7 @@ function! s:loadSettings()
 endfunction
 
 call s:loadSettings()
-
-" create the text objects (current total count: 544)
-" more specific ones first for #145
-call s:createTagTextObjects('o')
-call s:createArgTextObjects('o')
-call s:createPairTextObjects('o')
-call s:createQuoteTextObjects('o')
-call s:createSeparatorTextObjects('o')
-call s:addVisualMappings()
+call s:addMappings()
 
 let &cpoptions = s:save_cpoptions
 unlet s:save_cpoptions

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -218,71 +218,13 @@ function! s:addMappings()
 endfunction
 
 function! s:loadSettings()
-    if !exists('g:targets_aiAI')
-        let g:targets_aiAI = 'aiAI'
-    endif
-    if !exists('g:targets_nl')
-        if exists('g:targets_nlNL')
-            let g:targets_nl = g:targets_nlNL[0:1] " legacy fallback
-        else
-            let g:targets_nl = 'nl'
-        endif
-    endif
-    if !exists('g:targets_pairs')
-        let g:targets_pairs = '()b {}B [] <>'
-    endif
-    if !exists('g:targets_quotes')
-        let g:targets_quotes = '" '' `'
-    endif
-    if !exists('g:targets_separators')
-        let g:targets_separators = ', . ; : + - = ~ _ * # / \ | & $'
-    endif
-    if !exists('g:targets_tagTrigger')
-        let g:targets_tagTrigger = 't'
-    endif
-    if !exists('g:targets_argTrigger')
-        let g:targets_argTrigger = 'a'
-    endif
-    if !exists('g:targets_argOpening')
-        let g:targets_argOpening = '[([]'
-    endif
-    if !exists('g:targets_argClosing')
-        let g:targets_argClosing = '[])]'
-    endif
-    if !exists('g:targets_argSeparator')
-        let g:targets_argSeparator = ','
-    endif
-    if !exists('g:targets_seekRanges')
-        let g:targets_seekRanges = 'cr cb cB lc ac Ac lr rr ll lb ar ab lB Ar aB Ab AB rb al rB Al bb aa bB Aa BB AA'
-    endif
-    if !exists('g:targets_jumpRanges')
-        let g:targets_jumpRanges = 'bb bB BB aa Aa AA'
-    endif
-
-    if !exists('g:targets_quoteDirs')
-        " currently undocumented, currently not supposed to be user defined
-        " but could be used to disable 'smart' quote skipping
-        " some technicalities: inverse mapping from quote reps to quote arg reps
-        " quote rep '102' means:
-        "   1: even number of quotation character left from cursor
-        "   0: no quotation char under cursor
-        "   2: even number (but nonzero) of quote chars right of cursor
-        " arg rep 'r1l' means:
-        "   r: select to right (l: to left; n: not at all)
-        "   1: single speed (each quote char starts one text object)
-        "      (2: double speed, skip pseudo quotes)
-        "   l: skip first quote when going left ("last" quote objects)
-        "      (r: skip once when going right ("next"); b: both; n: none)
-        let g:targets_quoteDirs = {
-                    \ 'r1n': ['001', '201', '100', '102'],
-                    \ 'r1l': ['010', '012', '111', '210', '212'],
-                    \ 'r2n': ['101'],
-                    \ 'r2l': ['011', '211'],
-                    \ 'r2b': ['000'],
-                    \ 'l2r': ['110', '112'],
-                    \ 'n2b': ['002', '200', '202'],
-                    \ }
-    endif
+    let g:targets_nl         = get(g:, 'targets_nl', get(g:, 'targets_nlNL', 'nl')[0:1]) " legacy fallback
+    let g:targets_aiAI       = get(g:, 'targets_aiAI', 'aiAI')
+    let g:targets_pairs      = get(g:, 'targets_pairs', '()b {}B [] <>')
+    let g:targets_quotes     = get(g:, 'targets_quotes', '" '' `')
+    let g:targets_separators = get(g:, 'targets_separators', ', . ; : + - = ~ _ * # / \ | & $')
+    let g:targets_tagTrigger = get(g:, 'targets_tagTrigger', 't')
+    let g:targets_argTrigger = get(g:, 'targets_argTrigger', 'a')
 
     let [s:a, s:i, s:A, s:I] = split(g:targets_aiAI, '\zs')
     let [s:n, s:l] = split(g:targets_nl, '\zs')

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -5,7 +5,7 @@
 if exists("g:loaded_targets") || &cp || v:version < 700
     finish
 endif
-let g:loaded_targets = '0.4.5' " version number
+let g:loaded_targets = '0.4.6' " version number
 let s:save_cpoptions = &cpoptions
 set cpo&vim
 


### PR DESCRIPTION
Back in https://github.com/wellle/targets.vim/pull/25 we started using expression mappings for visual mode mappings. We did that to avoid breaking some use cases related to visual block mode. In https://github.com/wellle/targets.vim/issues/117 we already talked about some performance benefits it actually has. The topic of targets.vim being somewhat slow to load comes up from time to time, for example in https://redd.it/7datnj.

While working on something else (stay tuned!) I came back to this and looked into this idea again. Turns out using expression mappings for the operator-pending mode mappings was not actually very complex to get working. In fact it's not very different to what we already have for the visual mappings. I'm not sure if or why I'd never tried that, seems very obvious now in hindsight.

Here are some plugin loading times for me on master:
```
125.769  008.553  008.553: sourcing /Users/welle/code/targets.vim/plugin/targets.vim
130.173  008.805  008.805: sourcing /Users/welle/code/targets.vim/plugin/targets.vim
133.473  009.718  009.718: sourcing /Users/welle/code/targets.vim/plugin/targets.vim
```

And here the times with expression mappings:
```
116.832  000.331  000.331: sourcing /Users/welle/code/targets.vim/plugin/targets.vim
113.782  000.319  000.319: sourcing /Users/welle/code/targets.vim/plugin/targets.vim
111.556  000.322  000.322: sourcing /Users/welle/code/targets.vim/plugin/targets.vim
```

So it went from around 8ms to 0.3ms 🎉 