### PR TITLE
make argument textobj work in { ... }

### DIFF
--- a/autoload/targets/mappings.vim
+++ b/autoload/targets/mappings.vim
@@ -57,7 +57,7 @@ function! s:addMappings()
                     \ })
 
         call targets#mappings#extend({'t': {'tag': [{}]}})
-        call targets#mappings#extend({'a': {'argument': [{'o': '[([]', 'c': '[])]', 's': ','}]}})
+        call targets#mappings#extend({'a': {'argument': [{'o': '[{([]', 'c': '[])}]', 's': ','}]}})
 
         call targets#mappings#extend({'b': {'pair': [{'o':'(', 'c':')'}, {'o':'[', 'c':']'}, {'o':'{', 'c':'}'}]}})
         call targets#mappings#extend({'q': {'quote': [{'d':"'"}, {'d':'"'}, {'d':'`'}]}})


### PR DESCRIPTION
It's super usefull for javascript like language.
like json, import...

```jsx
import React, { useState, useContext } from 'react'

{ a: 10, React }
```