### PR TITLE
209 Make expression mappings non silent

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -107,9 +107,9 @@ endfunction
 function! targets#e(modifier, original)
     let mode = mode(1)
     if mode ==? 'v' " visual mode, from xnoremap
-        let prefix = "\<Esc>:\<C-U>call targets#x('"
+        let prefix = "call targets#x('"
     elseif mode ==# 'no' " operator pending, from onoremap
-        let prefix = ":call targets#o('"
+        let prefix = "call targets#o('"
     else
         return a:modifier
     endif
@@ -136,7 +136,14 @@ function! targets#e(modifier, original)
         let delimiter = "''"
     endif
 
-    return prefix . delimiter . which . a:modifier . "', " . v:count1 . ")\<CR>"
+    let s:call = prefix . delimiter . which . a:modifier . "', " . v:count1 . ")"
+    " indirectly (but silently) call targets#do below
+    return "@(targets)"
+endfunction
+
+" gets called via the @(targets) mapping from above
+function! targets#do()
+    exe s:call
 endfunction
 
 " 'x' is for visual (as in :xnoremap, not in select mode)

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -189,15 +189,23 @@ endfunction
 function! s:addMappings()
     if v:version >= 704 || (v:version == 703 && has('patch338'))
         " if possible, create only a few expression mappings to speed up loading times
-        silent! execute 'onoremap <expr> <silent> <unique> ' . s:i . " targets#e('i', '" . s:i . "')"
-        silent! execute 'onoremap <expr> <silent> <unique> ' . s:a . " targets#e('a', '" . s:a . "')"
-        silent! execute 'onoremap <expr> <silent> <unique> ' . s:I . " targets#e('I', '" . s:I . "')"
-        silent! execute 'onoremap <expr> <silent> <unique> ' . s:A . " targets#e('A', '" . s:A . "')"
+        silent! execute 'omap <expr> <unique> ' . s:i . " targets#e('i', '" . s:i . "')"
+        silent! execute 'omap <expr> <unique> ' . s:a . " targets#e('a', '" . s:a . "')"
+        silent! execute 'omap <expr> <unique> ' . s:I . " targets#e('I', '" . s:I . "')"
+        silent! execute 'omap <expr> <unique> ' . s:A . " targets#e('A', '" . s:A . "')"
 
-        silent! execute 'xnoremap <expr> <silent> <unique> ' . s:i . " targets#e('i', '" . s:i . "')"
-        silent! execute 'xnoremap <expr> <silent> <unique> ' . s:a . " targets#e('a', '" . s:a . "')"
-        silent! execute 'xnoremap <expr> <silent> <unique> ' . s:I . " targets#e('I', '" . s:I . "')"
-        silent! execute 'xnoremap <expr> <silent> <unique> ' . s:A . " targets#e('A', '" . s:A . "')"
+        silent! execute 'xmap <expr> <unique> ' . s:i . " targets#e('i', '" . s:i . "')"
+        silent! execute 'xmap <expr> <unique> ' . s:a . " targets#e('a', '" . s:a . "')"
+        silent! execute 'xmap <expr> <unique> ' . s:I . " targets#e('I', '" . s:I . "')"
+        silent! execute 'xmap <expr> <unique> ' . s:A . " targets#e('A', '" . s:A . "')"
+
+        " #209: The above mappings don't use <silent> for better visual
+        " feedback on `!ip` (when we pass back control to Vim). To be silent
+        " when calling internal targest functions, we use this special mapping
+        " which does use <silent>. It should not lead to conflicts because (
+        " is not a valid register.
+        onoremap <silent> @(targets) :<C-u>call targets#do()<CR>
+        xnoremap <silent> @(targets) :<C-u>call targets#do()<CR>
 
     else
         " otherwise create individual mappings #117

--- a/test/testM.ok
+++ b/test/testM.ok
@@ -48,7 +48,7 @@ Warning: terminal cannot highlight
 "test7.in"
 "test7.in" 72L, 1422C
 /010
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /010
 3 more lines
@@ -122,7 +122,7 @@ Warning: terminal cannot highlight
 3 more lines
 /010
 /001
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /001
 3 more lines
@@ -196,7 +196,7 @@ Warning: terminal cannot highlight
 3 more lines
 /001
 /201
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /201
 3 more lines
@@ -270,7 +270,7 @@ Warning: terminal cannot highlight
 3 more lines
 /201
 /100
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /100
 3 more lines
@@ -344,7 +344,7 @@ Warning: terminal cannot highlight
 3 more lines
 /100
 /102
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /102
 3 more lines
@@ -418,7 +418,7 @@ Warning: terminal cannot highlight
 3 more lines
 /102
 /012
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /012
 3 more lines
@@ -492,7 +492,7 @@ Warning: terminal cannot highlight
 3 more lines
 /012
 /111
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /111
 3 more lines
@@ -566,7 +566,7 @@ Warning: terminal cannot highlight
 3 more lines
 /111
 /210
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /210
 3 more lines
@@ -640,7 +640,7 @@ Warning: terminal cannot highlight
 3 more lines
 /210
 /212
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /212
 3 more lines
@@ -714,7 +714,7 @@ Warning: terminal cannot highlight
 3 more lines
 /212
 /101
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /101
 3 more lines
@@ -788,7 +788,7 @@ Warning: terminal cannot highlight
 3 more lines
 /101
 /011
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /011
 3 more lines
@@ -862,7 +862,7 @@ Warning: terminal cannot highlight
 3 more lines
 /011
 /211
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /211
 3 more lines
@@ -936,7 +936,7 @@ Warning: terminal cannot highlight
 3 more lines
 /211
 /110
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /110
 3 more lines
@@ -1010,7 +1010,7 @@ Warning: terminal cannot highlight
 3 more lines
 /110
 /112
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /112
 3 more lines
@@ -1084,7 +1084,7 @@ Warning: terminal cannot highlight
 3 more lines
 /112
 /000
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /000
 3 more lines
@@ -1158,7 +1158,7 @@ Warning: terminal cannot highlight
 3 more lines
 /000
 /002
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /002
 3 more lines
@@ -1232,7 +1232,7 @@ Warning: terminal cannot highlight
 3 more lines
 /002
 /200
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /200
 3 more lines
@@ -1306,7 +1306,7 @@ Warning: terminal cannot highlight
 3 more lines
 /200
 /202
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /202
 3 more lines

--- a/test/testM.out
+++ b/test/testM.out
@@ -48,7 +48,7 @@ Warning: terminal cannot highlight
 "test7.in"
 "test7.in" 72L, 1422C
 /010
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /010
 3 more lines
@@ -122,7 +122,7 @@ Warning: terminal cannot highlight
 3 more lines
 /010
 /001
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /001
 3 more lines
@@ -196,7 +196,7 @@ Warning: terminal cannot highlight
 3 more lines
 /001
 /201
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /201
 3 more lines
@@ -270,7 +270,7 @@ Warning: terminal cannot highlight
 3 more lines
 /201
 /100
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /100
 3 more lines
@@ -344,7 +344,7 @@ Warning: terminal cannot highlight
 3 more lines
 /100
 /102
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /102
 3 more lines
@@ -418,7 +418,7 @@ Warning: terminal cannot highlight
 3 more lines
 /102
 /012
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /012
 3 more lines
@@ -492,7 +492,7 @@ Warning: terminal cannot highlight
 3 more lines
 /012
 /111
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /111
 3 more lines
@@ -566,7 +566,7 @@ Warning: terminal cannot highlight
 3 more lines
 /111
 /210
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /210
 3 more lines
@@ -640,7 +640,7 @@ Warning: terminal cannot highlight
 3 more lines
 /210
 /212
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /212
 3 more lines
@@ -714,7 +714,7 @@ Warning: terminal cannot highlight
 3 more lines
 /212
 /101
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /101
 3 more lines
@@ -788,7 +788,7 @@ Warning: terminal cannot highlight
 3 more lines
 /101
 /011
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /011
 3 more lines
@@ -862,7 +862,7 @@ Warning: terminal cannot highlight
 3 more lines
 /011
 /211
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /211
 3 more lines
@@ -936,7 +936,7 @@ Warning: terminal cannot highlight
 3 more lines
 /211
 /110
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /110
 3 more lines
@@ -1010,7 +1010,7 @@ Warning: terminal cannot highlight
 3 more lines
 /110
 /112
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /112
 3 more lines
@@ -1084,7 +1084,7 @@ Warning: terminal cannot highlight
 3 more lines
 /112
 /000
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /000
 3 more lines
@@ -1158,7 +1158,7 @@ Warning: terminal cannot highlight
 3 more lines
 /000
 /002
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /002
 3 more lines
@@ -1232,7 +1232,7 @@ Warning: terminal cannot highlight
 3 more lines
 /002
 /200
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /200
 3 more lines
@@ -1306,7 +1306,7 @@ Warning: terminal cannot highlight
 3 more lines
 /200
 /202
-3 lines yanked
+3 lines yanked into "p
 3 more lines
 /202
 3 more lines


### PR DESCRIPTION
>To restore the visual feedback for commands like `!ip`.
Adds two new silent general purpose mappings which get silently invoked
by the expression mapping function to then actually carry out the work.

Close #209 

@Asheq: As mentioned in #209 I think I found a way to fix `!ip` while avoiding flickering. If you have some time, would you try using this branch and let me know if that works for you? Thanks again for bringing this up 👍 