### PR TITLE
229 Add support for gracious growing/seeking

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ correctly.
 	* [g:targets_nl](#gtargets_nl)
 	* [g:targets_seekRanges](#gtargets_seekranges)
 	* [g:targets_jumpRanges](#gtargets_jumpranges)
+	* [g:targets_gracious](#gtargets_gracious)
 	* [targets#mappings#extend](#targets#mappings#extend)
 * [Notes](#notes)
 * [Issues](#issues)
@@ -71,7 +72,7 @@ correctly.
 | [Vundle][vundle]       | `Bundle 'wellle/targets.vim'`                                                 |
 | [Vim-plug][vim-plug]   | `Plug 'wellle/targets.vim'`                                                   |
 | [Pathogen][pathogen]   | `git clone git://github.com/wellle/targets.vim.git ~/.vim/bundle/targets.vim` |
-| [Dein][dein]		 | `call dein#add('wellle/targets.vim')`					 |
+| [Dein][dein]		     | `call dein#add('wellle/targets.vim')`					                     |
 
 ## Examples
 
@@ -662,6 +663,21 @@ Only add to jumplist if cursor was not inside the target:
 ```vim
 let g:targets_jumpRanges = 'rr rb rB bb bB BB ll al Al aa Aa AA'
 ```
+
+### g:targets_gracious
+
+Default:
+
+```vim
+let g:targets_gracious = 0
+```
+
+If enabled (set to `1`) , both growing and seeking will work on the largest
+available count if a too large count is given. For example:
+
+- `v100ab` will select the most outer block around the cursor
+- `v100inq` will select the most distant quote to the right/down
+  (the last one in the file)
 
 ### targets#mappings#extend
 

--- a/autoload/targets/generator.vim
+++ b/autoload/targets/generator.vim
@@ -60,8 +60,8 @@ endfunction
 " if a:first is 1, the first call to next will have first set
 function! targets#generator#nextN(n, first) dict
     for i in range(1, a:n)
-        let target = self.next(i == a:first)
-        if target.state().isInvalid()
+        let [target, ok] = self.next(i == a:first)
+        if !ok
             return target
         endif
     endfor

--- a/autoload/targets/multigen.vim
+++ b/autoload/targets/multigen.vim
@@ -23,6 +23,8 @@ function! targets#multigen#add(factories, ...) dict
     endfor
 endfunction
 
+let s:gracious = get(g:, 'targets_gracious', 0)
+
 function! targets#multigen#next(first) dict
     if a:first
         for gen in self.gens
@@ -40,8 +42,12 @@ function! targets#multigen#next(first) dict
     while 1
         let [target, idx] = s:bestTarget(targets, self.context, 'multigen')
         if target.state().isInvalid() " best is invalid -> done
-            let self.currentTarget = target
-            return self.currentTarget
+            let gracious = 1
+            " keep last good target if gracious is enabled
+            if !exists('self.currentTarget') || !s:gracious
+                let self.currentTarget = target
+            endif
+            return [self.currentTarget, 0]
         endif
 
         " if two generators produce the same target, skip it
@@ -52,7 +58,7 @@ function! targets#multigen#next(first) dict
         endif
 
         let self.currentTarget = target
-        return self.currentTarget
+        return [self.currentTarget, 1]
     endwhile
 endfunction
 

--- a/doc/targets.txt
+++ b/doc/targets.txt
@@ -516,6 +516,7 @@ Available options: ~
     |g:targets_nl|
     |g:targets_seekRanges|
     |g:targets_jumpRanges|
+    |g:targets_gracious|
     |targets#mappings#extend|
 
 ------------------------------------------------------------------------------
@@ -686,6 +687,19 @@ Always add cursor position to jumplist:
 
 Only add to jumplist if cursor was not inside the target:
     let g:targets_jumpRanges = 'rr rb rB bb bB BB ll al Al aa Aa AA' ~
+
+------------------------------------------------------------------------------
+                                                          *g:targets_gracious*
+
+Default:
+    let g:targets_gracious = 0
+
+If enabled (set to `1`) , both growing and seeking will work on the largest
+available count if a too large count is given. For example:
+
+- `v100ab`  will select the most outer block around the cursor
+- `v100inq` will select the most distant quote to the right/down
+  (the last one in the file)
 
 ------------------------------------------------------------------------------
                                                      *targets#mappings#extend*


### PR DESCRIPTION
>    Add setting `g:targets_gracious`
>
>    If enabled (set to `1`), both growing and seeking will work on the largest available count if a too large count is given. For example:
>
>    - `v100ab` will select the most outer block around the cursor
>    - `v100inq` will select the most distant quote to the right/down
      (the last one in the file)

Close #229 