### PR TITLE
227 Only consider targets with matching seek range

### DIFF
--- a/autoload/targets/multigen.vim
+++ b/autoload/targets/multigen.vim
@@ -166,6 +166,6 @@ function! s:rangeScore(range)
             let s:rangeScores[ranges[i]] = rangesN - i
         endfor
     endif
-    return get(s:rangeScores, a:range)
+    return get(s:rangeScores, a:range, -1)
 endfunction
 


### PR DESCRIPTION
>If a range is not found in g:targets_seekRanges, don't consider it.
Before it was still considered, just with the lowest possible score, so
ranges from g:targets_seekRanges would be preferred, but it was
impossible to actually limit the ranges.

Close #227