### PR TITLE
Add health check

### DIFF
--- a/autoload/health/targets.vim
+++ b/autoload/health/targets.vim
@@ -1,0 +1,33 @@
+function! health#targets#check() abort
+    let conflicts = 0
+
+    for trigger in targets#mappings#list()
+        for ai in split(g:targets_aiAI, '\zs')
+            let conflicts += s:check(trigger, ai . trigger)
+            for nl in split(g:targets_nl, '\zs')
+                let conflicts += s:check(trigger, ai . nl . trigger)
+            endfor
+        endfor
+    endfor
+
+    if conflicts == 0
+        call health#report_ok('No conflicting mappings found')
+    endif
+endfunction
+
+function! s:check(trigger, map)
+    for mode in ['x', 'o']
+        let arg = maparg(a:map, mode)
+        if arg == ''
+            continue
+        endif
+
+        call health#report_warn("Conflicting mapping found:\n"
+                    \ . a:map . ' → ' . arg . "\n"
+                    \ . a:trigger . " → " . string(targets#mappings#get(a:trigger))
+                    \ )
+        " no need to warn again for the other mode
+        return 1
+    endfor
+    return 0
+endfunction

--- a/autoload/targets/mappings.vim
+++ b/autoload/targets/mappings.vim
@@ -80,6 +80,10 @@ function! targets#mappings#get(trigger)
     return get(s:mappings, a:trigger, {})
 endfunction
 
+function! targets#mappings#list()
+    return keys(s:mappings)
+endfunction
+
 function! s:hasLegacySettings()
     return
                 \ has_key(g:, 'targets_pairs') ||

--- a/plugin/targets.vim
+++ b/plugin/targets.vim
@@ -12,13 +12,13 @@ set cpo&vim
 function! s:addAllMappings()
     " this is somewhat ugly, but we still need these nl values inside of the
     " expression mapping and don't want to have this legacy fallback in two
-    " places
-    let g:targets_nl = get(g:, 'targets_nl', get(g:, 'targets_nlNL', 'nl')[0:1]) " legacy fallback
-    let aiAI         = get(g:, 'targets_aiAI', 'aiAI')
-    let mapped_aiAI  = get(g:, 'targets_mapped_aiAI', aiAI)
-    let [s:a,  s:i,  s:A,  s:I]  = split(aiAI, '\zs')
-    let [s:ma, s:mi, s:mA, s:mI] = split(mapped_aiAI, '\zs')
+    " places. similarly we reuse g:targets_aiAI in the health check
+    let g:targets_nl   = get(g:, 'targets_nl', get(g:, 'targets_nlNL', 'nl')[0:1]) " legacy fallback
+    let g:targets_aiAI = get(g:, 'targets_aiAI', 'aiAI')
+    let mapped_aiAI    = get(g:, 'targets_mapped_aiAI', g:targets_aiAI)
     let [s:n, s:l]               = split(g:targets_nl, '\zs')
+    let [s:a,  s:i,  s:A,  s:I]  = split(g:targets_aiAI, '\zs')
+    let [s:ma, s:mi, s:mA, s:mI] = split(mapped_aiAI, '\zs')
 
     if v:version >= 704 || (v:version == 703 && has('patch338'))
         " if possible, create only a few expression mappings to speed up loading times


### PR DESCRIPTION
As suggested in https://github.com/lervag/vimtex/pull/1384#issuecomment-520750027, this PR adds a health check that can be invoked in Neovim by calling `:checkhealth`.

It checks whether there are any Vim mappings set up which conflict with targets.vim mappings.

For example, if I add this to my vimrc
```vim
autocmd User targets#mappings#user call targets#mappings#extend({
    \ 'c': {'separator': [{'d':','}]}
    \ })
```
and run the health check, it shows:
```
health#targets#check
========================================================================
  - WARNING: Conflicting mapping found:
    ac → :<C-U>call TextObjWordBasedColumn("aw")<CR>
    c → {'separator': [{'d': ','}]}
  - WARNING: Conflicting mapping found:
    ic → :<C-U>call TextObjWordBasedColumn("iw")<CR>
    c → {'separator': [{'d': ','}]}
```
As `ac` and `ic` are mapped by https://github.com/coderifous/textobj-word-column.vim, but would be shadowed by the new comma separator target from above.