### PR TITLE
Fix test for whether GenFunc is a function

### DIFF
--- a/autoload/targets/factory.vim
+++ b/autoload/targets/factory.vim
@@ -40,7 +40,7 @@ endfunction
 " invocations
 function! targets#factory#new(oldpos, which) dict
     let GenFunc = get(self.genFuncs, a:which, 0)
-    if GenFunc == 0
+    if type(GenFunc) != type(function("tr"))
         " NOTE: we could drop this message and consider individual gen funcs
         " optional. but for seeking to work we need all three, so all of them
         " are required for now


### PR DESCRIPTION
The current test for whether GenFunc is a function is:

    if GenFunc == 0

On up-to-date versions of vim, this works fine. However, on older
versions (in particular vim 7.4 with patches 0-900) this throws an
"Invalid expression" error. Rather, targets should test directly whether
GenFunc is a FunctionRef. This patch does that as recommended in `:h
type()`.