### PR TITLE
213 Add setting g:targets_mapped_aiAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ correctly.
 		* [Any Quote](#any-quote)
 * [Settings](#settings)
 	* [g:targets_aiAI](#gtargets_aiai)
+	* [g:targets_mapped_aiAI](#gtargets_mapped_aiai)
 	* [g:targets_nl](#gtargets_nl)
 	* [g:targets_seekRanges](#gtargets_seekranges)
 	* [g:targets_jumpRanges](#gtargets_jumpranges)
@@ -539,6 +540,23 @@ let g:targets_aiAI = 'aiAI'
 Controls the normal mode operator mode maps that get created for In Pair (`i`),
 A Pair (`a`), Inside Pair (`I`), and Around Pair (`A`). Required to be a 4
 character long list. Use a space to deactivate a mode.
+
+### g:targets_mapped_aiAI
+
+Default:
+
+```vim
+let g:targets_mapped_aiAI = g:targets_aiAI
+```
+
+If you can't get your g:targets_aiAI settings to work because they conflict
+with other mappings you have, you might need to use g:targets_mapped_aiAI. For
+example if you want to map `k` to `i` and use `k` as `i` in targets mappings,
+you need to NOT map `k` to `i` in operator pending mode, and set
+`g:targets_aiAI = 'akAI'` and `g:targets_mapped_aiAI = 'aiAI'`.
+
+For more details see issue #213 and don't hesitate to comment there or open a
+new issue if you need assistance.
 
 ### g:targets_nl
 

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -512,6 +512,7 @@ here.
 Available options: ~
 
     |g:targets_aiAI|
+    |g:targets_mapped_aiAI|
     |g:targets_nl|
     |g:targets_seekRanges|
     |g:targets_jumpRanges|
@@ -525,6 +526,20 @@ Default:
 Controls the normal mode operator mode maps that get created for In Pair (i),
 A Pair (a), Inside Pair (I), and Around Pair (A). Required to be a 4 character
 long list. Use a space to deactivate a mode.
+
+------------------------------------------------------------------------------
+                                                       *g:targets_mapped_aiAI*
+Default:
+    let g:targets_mapped_aiAI = g:targets_aiAI ~
+
+If you can't get your g:targets_aiAI settings to work because they conflict
+with other mappings you have, you might need to use g:targets_mapped_aiAI. For
+example if you want to map `k` to `i` and use `k` as `i` in targets mappings,
+you need to NOT map `k` to `i` in operator pending mode, and set
+`g:targets_aiAI = 'akAI'` and `g:targets_mapped_aiAI = 'aiAI'`
+
+For more details see issue #213 and don't hesitate to comment there or open a
+new issue if you need assistance.
 
 ------------------------------------------------------------------------------
                                                                 *g:targets_nl*

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -15,20 +15,22 @@ function! s:addAllMappings()
     " places
     let g:targets_nl = get(g:, 'targets_nl', get(g:, 'targets_nlNL', 'nl')[0:1]) " legacy fallback
     let aiAI         = get(g:, 'targets_aiAI', 'aiAI')
-    let [s:a, s:i, s:A, s:I] = split(aiAI, '\zs')
-    let [s:n, s:l]           = split(g:targets_nl, '\zs')
+    let mapped_aiAI  = get(g:, 'targets_mapped_aiAI', aiAI)
+    let [s:a,  s:i,  s:A,  s:I]  = split(aiAI, '\zs')
+    let [s:ma, s:mi, s:mA, s:mI] = split(mapped_aiAI, '\zs')
+    let [s:n, s:l]               = split(g:targets_nl, '\zs')
 
     if v:version >= 704 || (v:version == 703 && has('patch338'))
         " if possible, create only a few expression mappings to speed up loading times
-        silent! execute 'omap <expr> <unique> ' . s:i . " targets#e('i', '" . s:i . "')"
-        silent! execute 'omap <expr> <unique> ' . s:a . " targets#e('a', '" . s:a . "')"
-        silent! execute 'omap <expr> <unique> ' . s:I . " targets#e('I', '" . s:I . "')"
-        silent! execute 'omap <expr> <unique> ' . s:A . " targets#e('A', '" . s:A . "')"
+        silent! execute 'omap <expr> <unique> ' . s:i . " targets#e('i', '" . s:mi . "')"
+        silent! execute 'omap <expr> <unique> ' . s:a . " targets#e('a', '" . s:ma . "')"
+        silent! execute 'omap <expr> <unique> ' . s:I . " targets#e('I', '" . s:mI . "')"
+        silent! execute 'omap <expr> <unique> ' . s:A . " targets#e('A', '" . s:mA . "')"
 
-        silent! execute 'xmap <expr> <unique> ' . s:i . " targets#e('i', '" . s:i . "')"
-        silent! execute 'xmap <expr> <unique> ' . s:a . " targets#e('a', '" . s:a . "')"
-        silent! execute 'xmap <expr> <unique> ' . s:I . " targets#e('I', '" . s:I . "')"
-        silent! execute 'xmap <expr> <unique> ' . s:A . " targets#e('A', '" . s:A . "')"
+        silent! execute 'xmap <expr> <unique> ' . s:i . " targets#e('i', '" . s:mi . "')"
+        silent! execute 'xmap <expr> <unique> ' . s:a . " targets#e('a', '" . s:ma . "')"
+        silent! execute 'xmap <expr> <unique> ' . s:I . " targets#e('I', '" . s:mI . "')"
+        silent! execute 'xmap <expr> <unique> ' . s:A . " targets#e('A', '" . s:mA . "')"
 
         " #209: The above mappings don't use <silent> for better visual
         " feedback on `!ip` (when we pass back control to Vim). To be silent


### PR DESCRIPTION
To allow setting up `g:targets_aiAI` even when you have conflicting mappings. Feel free to comment here or on #213 if you can't get it to work. I understand this is not as convenient to set up as it should be, but I'm not aware of a nicer way to achieve this.

Close #213 