### PR TITLE
Use non-depricated healthcheck functions.

### DIFF
--- a/autoload/health/targets.vim
+++ b/autoload/health/targets.vim
@@ -11,7 +11,7 @@ function! health#targets#check() abort
     endfor
 
     if conflicts == 0
-        call health#report_ok('No conflicting mappings found')
+        call v:lua.vim.health.ok('No conflicting mappings found')
     endif
 endfunction
 
@@ -22,12 +22,14 @@ function! s:check(trigger, map)
             continue
         endif
 
-        call health#report_warn("Conflicting mapping found:\n"
+        let warning = "Conflicting mapping found:\n"
                     \ . a:map . ' → ' . arg . "\n"
                     \ . a:trigger . " → " . string(targets#mappings#get(a:trigger))
-                    \ )
+        
+        call v:lua.vim.health.warn(warning)
         " no need to warn again for the other mode
         return 1
     endfor
     return 0
 endfunction
+


### PR DESCRIPTION
The `health#report_ok` and `health#report_warn` are depricated and removed in nightly Neovim. This commit calls the new `vim.health.ok` and `vim.health.warn` functions instead.