### PR TITLE
211 Fix visual block mode handling in expression mappings

### DIFF
--- a/autoload/targets.vim
+++ b/autoload/targets.vim
@@ -111,7 +111,7 @@ function! targets#e(modifier, original)
     elseif mode ==# 'no' " operator pending, from onoremap
         let prefix = "call targets#o('"
     else
-        return a:modifier
+        return a:original
     endif
 
     let char1 = nr2char(getchar())


### PR DESCRIPTION
>So typing `I` and `A` in visual block mode works as expected with custom `g:targets_aiAI` settings.

Close #211